### PR TITLE
Add comments for http server methods

### DIFF
--- a/cmd/daemon/full_test.go
+++ b/cmd/daemon/full_test.go
@@ -197,9 +197,7 @@ func TestFull(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 
-			var (
-				resp *http.Response
-			)
+			var resp *http.Response
 
 			go func() {
 				defer wg.Done()

--- a/cmd/daemon/reload_test.go
+++ b/cmd/daemon/reload_test.go
@@ -149,9 +149,7 @@ func TestReload(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	var (
-		resp *http.Response
-	)
+	var resp *http.Response
 
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
## Summary
- document exported methods in `internal/httpserver/main.go`
- run `make fmt` which updated a couple test files

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685448e6217c83218e1295efdc569d4c