### PR TITLE
Fix releases architecture

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ builds:
       - amd64
       - arm64
     mod_timestamp: '{{ .CommitTimestamp }}'
-    no_unique_dist_dir: true
+    no_unique_dist_dir: false
 nfpms:
   - id: openvpn-auth-oauth2
     homepage: https://github.com/jkroepke/openvpn-auth-oauth2

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -51,7 +51,7 @@ It's highly recommend to put openvpn-auth-oauth2 behind a reverse proxy which te
 
 ## Setup OIDC Provider
 
-See [Providers](Providers.md) for more information
+See [Providers](Providers) for more information
 
 ## Setup OpenVPN server
 
@@ -59,7 +59,7 @@ See [Providers](Providers.md) for more information
 
 ```
 # /etc/openvpn/password.txt is a password file where the password must be on first line
-management /run/openvpn/server.sock /etc/openvpn/password.txt
+management /run/openvpn/server.sock unix /etc/openvpn/password.txt
 management-hold
 management-client-auth
 ```


### PR DESCRIPTION
Change GoReleaser 'no_unique_dist_dir' to false so the generated artifacts have the correct architecture
As of v1.5.0, both arm64 and amd64 releases contain a compiled binary for arm64

I also introduced two small fixes for the wiki
