### PR TITLE
BREAKING: openvpn.bypass.cn -> openvpn.bypass.common-names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           args: --out-format "github-actions,colored-line-number"
 

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ $RECYCLE.BIN/
 *.lnk
 
 openvpn-auth-oauth2
+openvpn-auth-oauth2.exe

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ goperfsprint:
 
 .PHONY: golangci
 golangci:
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2 run ./...
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1 run ./...
 
 .PHONY: golangci-fix
 golangci-fix:
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2 run ./... --fix
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1 run ./... --fix

--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,24 @@ help: ## show this help.
 
 .PHONY: clean
 clean: ## clean builds dir
-	@rm -rf openvpn-auth-oauth2 dist/
+	@rm -rf openvpn-auth-oauth2 openvpn-auth-oauth2.exe dist/
 
 .PHONY: check
 check: test lint golangci ## Run all checks locally
 
 .PHONY: build
-build: clean openvpn-auth-oauth2  ## Build openvpn-auth-oauth2
+ifeq ($(OS),Windows_NT)
+build: clean openvpn-auth-oauth2.exe  ## Build openvpn-auth-oauth2
+else
+build: clean openvpn-auth-oauth2
+endif
+
 
 openvpn-auth-oauth2:
 	@go build -o openvpn-auth-oauth2 .
+
+openvpn-auth-oauth2.exe:
+	@go build -o openvpn-auth-oauth2.exe .
 
 .Phony: build-debug
 build-debug: ## Build openvpn-auth-oauth2 with debug flags

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,137 +32,151 @@ openvpn-auth-oauth2 supports configuration via a YAML file. The file can be pass
 debug:
     pprof: false
     listen: :9001
+http:
+    baseurl: "http://localhost:9000/"
+    cert: ""
+    check:
+        ipaddr: false
+    enable-proxy-headers: true
+    key: ""
+    listen: ":9000"
+    # secret: ""
+    # template: "" # Path to a HTML file which is displayed at the end of the screen   
+    tls: false
 log:
     format: console
     level: INFO
-http:
-    listen: :9000
-    baseurl: "http://<vpn>:9000/"
-    secret: "1jd93h5b6s82lf03jh5b2hf9"
-    check:
-        ipaddr: false
-    enableproxyheaders: false
-openvpn:
-    addr: "unix:///run/openvpn/server.sock"
-    password: ""
-    bypass:
-        commonnames: ""
-    authtokenuser: true
-    authpendingtimeout: 3m
-    commonname:
-        mode: plain
 oauth2:
-    issuer: "https://company.zitadel.cloud"
-    provider: generic
-    authorizeparams: ""
-    endpoints:
-        discovery:
-        auth:
-        token:
+    authorize-params: "a=c"
     client:
-        id: ""
-        secret: ""
-    scopes: ""
-    nonce: true
-    pkce: true
+        id: "test"
+        secret: "test"
+    endpoint:
+        # discovery: "https://idp/.well-known/openid-configuration"
+        # auth: "https://idp/oauth/auth"
+        # token: "https://idp/oauth/token"
+    issuer: "https://idp"
+    # scopes:
+    #  - "openid"
+    #  - "profile"
     validate:
-        groups: ""
-        roles: ""
+        common-name: ""
+        # groups:
+        #  - "test"
+        #  - "test2"
+        # roles:
+        #   - "test"
+        #   - "test2"
         ipaddr: false
         issuer: true
-        commonname: ""
+    nonce: true
+    pkce: true
     refresh:
         enabled: false
         expires: 8h0m0s
-        secret: ""
+        # secret: ""
+openvpn:
+    addr: "unix:///run/openvpn/server.sock"
+    auth-token-user: true
+    auth-pending-timeout: 2m
+    bypass:
+        # common-names:
+        # - "test"
+        # - "test2"
+    common-name:
+        mode: plain
+    # password: ""
 ```
 </details>
 
 ## Supported configuration properties
 
 ```
-Usage of ./openvpn-auth-oauth2:
+Usage of openvpn-auth-oauth2:
+
 
   --config string
-    	path to one .yaml config file (env: CONFIG_CONFIG)
+        path to one .yaml config file (env: CONFIG_CONFIG)
   --debug.listen string
-    	listen address for go profiling endpoint (env: CONFIG_DEBUG_LISTEN) (default ":9001")
+        listen address for go profiling endpoint (env: CONFIG_DEBUG_LISTEN) (default ":9001")
   --debug.pprof
-    	Enables go profiling endpoint. This should be never exposed. (env: CONFIG_DEBUG_PPROF)
+        Enables go profiling endpoint. This should be never exposed. (env: CONFIG_DEBUG_PPROF)
   --http.baseurl string
-    	listen addr for client listener (env: CONFIG_HTTP_BASEURL) (default "http://localhost:9000")
+        listen addr for client listener (env: CONFIG_HTTP_BASEURL) (default "http://localhost:9000")
   --http.cert string
-    	Path to tls server certificate (env: CONFIG_HTTP_CERT)
+        Path to tls server certificate (env: CONFIG_HTTP_CERT)
   --http.check.ipaddr
-    	Check if client IP in http and VPN is equal (env: CONFIG_HTTP_CHECK_IPADDR)
+        Check if client IP in http and VPN is equal (env: CONFIG_HTTP_CHECK_IPADDR)
   --http.enable-proxy-headers
-    	Use X-Forward-For http header for client ips (env: CONFIG_HTTP_ENABLE__PROXY__HEADERS)
+        Use X-Forward-For http header for client ips (env: CONFIG_HTTP_ENABLE__PROXY__HEADERS)
   --http.key string
-    	Path to tls server key (env: CONFIG_HTTP_KEY)
+        Path to tls server key (env: CONFIG_HTTP_KEY)
   --http.listen string
-    	listen addr for client listener (env: CONFIG_HTTP_LISTEN) (default ":9000")
+        listen addr for client listener (env: CONFIG_HTTP_LISTEN) (default ":9000")
   --http.secret value
-    	Random generated secret for cookie encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file. (env: CONFIG_HTTP_SECRET)
+        Random generated secret for cookie encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file. (env: CONFIG_HTTP_SECRET)
   --http.template string
-    	Path to a HTML file which is displayed at the end of the screen (env: CONFIG_HTTP_TEMPLATE)
+        Path to a HTML file which is displayed at the end of the screen (env: CONFIG_HTTP_TEMPLATE)
   --http.tls
-    	enable TLS listener (env: CONFIG_HTTP_TLS)
+        enable TLS listener (env: CONFIG_HTTP_TLS)
   --log.format string
-    	log format. json or console (env: CONFIG_LOG_FORMAT) (default "console")
+        log format. json or console (env: CONFIG_LOG_FORMAT) (default "console")
   --log.level value
-    	log level (env: CONFIG_LOG_LEVEL) (default INFO)
+        log level (env: CONFIG_LOG_LEVEL) (default INFO)
   --oauth2.authorize-params string
-    	additional url query parameter to authorize endpoint (env: CONFIG_OAUTH2_AUTHORIZE__PARAMS)
+        additional url query parameter to authorize endpoint (env: CONFIG_OAUTH2_AUTHORIZE__PARAMS)
   --oauth2.client.id string
-    	oauth2 client id (env: CONFIG_OAUTH2_CLIENT_ID)
+        oauth2 client id (env: CONFIG_OAUTH2_CLIENT_ID)
   --oauth2.client.secret value
-    	oauth2 client secret. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OAUTH2_CLIENT_SECRET)
+        oauth2 client secret. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OAUTH2_CLIENT_SECRET)
   --oauth2.endpoint.auth string
-    	custom oauth2 auth endpoint (env: CONFIG_OAUTH2_ENDPOINT_AUTH)
+        custom oauth2 auth endpoint (env: CONFIG_OAUTH2_ENDPOINT_AUTH)
   --oauth2.endpoint.discovery string
-    	custom oauth2 discovery url (env: CONFIG_OAUTH2_ENDPOINT_DISCOVERY)
+        custom oauth2 discovery url (env: CONFIG_OAUTH2_ENDPOINT_DISCOVERY)
   --oauth2.endpoint.token string
-    	custom oauth2 token endpoint (env: CONFIG_OAUTH2_ENDPOINT_TOKEN)
+        custom oauth2 token endpoint (env: CONFIG_OAUTH2_ENDPOINT_TOKEN)
   --oauth2.issuer string
-    	oauth2 issuer (env: CONFIG_OAUTH2_ISSUER)
+        oauth2 issuer (env: CONFIG_OAUTH2_ISSUER)
   --oauth2.nonce
-    	If true, a nonce will be defined on the auth URL which is expected inside the token. (env: CONFIG_OAUTH2_NONCE) (default true)
+        If true, a nonce will be defined on the auth URL which is expected inside the token. (env: CONFIG_OAUTH2_NONCE) (default true)
   --oauth2.pkce
-    	If true, Proof Key for Code Exchange (PKCE) RFC 7636 is used for token exchange. (env: CONFIG_OAUTH2_PKCE) (default true)
+        If true, Proof Key for Code Exchange (PKCE) RFC 7636 is used for token exchange. (env: CONFIG_OAUTH2_PKCE) (default true)
   --oauth2.provider string
-    	oauth2 provider (env: CONFIG_OAUTH2_PROVIDER) (default "generic")
+        oauth2 provider (env: CONFIG_OAUTH2_PROVIDER) (default "generic")
   --oauth2.refresh.enabled
-    	If true, openvpn-auth-oauth2 stores refresh tokens and will use it do an non-interaction reauth. (env: CONFIG_OAUTH2_REFRESH_ENABLED)
+        If true, openvpn-auth-oauth2 stores refresh tokens and will use it do an non-interaction reauth. (env: CONFIG_OAUTH2_REFRESH_ENABLED)
   --oauth2.refresh.expires duration
-    	TTL of stored oauth2 token. (env: CONFIG_OAUTH2_REFRESH_EXPIRES) (default 8h0m0s)
+        TTL of stored oauth2 token. (env: CONFIG_OAUTH2_REFRESH_EXPIRES) (default 8h0m0s)
   --oauth2.refresh.secret value
-    	Required, if oauth2.refresh.enabled=true. Random generated secret for token encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OAUTH2_REFRESH_SECRET)
+        Required, if oauth2.refresh.enabled=true. Random generated secret for token encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file. (env: CO
+NFIG_OAUTH2_REFRESH_SECRET)
   --oauth2.scopes value
-    	oauth2 token scopes. Defaults depends on oauth2.provider (env: CONFIG_OAUTH2_SCOPES)
+        oauth2 token scopes. Defaults depends on oauth2.provider. Comma separated list. Example: openid,profile,email (env: CONFIG_OAUTH2_SCOPES)
   --oauth2.validate.common-name string
-    	validate common_name from OpenVPN with IDToken claim (env: CONFIG_OAUTH2_VALIDATE_COMMON__NAME)
+        validate common_name from OpenVPN with IDToken claim. For example: preferred_username or sub (env: CONFIG_OAUTH2_VALIDATE_COMMON__NAME)
   --oauth2.validate.groups value
-    	oauth2 required user groups (env: CONFIG_OAUTH2_VALIDATE_GROUPS)
+        oauth2 required user groups. Comma separated list. Example: group1,group2,group3 (env: CONFIG_OAUTH2_VALIDATE_GROUPS)
   --oauth2.validate.ipaddr
-    	validate client ipaddr between VPN and oidc token (env: CONFIG_OAUTH2_VALIDATE_IPADDR)
+        validate client ipaddr between VPN and oidc token (env: CONFIG_OAUTH2_VALIDATE_IPADDR)
   --oauth2.validate.issuer
-    	validate issuer from oidc discovery (env: CONFIG_OAUTH2_VALIDATE_ISSUER) (default true)
+        validate issuer from oidc discovery (env: CONFIG_OAUTH2_VALIDATE_ISSUER) (default true)
   --oauth2.validate.roles value
-    	oauth2 required user roles (env: CONFIG_OAUTH2_VALIDATE_ROLES)
+        oauth2 required user roles. Comma separated list. Example: role1,role2,role3 (env: CONFIG_OAUTH2_VALIDATE_ROLES)
   --openvpn.addr string
-    	openvpn management interface addr. Must start with unix:// or tcp:// (env: CONFIG_OPENVPN_ADDR) (default "unix:/run/openvpn/server.sock")
+        openvpn management interface addr. Must start with unix:// or tcp:// (env: CONFIG_OPENVPN_ADDR) (default "unix:/run/openvpn/server.sock")
   --openvpn.auth-pending-timeout duration
-    	How long OpenVPN server wait until user is authenticated (env: CONFIG_OPENVPN_AUTH__PENDING__TIMEOUT) (default 3m0s)
+        How long OpenVPN server wait until user is authenticated (env: CONFIG_OPENVPN_AUTH__PENDING__TIMEOUT) (default 3m0s)
   --openvpn.auth-token-user
-    	Define auth-token-user for all sessions (env: CONFIG_OPENVPN_AUTH__TOKEN__USER) (default true)
-  --openvpn.bypass.cn value
-    	bypass oauth authentication for CNs (env: CONFIG_OPENVPN_BYPASS_CN)
+        Define auth-token-user for all sessions (env: CONFIG_OPENVPN_AUTH__TOKEN__USER) (default true)
+  --openvpn.bypass.common-names value
+        bypass oauth authentication for CNs. Comma separated list. (env: CONFIG_OPENVPN_BYPASS_COMMON__NAMES)
   --openvpn.common-name.mode string
-    	If common names are too long, use md5/sha1 to hash them or omit to skip them. If omit, oauth2.validate.common-name does not work anymore. Values: [plain,omit] (env: CONFIG_OPENVPN_COMMON__NAME_MODE) (default "plain")
+        If common names are too long, use md5/sha1 to hash them or omit to skip them. If omit, oauth2.validate.common-name does not work anymore. Values: [plain,omit] (env: CONFIG_OPENVPN_COMMON__NAME_M
+ODE) (default "plain")
   --openvpn.password value
-    	openvpn management interface password. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OPENVPN_PASSWORD)
+        openvpn management interface password. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OPENVPN_PASSWORD)
   --version
-    	show version
+        show version
 ```
 
 ## Read sensitive data from file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,8 @@ func FlagSet(name string) *flag.FlagSet {
 	flagSet.TextVar(new(Secret),
 		"http.secret",
 		Defaults.HTTP.Secret,
-		"Random generated secret for cookie encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file.",
+		"Random generated secret for cookie encryption. Must be 16, 24 or 32 characters. "+
+			"If argument starts with file:// it reads the secret from a file.",
 	)
 	flagSet.String(
 		"http.key",
@@ -118,9 +119,9 @@ func FlagSet(name string) *flag.FlagSet {
 		"How long OpenVPN server wait until user is authenticated",
 	)
 	flagSet.TextVar(new(StringSlice),
-		"openvpn.bypass.cn",
+		"openvpn.bypass.common-names",
 		Defaults.OpenVpn.Bypass.CommonNames,
-		"bypass oauth authentication for CNs",
+		"bypass oauth authentication for CNs. Comma separated list.",
 	)
 	flagSet.String(
 		"openvpn.common-name.mode",
@@ -197,12 +198,14 @@ func FlagSet(name string) *flag.FlagSet {
 	flagSet.TextVar(new(StringSlice),
 		"oauth2.validate.groups",
 		Defaults.OAuth2.Validate.Groups,
-		"oauth2 required user groups",
+		"oauth2 required user groups. Comma separated list. "+
+			"Example: group1,group2,group3",
 	)
 	flagSet.TextVar(new(StringSlice),
 		"oauth2.validate.roles",
 		Defaults.OAuth2.Validate.Roles,
-		"oauth2 required user roles",
+		"oauth2 required user roles. Comma separated list. "+
+			"Example: role1,role2,role3",
 	)
 	flagSet.Bool(
 		"oauth2.validate.ipaddr",
@@ -217,12 +220,13 @@ func FlagSet(name string) *flag.FlagSet {
 	flagSet.String(
 		"oauth2.validate.common-name",
 		Defaults.OAuth2.Validate.CommonName,
-		"validate common_name from OpenVPN with IDToken claim",
+		"validate common_name from OpenVPN with IDToken claim. For example: preferred_username or sub",
 	)
 	flagSet.TextVar(new(StringSlice),
 		"oauth2.scopes",
 		Defaults.OAuth2.Scopes,
-		"oauth2 token scopes. Defaults depends on oauth2.provider",
+		"oauth2 token scopes. Defaults depends on oauth2.provider. Comma separated list. "+
+			"Example: openid,profile,email",
 	)
 	flagSet.Bool(
 		"version",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,10 +30,10 @@ func TestFlagSet(t *testing.T) {
 			},
 		},
 		{
-			"--openvpn.bypass.cn",
-			[]string{"--openvpn.bypass.cn=a,b"},
+			"--openvpn.bypass.common-names",
+			[]string{"--openvpn.bypass.common-names=a,b"},
 			map[string]any{
-				"openvpn.bypass.cn": []string{"a", "b"},
+				"openvpn.bypass.common-names": []string{"a", "b"},
 			},
 		},
 		{

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -30,7 +30,7 @@ func TestLoad(t *testing.T) {
 		},
 		{
 			"minimal file",
-			//language=yaml
+			// language=yaml
 			`
 oauth2:
     issuer: "https://company.zitadel.cloud"
@@ -50,13 +50,14 @@ http:
 				}
 				conf.OAuth2.Client.ID = "test"
 				conf.OAuth2.Client.Secret = "test"
+
 				return conf
 			}(),
 			nil,
 		},
 		{
 			"full file",
-			//language=yaml
+			// language=yaml
 			`
 debug:
     pprof: true

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,0 +1,211 @@
+package config_test
+
+import (
+	"errors"
+	"flag"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log/slog"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name       string
+		configFile string
+		conf       config.Config
+		err        error
+	}{
+		{
+			"empty file",
+			"",
+			config.Config{},
+			errors.New("validation error: oauth2.client.id is required"),
+		},
+		{
+			"minimal file",
+			//language=yaml
+			`
+oauth2:
+    issuer: "https://company.zitadel.cloud"
+    client:
+        id: "test"
+        secret: "test"
+http:
+    secret: "1jd93h5b6s82lf03jh5b2hf9"
+`,
+			func() config.Config {
+				conf := config.Defaults
+				conf.HTTP.CallbackTemplate = nil
+				conf.HTTP.Secret = "1jd93h5b6s82lf03jh5b2hf9"
+				conf.OAuth2.Issuer = &url.URL{
+					Scheme: "https",
+					Host:   "company.zitadel.cloud",
+				}
+				conf.OAuth2.Client.ID = "test"
+				conf.OAuth2.Client.Secret = "test"
+				return conf
+			}(),
+			nil,
+		},
+		{
+			"full file",
+			//language=yaml
+			`
+debug:
+    pprof: true
+    listen: :9002
+log:
+    format: json
+    level: DEBUG
+oauth2:
+    issuer: "https://company.zitadel.cloud"
+    client:
+        id: "test"
+        secret: "test"
+    validate:
+        common-name: "preffered_username"
+        groups:
+        - "test"
+        - "test2"
+        roles: 
+        - "test"
+        - "test2"
+        ipaddr: true
+        issuer: false
+    authorize-params: "a=c"
+    scopes: 
+    - "openid"
+    - "profile"
+    nonce: true
+    pkce: true
+    refresh:
+        enabled: true
+        expires: 10h0m0s
+        secret: "1jd93h5b6s82lf03jh5b2hf9"
+openvpn:
+    addr: "unix:///run/openvpn/server2.sock"
+    auth-token-user: true
+    auth-pending-timeout: 2m
+    bypass:
+        common-names:
+        - "test"
+        - "test2"
+    common-name:
+        mode: omit
+    password: "1jd93h5b6s82lf03jh5b2hf9"
+http:
+    listen: ":9001"
+    secret: "1jd93h5b6s82lf03jh5b2hf9"
+    enable-proxy-headers: true
+    check:
+        ipaddr: true
+`,
+			config.Config{
+				Debug: config.Debug{
+					Pprof:  true,
+					Listen: ":9002",
+				},
+				Log: config.Log{
+					Format: "json",
+					Level:  slog.LevelDebug,
+				},
+				HTTP: config.HTTP{
+					Listen:             ":9001",
+					EnableProxyHeaders: true,
+					Check: config.HTTPCheck{
+						IPAddr: true,
+					},
+					Secret: "1jd93h5b6s82lf03jh5b2hf9",
+					BaseURL: &url.URL{
+						Scheme: "http",
+						Host:   "localhost:9000",
+					},
+				},
+				OpenVpn: config.OpenVpn{
+					Addr: &url.URL{
+						Scheme:   "unix",
+						Path:     "/run/openvpn/server2.sock",
+						OmitHost: false,
+					},
+					Bypass: config.OpenVpnBypass{
+						CommonNames: []string{"test", "test2"},
+					},
+					Password:           "1jd93h5b6s82lf03jh5b2hf9",
+					AuthTokenUser:      true,
+					AuthPendingTimeout: 2 * time.Minute,
+					CommonName: config.OpenVPNCommonName{
+						Mode: config.CommonNameModeOmit,
+					},
+				},
+				OAuth2: config.OAuth2{
+					Issuer: &url.URL{
+						Scheme: "https",
+						Host:   "company.zitadel.cloud",
+					},
+					Provider: "generic",
+
+					AuthorizeParams: "a=c",
+					Endpoints: config.OAuth2Endpoints{
+						Auth:      &url.URL{},
+						Token:     &url.URL{},
+						Discovery: &url.URL{},
+					},
+					Client: config.OAuth2Client{
+						ID:     "test",
+						Secret: "test",
+					},
+					Nonce:  true,
+					Pkce:   true,
+					Scopes: []string{"openid", "profile"},
+					Refresh: config.OAuth2Refresh{
+						Enabled: true,
+						Expires: 10 * time.Hour,
+						Secret:  "1jd93h5b6s82lf03jh5b2hf9",
+					},
+					Validate: config.OAuth2Validate{
+						CommonName: "preffered_username",
+						IPAddr:     true,
+						Issuer:     false,
+						Groups:     []string{"test", "test2"},
+						Roles:      []string{"test", "test2"},
+					},
+				},
+			},
+			nil,
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			file, err := os.CreateTemp("", "openvpn-auth-oauth2-*")
+			require.NoError(t, err)
+
+			// close and remove the temporary file at the end of the program
+			defer file.Close()
+			defer os.Remove(file.Name())
+
+			_, err = file.WriteString(tt.configFile)
+			require.NoError(t, err)
+
+			conf, err := config.Load(config.ManagementClient, file.Name(), flag.NewFlagSet("openvpn-auth-oauth2", flag.ContinueOnError))
+			conf.HTTP.CallbackTemplate = nil
+
+			if tt.err != nil {
+				require.Error(t, err)
+				assert.Equal(t, tt.err.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.conf, conf)
+			}
+		})
+	}
+}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -3,14 +3,15 @@ package config_test
 import (
 	"errors"
 	"flag"
-	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"log/slog"
 	"net/url"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoad(t *testing.T) {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -49,7 +49,7 @@ type OpenVpn struct {
 }
 
 type OpenVpnBypass struct {
-	CommonNames StringSlice `koanf:"cn"`
+	CommonNames StringSlice `koanf:"common-names"`
 }
 
 type OpenVPNCommonName struct {
@@ -85,7 +85,7 @@ type OAuth2Validate struct {
 	Roles      StringSlice `koanf:"roles"`
 	IPAddr     bool        `koanf:"ipaddr"`
 	Issuer     bool        `koanf:"issuer"`
-	CommonName string      `koanf:"common_name"`
+	CommonName string      `koanf:"common-name"`
 }
 
 type OAuth2Refresh struct {


### PR DESCRIPTION
#### What this PR does / why we need it

* Fixed `oauth2.validate.common-name`
* Renamed CLI flag `openvpn.bypass.cn` to `openvpn.bypass.common-names`

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #143 
fixes #149

#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] The PR title has a summary of the changes
- [ ] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
