### PR TITLE
Feature: Add Support  for Custom auth-token validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ $RECYCLE.BIN/
 
 /openvpn-auth-oauth2
 /openvpn-auth-oauth2.exe
+
+vendor/

--- a/internal/openvpn/client.go
+++ b/internal/openvpn/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/crypto"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -155,8 +156,10 @@ func (c *Client) checkAuthToken(logger *slog.Logger, client connection.Client) b
 		deCryptBytes, err := crypto.DecryptBytesAES(ps, c.conf.HTTP.Secret.String())
 		if err == nil {
 			payload := strings.Split(string(deCryptBytes), "|")
-			if len(payload) == 2 {
+			if len(payload) == 2 && payload[1] != "" {
+				t, _ := strconv.ParseInt(payload[1], 10, 0)
 				// todo check auth-token lifetime with a configurable value
+				_ = t
 			}
 
 			ClientIdentifier.AuthToken = authTokenString

--- a/internal/openvpn/connection/client.go
+++ b/internal/openvpn/connection/client.go
@@ -15,10 +15,22 @@ type Client struct {
 	IPAddr     string
 	CommonName string
 	IvSSO      string
+	Env        map[string]string
+}
+
+func (client *Client) GetUserName() string {
+	commonName := client.CommonName
+	if client.Env["username"] != "" {
+		commonName = client.Env["username"]
+	}
+
+	return commonName
 }
 
 func NewClient(conf config.Config, message string) (Client, error) { //nolint:cyclop
-	client := Client{}
+	client := Client{
+		Env: make(map[string]string),
+	}
 
 	var (
 		err  error
@@ -42,7 +54,7 @@ func NewClient(conf config.Config, message string) (Client, error) { //nolint:cy
 			if envKey == "" || envValue == "" {
 				continue
 			}
-
+			client.Env[envKey] = envValue
 			switch envKey {
 			case "untrusted_ip":
 				client.IPAddr = envValue

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -25,6 +25,7 @@ type ClientIdentifier struct {
 	Kid                  uint64
 	AuthFailedReasonFile string
 	AuthControlFile      string
+	AuthToken            string
 }
 
 func New(client ClientIdentifier, ipaddr, commonName string) State {


### PR DESCRIPTION
#### What this PR does / why we need it

Add Support  for Custom auth-token validation

- If `openvpn.auth-token-user` is enabled, the server will push the auth-token to the client, and finish quickly recover when the client is recovering from wakeup

- **re-auth is also benefited from this PR**, there will be a very quick re-auth even **without enabling** `oauth2.refresh.enabled`
-  #144  is also benefited from this PR if `oauth2.refresh.enabled` is disabled

#### Which issue this PR fixes
- fixes #184 
- fixes https://github.com/OpenVPN/openvpn/issues/296

#### Special notes for your reviewer

TODO: [configurable AUTH-TOKEN lifetime checker](https://github.com/jkroepke/openvpn-auth-oauth2/pull/188/files#diff-f468b087ae22ac24635436d0d7b3cf7b4dd3b0f8af01b82f5983015ca4b8510fR159)

#### Particularly user-facing changes

Please ensure to **remove `auth-gen-token` from your OpenVPN server configuration** to make this work

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
