### PR TITLE
Proposal: Run under preconfigured user

### DIFF
--- a/packaging/openvpn-auth-oauth2.service
+++ b/packaging/openvpn-auth-oauth2.service
@@ -6,8 +6,8 @@ After=network-online.target openvpn.service openvpn@.service openvpn-server@.ser
 PartOf=openvpn.service openvpn@.service openvpn-server@.service
 
 [Service]
-DynamicUser=true
-Group=nogroup
+User=openvpn-auth-oauth2
+Group=openvpn-auth-oauth2
 ExecStart=/usr/bin/openvpn-auth-oauth2
 EnvironmentFile=/etc/sysconfig/openvpn-auth-oauth2
 ProtectSystem=strict

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -3,7 +3,7 @@
 set -e
 
 if ! getent passwd _openvpn-auth-oauth2 > /dev/null; then
-    adduser --system --group --no-create-home --disabled-login --disabled-password _openvpn-auth-oauth2
+    adduser --system --group --no-create-home --disabled-login --disabled-password openvpn-auth-oauth2
 fi
 
 if command -v systemctl >/dev/null 2>&1; then

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-if ! getent passwd openvpn-auth-oauth2 > /dev/null; then
-    adduser --system --group --no-create-home --disabled-login --disabled-password openvpn-auth-oauth2
+if ! getent passwd _openvpn-auth-oauth2 > /dev/null; then
+    adduser --system --group --no-create-home --disabled-login --disabled-password _openvpn-auth-oauth2
 fi
 
 if command -v systemctl >/dev/null 2>&1; then

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if ! getent passwd openvpn-auth-oauth2 > /dev/null; then
+    adduser --system --group --no-create-home --disabled-login --disabled-password openvpn-auth-oauth2
+fi
+
 if command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload
     if systemctl is-active --quiet openvpn-auth-oauth2; then

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -3,11 +3,11 @@
 set -e
 
 if [ -x "$(command -v deluser)" ]; then
-     deluser --quiet --system openvpn-auth-oauth2 > /dev/null || true
+     deluser --quiet --system _openvpn-auth-oauth2 > /dev/null || true
   else
-     echo >&2 "not removing openvpn-auth-oauth2 system account because deluser command was not found"
+     echo >&2 "not removing _openvpn-auth-oauth2 system account because deluser command was not found"
 fi
 
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl disable -q --now openvpn-auth-oauth2 > /dev/null 2>&1 || true
+    systemctl disable -q --now _openvpn-auth-oauth2 > /dev/null 2>&1 || true
 fi

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -3,9 +3,9 @@
 set -e
 
 if [ -x "$(command -v deluser)" ]; then
-     deluser --quiet --system _openvpn-auth-oauth2 > /dev/null || true
+     deluser --quiet --system openvpn-auth-oauth2 > /dev/null || true
   else
-     echo >&2 "not removing _openvpn-auth-oauth2 system account because deluser command was not found"
+     echo >&2 "not removing openvpn-auth-oauth2 system account because deluser command was not found"
 fi
 
 if command -v systemctl >/dev/null 2>&1; then

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -9,5 +9,5 @@ if [ -x "$(command -v deluser)" ]; then
 fi
 
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl disable -q --now _openvpn-auth-oauth2 > /dev/null 2>&1 || true
+    systemctl disable -q --now openvpn-auth-oauth2 > /dev/null 2>&1 || true
 fi

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+if [ -x "$(command -v deluser)" ]; then
+     deluser --quiet --system openvpn-auth-oauth2 > /dev/null || true
+  else
+     echo >&2 "not removing openvpn-auth-oauth2 system account because deluser command was not found"
+fi
+
 if command -v systemctl >/dev/null 2>&1; then
     systemctl disable -q --now openvpn-auth-oauth2 > /dev/null 2>&1 || true
 fi


### PR DESCRIPTION
#### What this PR does / why we need it
Currently, the `openvpn-auth-oauth2` service runs under a `DynamicUser` which means that rights can not reliably be given to the user. 
This is necessary for locking down:
- the Service Account JSON file containing SA credentials
- server certificates
- maybe also /etc/sysconfig/openvpn-auth-oauth2?

#### Special notes for your reviewer
I'm not sure if this is the way to go, since ideally you want to run under the nobody user, but in that case I still don't know how to grant the correct permissions to the above files.

I also am not an expert on packaging, so I have **not** been able to test this. Mainly as a start of the discussion.

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] The PR title has a summary of the changes
- [ ] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
