### PR TITLE
Fix typos in HTTPS Listener docs

### DIFF
--- a/docs/HTTPS Listener.md
+++ b/docs/HTTPS Listener.md
@@ -62,13 +62,13 @@ Alternatively, can use [acme.sh](https://acme.sh/), which is a pure Unix shell s
 
 openvpn-auth-oauth2 requires a [`SIGHUP` signal](https://en.wikipedia.org/wiki/SIGHUP) to reload the TLS certificate.
 
-## Signing certificates with certbot via dns-challange
+## Signing certificates with certbot via dns-challenge
 
-You need to install `certbot` and suitable for you `DNS plugin`. More information on supported by certbot DNS plugins and how to config them you may find [here](https://eff-certbot.readthedocs.io/en/stable/using.html#dns-plugins). It's up to you to define what ACME server to use for verification. By default it's set to letsencrypt, you may change it with `--server` [option](https://eff-certbot.readthedocs.io/en/stable/using.html#changing-the-acme-server). Also, take a look at [RFS 8555](https://datatracker.ietf.org/doc/html/rfc8555) about ACME Protocol.
+You need to install `certbot` and suitable for you `DNS plugin`. More information on supported by certbot DNS plugins and how to config them you may find [here](https://eff-certbot.readthedocs.io/en/stable/using.html#dns-plugins). It's up to you to define what ACME server to use for verification. By default it's set to letsencrypt, you may change it with `--server` [option](https://eff-certbot.readthedocs.io/en/stable/using.html#changing-the-acme-server). Also, take a look at [RFC 8555](https://datatracker.ietf.org/doc/html/rfc8555) about ACME Protocol.
 
 You can create certs with command below and than copy them to `/etc/openvpn-auth-oauth2/` directory or create a link to files. Do not forget to set right permissions.
 
-The command below utilize certbot to create an free ssl certificate for a domain hosted on cloudflare.
+The command below uses certbot to create a free SSL certificate for a domain hosted on cloudflare.
 
 ```bash
 certbot certonly --noninteractive --verbose \


### PR DESCRIPTION
## Summary
- fix typos in HTTPS Listener documentation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844139fee148321b63940c77adc29c1