### PR TITLE
Improve OAuth2 docs

### DIFF
--- a/internal/oauth2/providers/generic/main.go
+++ b/internal/oauth2/providers/generic/main.go
@@ -13,12 +13,16 @@ type Provider struct {
 	Conf config.Config
 }
 
+// NewProvider creates a new generic provider from the supplied configuration.
+// The http.Client argument is ignored because the provider uses the global
+// client from the oauth2 package.
 func NewProvider(_ context.Context, conf config.Config, _ *http.Client) (*Provider, error) {
 	return &Provider{
 		Conf: conf,
 	}, nil
 }
 
+// GetName returns the identifier of this provider implementation.
 func (p Provider) GetName() string {
 	return Name
 }

--- a/internal/oauth2/providers/github/main.go
+++ b/internal/oauth2/providers/github/main.go
@@ -16,6 +16,8 @@ type Provider struct {
 	httpClient *http.Client
 }
 
+// NewProvider returns a GitHub provider configured with the given settings.
+// It wraps the generic provider and adds the HTTP client for API lookups.
 func NewProvider(ctx context.Context, conf config.Config, httpClient *http.Client) (Provider, error) {
 	provider, err := generic.NewProvider(ctx, conf, httpClient)
 	if err != nil {
@@ -28,6 +30,7 @@ func NewProvider(ctx context.Context, conf config.Config, httpClient *http.Clien
 	}, nil
 }
 
+// GetName returns the provider name.
 func (p Provider) GetName() string {
 	return Name
 }

--- a/internal/oauth2/providers/google/main.go
+++ b/internal/oauth2/providers/google/main.go
@@ -16,6 +16,8 @@ type Provider struct {
 	httpClient *http.Client
 }
 
+// NewProvider instantiates the Google provider using the generic implementation
+// as a base. It wires in the HTTP client for REST API calls.
 func NewProvider(ctx context.Context, conf config.Config, httpClient *http.Client) (*Provider, error) {
 	provider, err := generic.NewProvider(ctx, conf, httpClient)
 	if err != nil {
@@ -28,6 +30,7 @@ func NewProvider(ctx context.Context, conf config.Config, httpClient *http.Clien
 	}, nil
 }
 
+// GetName returns the provider name used in configuration and logging.
 func (p Provider) GetName() string {
 	return Name
 }

--- a/internal/oauth2/utils.go
+++ b/internal/oauth2/utils.go
@@ -68,6 +68,9 @@ func (c Client) getNonce(id string) string {
 	return hex.EncodeToString(nonce.Sum(nil))
 }
 
+// OAuthConfig returns the underlying [oauth2.Config] used by the relying party.
+// It is primarily exposed for tests that need direct access to the client
+// configuration.
 func (c Client) OAuthConfig() *oauth2.Config {
 	return c.relyingParty.OAuthConfig()
 }


### PR DESCRIPTION
## Summary
- document OAuthConfig helper
- document provider constructors and GetName methods

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685448ee11f08321b1bee0b639bb3034