### PR TITLE
If multiple groups are configured, the user needs to be least in one group instead of all groups.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,14 +198,14 @@ func FlagSet(name string) *flag.FlagSet {
 	flagSet.TextVar(new(StringSlice),
 		"oauth2.validate.groups",
 		Defaults.OAuth2.Validate.Groups,
-		"oauth2 required user groups. Comma separated list. "+
-			"Example: group1,group2,group3",
+		"oauth2 required user groups. If multiple groups are configured, the user needs to be least in one group. "+
+			"Comma separated list. Example: group1,group2,group3",
 	)
 	flagSet.TextVar(new(StringSlice),
 		"oauth2.validate.roles",
 		Defaults.OAuth2.Validate.Roles,
-		"oauth2 required user roles. Comma separated list. "+
-			"Example: role1,role2,role3",
+		"oauth2 required user roles. If multiple role are configured, the user needs to be least in one role. "+
+			"Comma separated list. Example: role1,role2,role3",
 	)
 	flagSet.Bool(
 		"oauth2.validate.ipaddr",

--- a/internal/oauth2/providers/generic/check.go
+++ b/internal/oauth2/providers/generic/check.go
@@ -50,12 +50,12 @@ func (p *Provider) CheckGroups(tokens *oidc.Tokens[*idtoken.Claims]) error {
 	}
 
 	for _, group := range p.Conf.OAuth2.Validate.Groups {
-		if !slices.Contains(tokenGroupsList, group) {
-			return fmt.Errorf("%w: %s", ErrMissingRequiredGroup, group)
+		if slices.Contains(tokenGroupsList, group) {
+			return nil
 		}
 	}
 
-	return nil
+	return ErrMissingRequiredGroup
 }
 
 func (p *Provider) CheckRoles(tokens *oidc.Tokens[*idtoken.Claims]) error {
@@ -74,12 +74,12 @@ func (p *Provider) CheckRoles(tokens *oidc.Tokens[*idtoken.Claims]) error {
 	}
 
 	for _, role := range p.Conf.OAuth2.Validate.Roles {
-		if !slices.Contains(tokenRolesList, role) {
-			return fmt.Errorf("%w: %s", ErrMissingRequiredRole, role)
+		if slices.Contains(tokenRolesList, role) {
+			return nil
 		}
 	}
 
-	return nil
+	return ErrMissingRequiredRole
 }
 
 func (p *Provider) CheckCommonName(session state.State, tokens *oidc.Tokens[*idtoken.Claims]) error {

--- a/internal/oauth2/providers/generic/check_test.go
+++ b/internal/oauth2/providers/generic/check_test.go
@@ -55,10 +55,11 @@ func TestValidateGroups(t *testing.T) {
 		{"groups not present", "groups", nil, []string{}, ""},
 		{"groups empty", "groups", []any{}, []string{}, ""},
 		{"groups present", "groups", []any{"apple"}, []string{}, ""},
-		{"require one group", "groups", []any{"apple"}, []string{"apple"}, ""},
-		{"require one group, claim not present", "", []any{"apple"}, []string{"apple"}, "missing claim: groups"},
-		{"require two group, missing one", "groups", []any{"apple"}, []string{"apple", "pear"}, ""},
-		{"require two group", "groups", []any{"apple", "pear"}, []string{"apple", "pear"}, ""},
+		{"configure one group", "groups", []any{"apple"}, []string{"apple"}, ""},
+		{"configure one group, claim not present", "", []any{"apple"}, []string{"apple"}, "missing claim: groups"},
+		{"configure two group, none match", "groups", []any{}, []string{"apple", "pear"}, generic.ErrMissingRequiredGroup.Error()},
+		{"configure two group, missing one", "groups", []any{"apple"}, []string{"apple", "pear"}, ""},
+		{"configure two group", "groups", []any{"apple", "pear"}, []string{"apple", "pear"}, ""},
 	} {
 		tt := tt
 
@@ -107,10 +108,11 @@ func TestValidateRoles(t *testing.T) {
 		{"groups not present", "roles", nil, []string{}, ""},
 		{"groups empty", "roles", []any{}, []string{}, ""},
 		{"groups present", "roles", []any{"apple"}, []string{}, ""},
-		{"require one group", "roles", []any{"apple"}, []string{"apple"}, ""},
-		{"require one group, claim not present", "", []any{"apple"}, []string{"apple"}, "missing claim: roles"},
-		{"require two group, missing one", "roles", []any{"apple"}, []string{"apple", "pear"}, ""},
-		{"require two group", "roles", []any{"apple", "pear"}, []string{"apple", "pear"}, ""},
+		{"configure one role", "roles", []any{"apple"}, []string{"apple"}, ""},
+		{"configure one role, claim not present", "", []any{"apple"}, []string{"apple"}, "missing claim: roles"},
+		{"configure two role, none match", "roles", []any{}, []string{"apple", "pear"}, generic.ErrMissingRequiredRole.Error()},
+		{"configure two role, missing one", "roles", []any{"apple"}, []string{"apple", "pear"}, ""},
+		{"configure two role", "roles", []any{"apple", "pear"}, []string{"apple", "pear"}, ""},
 	} {
 		tt := tt
 

--- a/internal/oauth2/providers/generic/check_test.go
+++ b/internal/oauth2/providers/generic/check_test.go
@@ -57,7 +57,7 @@ func TestValidateGroups(t *testing.T) {
 		{"groups present", "groups", []any{"apple"}, []string{}, ""},
 		{"require one group", "groups", []any{"apple"}, []string{"apple"}, ""},
 		{"require one group, claim not present", "", []any{"apple"}, []string{"apple"}, "missing claim: groups"},
-		{"require two group, missing one", "groups", []any{"apple"}, []string{"apple", "pear"}, "missing required group: pear"},
+		{"require two group, missing one", "groups", []any{"apple"}, []string{"apple", "pear"}, ""},
 		{"require two group", "groups", []any{"apple", "pear"}, []string{"apple", "pear"}, ""},
 	} {
 		tt := tt
@@ -109,7 +109,7 @@ func TestValidateRoles(t *testing.T) {
 		{"groups present", "roles", []any{"apple"}, []string{}, ""},
 		{"require one group", "roles", []any{"apple"}, []string{"apple"}, ""},
 		{"require one group, claim not present", "", []any{"apple"}, []string{"apple"}, "missing claim: roles"},
-		{"require two group, missing one", "roles", []any{"apple"}, []string{"apple", "pear"}, "missing required role: pear"},
+		{"require two group, missing one", "roles", []any{"apple"}, []string{"apple", "pear"}, ""},
 		{"require two group", "roles", []any{"apple", "pear"}, []string{"apple", "pear"}, ""},
 	} {
 		tt := tt


### PR DESCRIPTION
…group instead of all groups.

#### What this PR does / why we need it

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #155

#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] The PR title has a summary of the changes
- [ ] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
