### PR TITLE
Fix demo issues by updating Go to 1.23 and removing an unsupported OpenVPN client directive.

### DIFF
--- a/docs/demo/docker-compose.yaml
+++ b/docs/demo/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
         GIT_BRANCH: release/2.6
       #language=dockerfile
       dockerfile_inline: |
-        FROM golang:1.22-alpine
+        FROM golang:1.23-alpine
 
         RUN go install github.com/jkroepke/openvpn-auth-oauth2@latest
     restart: unless-stopped

--- a/docs/demo/docker-compose.yaml
+++ b/docs/demo/docker-compose.yaml
@@ -85,7 +85,6 @@ services:
         tls-version-min 1.3
         auth SHA512
 
-        push "redirect-gateway def1"
         auth-nocache
         tun-mtu 1420
         mssfix 1300


### PR DESCRIPTION
#### What this PR does / why we need it

This PR fixes issues in the demo section:
1. Updates the Docker Compose base image to Go 1.23 to resolve dependency compatibility issues in the demo environment.
2. Removes the `push "redirect-gateway def1"` directive from the demo's OpenVPN client configuration to fix connection failures caused by unsupported options.

#### Special notes for your reviewer

- These changes only impact the demo section.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
