### PR TITLE
Improve testutils documentation

### DIFF
--- a/internal/utils/testutils/logger.go
+++ b/internal/utils/testutils/logger.go
@@ -6,11 +6,14 @@ import (
 	"sync"
 )
 
+// Logger combines slog.Logger with a synchronized buffer used in tests.
 type Logger struct {
 	*slog.Logger
 	*SyncBuffer
 }
 
+// NewTestLogger returns a logger that stores all logs in memory so tests can
+// inspect them.
 func NewTestLogger() *Logger {
 	syncBuffer := new(SyncBuffer)
 	syncBuffer.buffer.Grow(16 << 20)
@@ -23,17 +26,18 @@ func NewTestLogger() *Logger {
 	}
 }
 
+// GetLogs returns the accumulated log output as a string.
 func (l Logger) GetLogs() string {
 	return l.String()
 }
 
+// SyncBuffer is a bytes.Buffer protected by a mutex for concurrent writes.
 type SyncBuffer struct {
 	buffer bytes.Buffer
 	mutex  sync.Mutex
 }
 
-// Write appends the contents of p to the buffer, growing the buffer as needed.
-// It returns the number of bytes written.
+// Write appends bytes to the buffer. It is safe for concurrent use.
 func (s *SyncBuffer) Write(p []byte) (int, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -41,9 +45,7 @@ func (s *SyncBuffer) Write(p []byte) (int, error) {
 	return s.buffer.Write(p) //nolint:wrapcheck
 }
 
-// String returns the contents of the unread portion of the buffer
-// as a string.
-// If the SyncBuffer is a nil pointer, it returns "<nil>".
+// String returns the buffered data as a string.
 func (s *SyncBuffer) String() string {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()

--- a/internal/utils/testutils/main.go
+++ b/internal/utils/testutils/main.go
@@ -40,6 +40,8 @@ const (
 	Secret   = "0123456789101112"
 )
 
+// ExpectVersionAndReleaseHold performs the initial handshake with the mocked
+// management interface. It checks for a version query and hold release.
 func ExpectVersionAndReleaseHold(tb testing.TB, conn net.Conn, reader *bufio.Reader) {
 	tb.Helper()
 
@@ -67,6 +69,7 @@ func ExpectVersionAndReleaseHold(tb testing.TB, conn net.Conn, reader *bufio.Rea
 	require.Equal(tb, 2, expectedCommand)
 }
 
+// SendMessagef sends a formatted string to the management interface connection.
 func SendMessagef(tb testing.TB, conn net.Conn, sendMessage string, args ...any) {
 	tb.Helper()
 
@@ -81,6 +84,8 @@ func SendMessagef(tb testing.TB, conn net.Conn, sendMessage string, args ...any)
 	require.NoError(tb, err)
 }
 
+// ExpectMessage reads from the connection and compares the output with the
+// expected message.
 func ExpectMessage(tb testing.TB, conn net.Conn, reader *bufio.Reader, expectMessage string) {
 	tb.Helper()
 
@@ -103,6 +108,7 @@ func ExpectMessage(tb testing.TB, conn net.Conn, reader *bufio.Reader, expectMes
 	}
 }
 
+// SendAndExpectMessage sends a message and immediately validates the response.
 func SendAndExpectMessage(tb testing.TB, conn net.Conn, reader *bufio.Reader, sendMessage, expectMessage string) {
 	tb.Helper()
 
@@ -110,6 +116,7 @@ func SendAndExpectMessage(tb testing.TB, conn net.Conn, reader *bufio.Reader, se
 	ExpectMessage(tb, conn, reader, expectMessage)
 }
 
+// ReadLine reads a single line from the connection with a timeout.
 func ReadLine(tb testing.TB, conn net.Conn, reader *bufio.Reader) string {
 	tb.Helper()
 
@@ -125,6 +132,7 @@ func ReadLine(tb testing.TB, conn net.Conn, reader *bufio.Reader) string {
 	return strings.TrimRightFunc(line, unicode.IsSpace)
 }
 
+// SetupResourceServer starts a minimal OIDC server used for integration tests.
 func SetupResourceServer(tb testing.TB, clientListener net.Listener, logger *slog.Logger) (*httptest.Server, types.URL, config.OAuth2Client, error) {
 	tb.Helper()
 
@@ -184,7 +192,9 @@ func SetupResourceServer(tb testing.TB, clientListener net.Listener, logger *slo
 	return resourceServer, resourceServerURL, config.OAuth2Client{ID: client.GetID(), Secret: "SECRET"}, nil
 }
 
-// SetupMockEnvironment setups an OpenVPN and IDP mock.
+// SetupMockEnvironment sets up an OpenVPN management interface and a mock OIDC
+// provider. It returns the adjusted configuration and helper instances used in
+// tests.
 func SetupMockEnvironment(ctx context.Context, tb testing.TB, conf config.Config, rt http.RoundTripper) (
 	config.Config, *openvpn.Client, net.Listener, *oauth2.Client, *httptest.Server, *http.Client, *Logger,
 ) {
@@ -269,6 +279,8 @@ func SetupMockEnvironment(ctx context.Context, tb testing.TB, conf config.Config
 	return conf, openvpnClient, managementInterface, oAuth2Client, httpClientListener, httpClientListenerClient, logger
 }
 
+// SetupOpenVPNOAuth2Clients creates mocked OpenVPN and OAuth2 clients using the
+// provided configuration.
 func SetupOpenVPNOAuth2Clients(
 	ctx context.Context, tb testing.TB, conf config.Config, logger *slog.Logger, httpClient *http.Client, tokenStorage tokenstorage.Storage,
 ) (*oauth2.Client, *openvpn.Client) {
@@ -313,6 +325,9 @@ func SetupOpenVPNOAuth2Clients(
 	return oAuth2Client, openVPNClient
 }
 
+// ConnectToManagementInterface establishes a connection to the given management
+// interface and returns the accepted net.Conn and an error channel for the
+// OpenVPN client.
 func ConnectToManagementInterface(tb testing.TB, managementInterface net.Listener, openVPNClient *openvpn.Client) (net.Conn, <-chan error, error) {
 	tb.Helper()
 

--- a/internal/utils/testutils/openvpn.go
+++ b/internal/utils/testutils/openvpn.go
@@ -6,12 +6,17 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/state"
 )
 
+// FakeOpenVPNClient implements the parts of the OpenVPN client interface used
+// in tests. It does not perform any actions.
 type FakeOpenVPNClient struct{}
 
+// NewFakeOpenVPNClient returns a FakeOpenVPNClient.
 func NewFakeOpenVPNClient() FakeOpenVPNClient {
 	return FakeOpenVPNClient{}
 }
 
+// AcceptClient is a no-op implementation of the real method.
 func (FakeOpenVPNClient) AcceptClient(_ *slog.Logger, _ state.ClientIdentifier, _ bool, _ string) {}
 
+// DenyClient is a no-op implementation of the real method.
 func (FakeOpenVPNClient) DenyClient(_ *slog.Logger, _ state.ClientIdentifier, _ string) {}

--- a/internal/utils/testutils/socket_unix.go
+++ b/internal/utils/testutils/socket_unix.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 )
 
+// GetGIDOfFile returns the numeric group ID of the given file.
 func GetGIDOfFile(fileName string) (int, error) {
 	stat, err := os.Stat(fileName)
 	if err != nil {
@@ -24,6 +25,8 @@ func GetGIDOfFile(fileName string) (int, error) {
 	return int(gid.Gid), nil
 }
 
+// GetPermissionsOfFile returns the permission bits of the given file as a
+// string, for example "drwxr-xr-x".
 func GetPermissionsOfFile(fileName string) (string, error) {
 	stat, err := os.Stat(fileName)
 	if err != nil {

--- a/internal/utils/testutils/socket_windows.go
+++ b/internal/utils/testutils/socket_windows.go
@@ -2,10 +2,13 @@
 
 package testutils
 
+// GetGIDOfFile returns 0 on Windows as the concept of GID is not used.
 func GetGIDOfFile(_ string) (int, error) {
 	return 0, nil
 }
 
+// GetPermissionsOfFile returns an empty string on Windows as file permission
+// bits are not represented in the same way as on Unix systems.
 func GetPermissionsOfFile(_ string) (string, error) {
 	return "", nil
 }

--- a/internal/utils/testutils/storage.go
+++ b/internal/utils/testutils/storage.go
@@ -1,23 +1,30 @@
 package testutils
 
+// FakeStorage is a no-op implementation of the token storage interface used in
+// tests.
 type FakeStorage struct{}
 
+// NewFakeStorage returns a new FakeStorage instance.
 func NewFakeStorage() *FakeStorage {
 	return &FakeStorage{}
 }
 
+// Get returns an empty token.
 func (FakeStorage) Get(_ string) (string, error) {
 	return "", nil
 }
 
+// Close is a no-op for FakeStorage.
 func (FakeStorage) Close() error {
 	return nil
 }
 
+// Delete is a no-op for FakeStorage.
 func (FakeStorage) Delete(_ string) error {
 	return nil
 }
 
+// Set is a no-op for FakeStorage.
 func (FakeStorage) Set(_, _ string) error {
 	return nil
 }


### PR DESCRIPTION
## Summary
- add missing comments for test helpers used in tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685448f04fec83218c0a68bd226ec493