### PR TITLE
Add openvpn.common-name.mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean: ## clean builds dir
 check: test lint golangci ## Run all checks locally
 
 .PHONY: build
-build: openvpn-auth-oauth2  ## Build openvpn-auth-oauth2
+build: clean openvpn-auth-oauth2  ## Build openvpn-auth-oauth2
 
 openvpn-auth-oauth2:
 	@go build -o openvpn-auth-oauth2 .

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -37,6 +37,7 @@ Usage of openvpn-auth-oauth2:
       --openvpn.auth-pending-timeout string   How long OpenVPN server wait until user is authenticated (env: CONFIG_OPENVPN_AUTH__PENDING__TIMEOUT) (default "3m0s")
       --openvpn.auth-token-user               Define auth-token-user for all sessions (env: CONFIG_OPENVPN_AUTH__TOKEN__USER) (default true)
       --openvpn.bypass.cn strings             bypass oauth authentication for CNs (env: CONFIG_OPENVPN_BYPASS_CN)
+      --openvpn.common-name.mode string       If common names are too long, use md5/sha1 to hash them or omit to skip them. If omit, oauth2.validate.common-name does not work anymore. Values: [plain,md5,sha1,omit] (env: CONFIG_OPENVPN_COMMON__NAME_MODE) (default "plain")
       --openvpn.password string               openvpn management interface password (env: CONFIG_OPENVPN_PASSWORD)
       --version                               show version
 ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -37,7 +37,7 @@ Usage of openvpn-auth-oauth2:
       --openvpn.auth-pending-timeout string   How long OpenVPN server wait until user is authenticated (env: CONFIG_OPENVPN_AUTH__PENDING__TIMEOUT) (default "3m0s")
       --openvpn.auth-token-user               Define auth-token-user for all sessions (env: CONFIG_OPENVPN_AUTH__TOKEN__USER) (default true)
       --openvpn.bypass.cn strings             bypass oauth authentication for CNs (env: CONFIG_OPENVPN_BYPASS_CN)
-      --openvpn.common-name.mode string       If common names are too long, use md5/sha1 to hash them or omit to skip them. If omit, oauth2.validate.common-name does not work anymore. Values: [plain,md5,sha1,omit] (env: CONFIG_OPENVPN_COMMON__NAME_MODE) (default "plain")
+      --openvpn.common-name.mode string       If common names are too long, use md5/sha1 to hash them or omit to skip them. If omit, oauth2.validate.common-name does not work anymore. Values: [plain,omit] (env: CONFIG_OPENVPN_COMMON__NAME_MODE) (default "plain")
       --openvpn.password string               openvpn management interface password (env: CONFIG_OPENVPN_PASSWORD)
       --version                               show version
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ func FlagSet() *flag.FlagSet {
 		"openvpn.common-name.mode",
 		Defaults.OpenVpn.CommonName.Mode.String(),
 		"If common names are too long, use md5/sha1 to hash them or omit to skip them. "+
-			"If omit, oauth2.validate.common-name does not work anymore. Values: [plain,md5,sha1,omit]",
+			"If omit, oauth2.validate.common-name does not work anymore. Values: [plain,omit]",
 	)
 	flagSet.String(
 		"oauth2.issuer",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
 	flag "github.com/spf13/pflag"
 )
 
@@ -110,6 +109,12 @@ func FlagSet() *flag.FlagSet {
 		"openvpn.bypass.cn",
 		Defaults.OpenVpn.Bypass.CommonNames,
 		"bypass oauth authentication for CNs",
+	)
+	flagSet.String(
+		"openvpn.common-name.mode",
+		Defaults.OpenVpn.CommonName.Mode.String(),
+		"If common names are too long, use md5/sha1 to hash them or omit to skip them. "+
+			"If omit, oauth2.validate.common-name does not work anymore. Values: [plain,md5,sha1,omit]",
 	)
 	flagSet.String(
 		"oauth2.issuer",
@@ -217,7 +222,7 @@ func Validate(mode int, conf Config) error { //nolint:cyclop
 		"http.baseurl":  conf.HTTP.BaseURL,
 		"oauth2.issuer": conf.OAuth2.Issuer,
 	} {
-		if utils.IsURLEmpty(value) {
+		if IsURLEmpty(value) {
 			return fmt.Errorf("%s is %w", key, ErrRequired)
 		}
 	}
@@ -233,12 +238,12 @@ func Validate(mode int, conf Config) error { //nolint:cyclop
 		"oauth2.endpoint.token":     conf.OAuth2.Endpoints.Token,
 		"oauth2.endpoint.auth":      conf.OAuth2.Endpoints.Auth,
 	} {
-		if utils.IsURLEmpty(uri) {
+		if IsURLEmpty(uri) {
 			continue
 		}
 
 		if !slices.Contains([]string{"http", "https"}, uri.Scheme) {
-			return errors.New(utils.StringConcat(key, ": invalid URL. only http:// or https:// scheme supported"))
+			return fmt.Errorf("%s: invalid URL. only http:// or https:// scheme supported", key)
 		}
 	}
 
@@ -246,7 +251,7 @@ func Validate(mode int, conf Config) error { //nolint:cyclop
 		for key, value := range map[string]*url.URL{
 			"openvpn.addr": conf.OpenVpn.Addr,
 		} {
-			if utils.IsURLEmpty(value) {
+			if IsURLEmpty(value) {
 				return fmt.Errorf("%s is %w", key, ErrRequired)
 			}
 		}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -30,6 +30,9 @@ var Defaults = Config{
 		},
 		AuthTokenUser:      true,
 		AuthPendingTimeout: 3 * time.Minute,
+		CommonName: OpenVPNCommonName{
+			Mode: CommonNameModePlain,
+		},
 		Bypass: OpenVpnBypass{
 			CommonNames: make([]string, 0),
 		},

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -97,6 +97,7 @@ const (
 //goland:noinspection GoMixedReceiverTypes
 func (s OpenVPNCommonNameMode) String() string {
 	text, _ := s.MarshalText()
+
 	return string(text)
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -88,8 +88,6 @@ type OpenVPNCommonNameMode int
 
 const (
 	CommonNameModePlain OpenVPNCommonNameMode = iota
-	CommonNameModeMD5
-	CommonNameModeSHA1
 	CommonNameModeOmit
 	CommonNameModeOmitValue = "<omit>"
 )
@@ -106,10 +104,6 @@ func (s OpenVPNCommonNameMode) MarshalText() ([]byte, error) {
 	switch s {
 	case CommonNameModePlain:
 		return []byte("plain"), nil
-	case CommonNameModeMD5:
-		return []byte("md5"), nil
-	case CommonNameModeSHA1:
-		return []byte("sha1"), nil
 	case CommonNameModeOmit:
 		return []byte("omit"), nil
 	default:
@@ -123,10 +117,6 @@ func (s *OpenVPNCommonNameMode) UnmarshalText(text []byte) error {
 	switch config {
 	case "plain":
 		*s = CommonNameModePlain
-	case "md5":
-		*s = CommonNameModeMD5
-	case "sha1":
-		*s = CommonNameModeSHA1
 	case "omit":
 		*s = CommonNameModeOmit
 	default:

--- a/internal/config/url.go
+++ b/internal/config/url.go
@@ -1,4 +1,4 @@
-package utils
+package config
 
 import "net/url"
 

--- a/internal/config/url_test.go
+++ b/internal/config/url_test.go
@@ -1,10 +1,10 @@
-package utils_test
+package config_test
 
 import (
 	"net/url"
 	"testing"
 
-	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,7 +37,7 @@ func TestIsUrlEmpty(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expect, utils.IsURLEmpty(tt.url))
+			assert.Equal(t, tt.expect, config.IsURLEmpty(tt.url))
 		})
 	}
 }

--- a/internal/oauth2/handler_test.go
+++ b/internal/oauth2/handler_test.go
@@ -422,7 +422,7 @@ func TestHandler(t *testing.T) {
 			}
 
 			if tt.conf.HTTP.CallbackTemplate != nil {
-				if !assert.Contains(t, string(body), "openvpn-auth-oauth2 is a management client for OpenVPN that handles the authentication") {
+				if !assert.Contains(t, string(body), "openvpn-auth-oauth2 is a management client for OpenVPN that handles the single sign-on") {
 					return
 				}
 			}

--- a/internal/oauth2/provider.go
+++ b/internal/oauth2/provider.go
@@ -71,7 +71,7 @@ func NewProvider(logger *slog.Logger, conf config.Config) (Provider, error) {
 	}
 
 	if endpoints == (oauth2.Endpoint{}) {
-		if !utils.IsURLEmpty(conf.OAuth2.Endpoints.Discovery) {
+		if !config.IsURLEmpty(conf.OAuth2.Endpoints.Discovery) {
 			logger.Info(utils.StringConcat(
 				"discover oidc auto configuration with provider ",
 				provider.GetName(), " for issuer ", conf.OAuth2.Issuer.String(),

--- a/internal/oauth2/providers/generic/check_test.go
+++ b/internal/oauth2/providers/generic/check_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/generic"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/state"
-	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -162,8 +161,6 @@ func TestValidateCommonName(t *testing.T) {
 		{"sub required", "sub", "apple", "apple", config.CommonNameModePlain, ""},
 		{"sub required wrong", "sub", "pear", "apple", config.CommonNameModePlain, "common_name mismatch: openvpn client: apple - oidc token: pear"},
 		{"nonexists claim", "nonexists", "pear", "apple", config.CommonNameModePlain, "missing claim: nonexists"},
-		{"sub md5", "sub", "apple", utils.TransformCommonName(config.CommonNameModeMD5, "apple"), config.CommonNameModeMD5, ""},
-		{"sub sha1", "sub", "apple", utils.TransformCommonName(config.CommonNameModeSHA1, "apple"), config.CommonNameModeSHA1, ""},
 		{"sub omit", "sub", "apple", config.CommonNameModeOmitValue, config.CommonNameModeOmit, "common_name mismatch: openvpn client is empty"},
 	} {
 		tt := tt

--- a/internal/oauth2/providers/generic/check_test.go
+++ b/internal/oauth2/providers/generic/check_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/generic"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/state"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -153,13 +154,17 @@ func TestValidateCommonName(t *testing.T) {
 		tokenClaim         string
 		tokenCommonName    any
 		requiredCommonName string
+		commonNameMode     config.OpenVPNCommonNameMode
 		err                string
 	}{
-		{"not require", "", nil, "", ""},
-		{"sub present", "sub", "apple", "", "common_name mismatch: openvpn client: apple - oidc token: "},
-		{"sub required", "sub", "apple", "apple", ""},
-		{"sub required wrong", "sub", "pear", "apple", "common_name mismatch: openvpn client: pear - oidc token: apple"},
-		{"nonexists claim", "nonexists", "pear", "apple", "missing claim: nonexists"},
+		{"not require", "", nil, "", config.CommonNameModePlain, ""},
+		{"sub empty", "sub", "apple", "", config.CommonNameModePlain, "common_name mismatch: openvpn client is empty"},
+		{"sub required", "sub", "apple", "apple", config.CommonNameModePlain, ""},
+		{"sub required wrong", "sub", "pear", "apple", config.CommonNameModePlain, "common_name mismatch: openvpn client: apple - oidc token: pear"},
+		{"nonexists claim", "nonexists", "pear", "apple", config.CommonNameModePlain, "missing claim: nonexists"},
+		{"sub md5", "sub", "apple", utils.TransformCommonName(config.CommonNameModeMD5, "apple"), config.CommonNameModeMD5, ""},
+		{"sub sha1", "sub", "apple", utils.TransformCommonName(config.CommonNameModeSHA1, "apple"), config.CommonNameModeSHA1, ""},
+		{"sub omit", "sub", "apple", config.CommonNameModeOmitValue, config.CommonNameModeOmit, "common_name mismatch: openvpn client is empty"},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -174,6 +179,11 @@ func TestValidateCommonName(t *testing.T) {
 			}
 
 			conf := config.Config{
+				OpenVpn: config.OpenVpn{
+					CommonName: config.OpenVPNCommonName{
+						Mode: tt.commonNameMode,
+					},
+				},
 				OAuth2: config.OAuth2{
 					Validate: config.OAuth2Validate{
 						CommonName: tt.tokenClaim,

--- a/internal/oauth2/providers/generic/endpoints.go
+++ b/internal/oauth2/providers/generic/endpoints.go
@@ -12,8 +12,7 @@ func (p *Provider) GetEndpoints(conf config.Config) (oauth2.Endpoint, error) {
 		return oauth2.Endpoint{}, nil
 	}
 
-	if (!config.IsURLEmpty(conf.OAuth2.Endpoints.Token) && config.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) ||
-		(config.IsURLEmpty(conf.OAuth2.Endpoints.Token) && !config.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) {
+	if config.IsURLEmpty(conf.OAuth2.Endpoints.Auth) || config.IsURLEmpty(conf.OAuth2.Endpoints.Token) {
 		return oauth2.Endpoint{}, errors.New("both oauth2.endpoints.tokenUrl and oauth2.endpoints.authUrl are required")
 	}
 

--- a/internal/oauth2/providers/generic/endpoints.go
+++ b/internal/oauth2/providers/generic/endpoints.go
@@ -4,17 +4,16 @@ import (
 	"errors"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
-	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
 	"golang.org/x/oauth2"
 )
 
 func (p *Provider) GetEndpoints(conf config.Config) (oauth2.Endpoint, error) {
-	if utils.IsURLEmpty(conf.OAuth2.Endpoints.Token) && utils.IsURLEmpty(conf.OAuth2.Endpoints.Auth) {
+	if config.IsURLEmpty(conf.OAuth2.Endpoints.Token) && config.IsURLEmpty(conf.OAuth2.Endpoints.Auth) {
 		return oauth2.Endpoint{}, nil
 	}
 
-	if (!utils.IsURLEmpty(conf.OAuth2.Endpoints.Token) && utils.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) ||
-		(utils.IsURLEmpty(conf.OAuth2.Endpoints.Token) && !utils.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) {
+	if (!config.IsURLEmpty(conf.OAuth2.Endpoints.Token) && config.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) ||
+		(config.IsURLEmpty(conf.OAuth2.Endpoints.Token) && !config.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) {
 		return oauth2.Endpoint{}, errors.New("both oauth2.endpoints.tokenUrl and oauth2.endpoints.authUrl are required")
 	}
 

--- a/internal/oauth2/providers/github/endpoints.go
+++ b/internal/oauth2/providers/github/endpoints.go
@@ -4,18 +4,17 @@ import (
 	"errors"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
-	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
 )
 
 func (p *Provider) GetEndpoints(conf config.Config) (oauth2.Endpoint, error) {
-	if utils.IsURLEmpty(conf.OAuth2.Endpoints.Token) && utils.IsURLEmpty(conf.OAuth2.Endpoints.Auth) {
+	if config.IsURLEmpty(conf.OAuth2.Endpoints.Token) && config.IsURLEmpty(conf.OAuth2.Endpoints.Auth) {
 		return github.Endpoint, nil
 	}
 
-	if (!utils.IsURLEmpty(conf.OAuth2.Endpoints.Token) && utils.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) ||
-		(utils.IsURLEmpty(conf.OAuth2.Endpoints.Token) && !utils.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) {
+	if (!config.IsURLEmpty(conf.OAuth2.Endpoints.Token) && config.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) ||
+		(config.IsURLEmpty(conf.OAuth2.Endpoints.Token) && !config.IsURLEmpty(conf.OAuth2.Endpoints.Auth)) {
 		return oauth2.Endpoint{}, errors.New("both oauth2.endpoints.tokenUrl and oauth2.endpoints.authUrl are required")
 	}
 

--- a/internal/openvpn/client.go
+++ b/internal/openvpn/client.go
@@ -52,7 +52,9 @@ func (c *Client) clientConnect(client connection.Client) error {
 		Kid: client.Kid,
 	}
 
-	session := state.New(ClientIdentifier, client.IPAddr, client.CommonName)
+	commonName := utils.TransformCommonName(c.conf.OpenVpn.CommonName.Mode, client.CommonName)
+
+	session := state.New(ClientIdentifier, client.IPAddr, commonName)
 	if err = session.Encode(c.conf.HTTP.Secret); err != nil {
 		return fmt.Errorf("error encoding state: %w", err)
 	}
@@ -61,6 +63,12 @@ func (c *Client) clientConnect(client connection.Client) error {
 		strings.TrimSuffix(c.conf.HTTP.BaseURL.String(), "/"),
 		"/oauth2/start?state=", url.QueryEscape(session.Encoded()),
 	)
+
+	if len(startURL) >= 245 {
+		c.DenyClient(logger, ClientIdentifier, "internal error")
+		return fmt.Errorf("url %s (%d chars) too long! OpenVPN support up to 245 chars. Try --openvpn.common-name.mode to avoid this error",
+			startURL, len(startURL))
+	}
 
 	logger.Info("start pending auth")
 

--- a/internal/openvpn/client.go
+++ b/internal/openvpn/client.go
@@ -66,6 +66,7 @@ func (c *Client) clientConnect(client connection.Client) error {
 
 	if len(startURL) >= 245 {
 		c.DenyClient(logger, ClientIdentifier, "internal error")
+
 		return fmt.Errorf("url %s (%d chars) too long! OpenVPN support up to 245 chars. Try --openvpn.common-name.mode to avoid this error",
 			startURL, len(startURL))
 	}

--- a/internal/utils/common_name.go
+++ b/internal/utils/common_name.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"fmt"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
+)
+
+func TransformCommonName(mode config.OpenVPNCommonNameMode, commonName string) string {
+	switch mode {
+	case config.CommonNameModePlain:
+		return commonName
+	case config.CommonNameModeMD5:
+		return fmt.Sprintf("%x", md5.Sum([]byte(commonName)))
+	case config.CommonNameModeSHA1:
+		return fmt.Sprintf("%x", sha1.Sum([]byte(commonName)))
+	case config.CommonNameModeOmit:
+		fallthrough
+	default:
+		return config.CommonNameModeOmitValue
+	}
+}

--- a/internal/utils/common_name.go
+++ b/internal/utils/common_name.go
@@ -1,10 +1,6 @@
 package utils
 
 import (
-	"crypto/md5"
-	"crypto/sha1"
-	"fmt"
-
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
 )
 
@@ -12,10 +8,6 @@ func TransformCommonName(mode config.OpenVPNCommonNameMode, commonName string) s
 	switch mode {
 	case config.CommonNameModePlain:
 		return commonName
-	case config.CommonNameModeMD5:
-		return fmt.Sprintf("%x", md5.Sum([]byte(commonName)))
-	case config.CommonNameModeSHA1:
-		return fmt.Sprintf("%x", sha1.Sum([]byte(commonName)))
 	case config.CommonNameModeOmit:
 		fallthrough
 	default:

--- a/internal/utils/common_name_test.go
+++ b/internal/utils/common_name_test.go
@@ -1,0 +1,48 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformCommonName(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		mode     config.OpenVPNCommonNameMode
+		expected string
+		actual   string
+	}{
+		{
+			config.CommonNameModePlain,
+			"hello world",
+			"hello world",
+		},
+		{
+			config.CommonNameModeMD5,
+			"5eb63bbbe01eeed093cb22bb8f5acdc3",
+			"hello world",
+		},
+		{
+			config.CommonNameModeSHA1,
+			"2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+			"hello world",
+		},
+		{
+			config.CommonNameModeOmit,
+			config.CommonNameModeOmitValue,
+			"hello world",
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.mode.String(), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, utils.TransformCommonName(tc.mode, tc.actual))
+		})
+	}
+}

--- a/internal/utils/common_name_test.go
+++ b/internal/utils/common_name_test.go
@@ -22,16 +22,6 @@ func TestTransformCommonName(t *testing.T) {
 			"hello world",
 		},
 		{
-			config.CommonNameModeMD5,
-			"5eb63bbbe01eeed093cb22bb8f5acdc3",
-			"hello world",
-		},
-		{
-			config.CommonNameModeSHA1,
-			"2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
-			"hello world",
-		},
-		{
 			config.CommonNameModeOmit,
 			config.CommonNameModeOmitValue,
 			"hello world",

--- a/internal/utils/common_name_test.go
+++ b/internal/utils/common_name_test.go
@@ -11,7 +11,7 @@ import (
 func TestTransformCommonName(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		mode     config.OpenVPNCommonNameMode
 		expected string
 		actual   string
@@ -37,12 +37,12 @@ func TestTransformCommonName(t *testing.T) {
 			"hello world",
 		},
 	} {
-		tc := tc
+		tt := tt
 
-		t.Run(tc.mode.String(), func(t *testing.T) {
+		t.Run(tt.mode.String(), func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tc.expected, utils.TransformCommonName(tc.mode, tc.actual))
+			assert.Equal(t, tt.expected, utils.TransformCommonName(tt.mode, tt.actual))
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

`openvpn.common-name.mode` is a new flag for mutate the common_name value of an OpenVPN client.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #73
 
#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] The PR title has a summary of the changes
- [ ] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
