### PR TITLE
Fix misspelling auth-gen-token

### DIFF
--- a/docs/Non-interactive session refresh.md
+++ b/docs/Non-interactive session refresh.md
@@ -39,7 +39,7 @@ until the connection lifetime is reached. Restarting the OpenVPN server will inv
 # Non-interactive session refresh across disconnects
 
 To facilitate non-interactive session refresh across disconnects,
-you must enable `auth-token-gen [lifetime] external-auth` on the OpenVPN server.
+you must enable `auth-gen-token [lifetime] external-auth` on the OpenVPN server.
 
 - `[lifetime]` represents the duration of the token in seconds.
   Once generated, the token's lifetime cannot be extended.


### PR DESCRIPTION
Clear documentation, thank you @jkroepke 

Just a small suggestion: there is no such option as `auth-token-gen` in **OpenVPN** server configuration. I think it's a typo, should be `auth-gen-token`

You can Ctrl+F on OpenVPN docs page to check it 
https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/#server-options

What do you think? 