### PR TITLE
Fix: Make `oauth2.client.secret` optional when PKCE is enabled

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -37,7 +37,7 @@ oauth2:
   authorize-params: "a=c"
   client:
     id: "test"
-    secret: "test"
+    secret: ""
   endpoint:
   # discovery: "https://idp/.well-known/openid-configuration"
   # auth: "https://idp/oauth/auth"
@@ -137,7 +137,7 @@ Documentation available at https://github.com/jkroepke/openvpn-auth-oauth2/wiki
   --oauth2.client.id string
     	oauth2 client id (env: CONFIG_OAUTH2_CLIENT_ID)
   --oauth2.client.secret value
-    	oauth2 client secret. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OAUTH2_CLIENT_SECRET)
+    	Required, if oauth2.pkce=false. oauth2 client secret. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OAUTH2_CLIENT_SECRET) (default "")
   --oauth2.endpoint.auth string
     	The flag is used to specify a custom OAuth2 authorization endpoint. (env: CONFIG_OAUTH2_ENDPOINT_AUTH)
   --oauth2.endpoint.discovery string
@@ -149,7 +149,7 @@ Documentation available at https://github.com/jkroepke/openvpn-auth-oauth2/wiki
   --oauth2.nonce
     	If true, a nonce will be defined on the auth URL which is expected inside the token. (env: CONFIG_OAUTH2_NONCE) (default true)
   --oauth2.pkce
-    	If true, Proof Key for Code Exchange (PKCE) RFC 7636 is used for token exchange. (env: CONFIG_OAUTH2_PKCE) (default true)
+    	If true, Proof Key for Code Exchange (PKCE) RFC 7636 is used for token exchange. If oauth2.client.secret is provided and not empty string, PKCE will not be used, and the Client Credentials Grant flow will be used instead. (env: CONFIG_OAUTH2_PKCE) (default: true)
   --oauth2.provider string
     	oauth2 provider (env: CONFIG_OAUTH2_PROVIDER) (default "generic")
   --oauth2.refresh.enabled

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -60,7 +60,9 @@ var Defaults = Config{
 	},
 	OAuth2: OAuth2{
 		AuthStyle: OAuth2AuthStyle(oauth2.AuthStyleInParams),
-		Client:    OAuth2Client{},
+		Client: OAuth2Client{
+			Secret: "",
+		},
 		Endpoints: OAuth2Endpoints{
 			Auth:      &url.URL{Scheme: "", Host: ""},
 			Discovery: &url.URL{Scheme: "", Host: ""},

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -114,6 +114,7 @@ func TestValidate(t *testing.T) {
 				},
 				OAuth2: config.OAuth2{
 					Client: config.OAuth2Client{ID: "ID"},
+					PKCE:   false,
 				},
 			},
 			"oauth2.client.secret is required",

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -13,28 +13,16 @@ import (
 //
 //nolint:cyclop
 func Validate(mode int, conf Config) error {
-	for key, value := range map[string]string{
-		"oauth2.client.id": conf.OAuth2.Client.ID,
-	} {
-		if value == "" {
-			return fmt.Errorf("%s is %w", key, ErrRequired)
-		}
+	if conf.OAuth2.Client.ID == "" {
+		return fmt.Errorf("oauth2.client.id is %w", ErrRequired)
 	}
 
-	for key, value := range map[string]Secret{
-		"http.secret": conf.HTTP.Secret,
-	} {
-		if value.String() == "" {
-			return fmt.Errorf("%s is %w", key, ErrRequired)
-		}
+	if conf.HTTP.Secret.String() == "" {
+		return fmt.Errorf("http.secret is %w", ErrRequired)
 	}
 
-	for key, value := range map[string]Secret{
-		"oauth2.client.secret": conf.OAuth2.Client.Secret,
-	} {
-		if value.String() == "" && !conf.OAuth2.PKCE {
-			return fmt.Errorf("%s is %w", key, ErrRequired)
-		}
+	if conf.OAuth2.Client.Secret.String() == "" && !conf.OAuth2.PKCE {
+		return fmt.Errorf("oauth2.client.secret is %w", ErrRequired)
 	}
 
 	for key, value := range map[string]*url.URL{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -22,10 +22,17 @@ func Validate(mode int, conf Config) error {
 	}
 
 	for key, value := range map[string]Secret{
-		"http.secret":          conf.HTTP.Secret,
-		"oauth2.client.secret": conf.OAuth2.Client.Secret,
+		"http.secret": conf.HTTP.Secret,
 	} {
 		if value.String() == "" {
+			return fmt.Errorf("%s is %w", key, ErrRequired)
+		}
+	}
+
+	for key, value := range map[string]Secret{
+		"oauth2.client.secret": conf.OAuth2.Client.Secret,
+	} {
+		if value.String() == "" && !conf.OAuth2.PKCE {
 			return fmt.Errorf("%s is %w", key, ErrRequired)
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it

This PR makes oauth2.client.secret optional when oauth2.pkce is true.
The change is necessary because, to use the Authorization Code Flow with PKCE in the zitadel/oidc library, the client secret must be an empty string. If the client secret is provided, the library defaults to the Client Credentials Grant, making it impossible to use PKCE, even though it is enabled by default.
With the current implementation, PKCE cannot function as intended since oauth2.client.secret is mandatory and cannot be an empty string.

#### Special notes for your reviewer

I considered other approaches to address this issue:
- Ignoring the client secret if PKCE is enabled:
This approach could introduce a breaking change since the default configuration and sample configuration have PKCE enabled by default. Users upgrading to this version might be surprised that PKCE is now working correctly and that their flows no longer work as expected.
- The implemented approach (this PR):
Making the client secret optional when PKCE is enabled ensures backward compatibility and provides a safer user experience by not introducing unexpected behavior.

#### Particularly user-facing changes

Users can now leave oauth2.client.secret as an empty string in configurations when PKCE is enabled.
This allows for proper use of the Authorization Code Flow with PKCE without requiring additional configuration changes.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
