### PR TITLE
feat: Add Authentik provider

### DIFF
--- a/cmd/daemon/root.go
+++ b/cmd/daemon/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/httphandler"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/httpserver"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/authentik"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/generic"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/github"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/google"
@@ -169,6 +170,8 @@ func setupOpenVPNClient(
 	var provider oauth2.Provider
 
 	switch conf.OAuth2.Provider {
+	case authentik.Name:
+		provider, err = authentik.NewProvider(ctx, conf, httpClient)
 	case generic.Name:
 		provider, err = generic.NewProvider(ctx, conf, httpClient)
 	case github.Name:

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -40,7 +40,6 @@ References:
 CONFIG_OAUTH2_ISSUER=https://login.microsoftonline.com/$TENANT_ID/v2.0
 CONFIG_OAUTH2_CLIENT_ID=<client_id>
 CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
-# The scopes openid profile are required, but configured by default.
 # offline_access is required for non-interactive session refresh.
 # CONFIG_OAUTH2_SCOPES=openid profile offline_access
 ```
@@ -202,7 +201,6 @@ Set the following variables in your `openvpn-auth-oauth2` configuration file:
 CONFIG_OAUTH2_ISSUER=https://<keycloak-domain>/auth/realms/<realm-name>
 CONFIG_OAUTH2_CLIENT_ID=<client_id>
 CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
-# The scopes openid profile are required, but configured by default.
 # offline_access is required for non-interactive session refresh.
 # CONFIG_OAUTH2_SCOPES=openid profile offline_access
 ```
@@ -454,6 +452,71 @@ oauth2:
   #  - "openid"
   #  - "profile"
   #  - "email"
+  #  - "offline_access"
+```
+</td></tr></tbody>
+</table>
+
+</details>
+
+## Authentik
+
+<details>
+<summary>Expand</summary>
+
+### Register an application in Authentik
+
+1. Sign in to your Authentik admin interface
+2. Navigate to **Applications** → **Providers**
+3. Click **Create** and select **OAuth2/OpenID Provider**
+4. Configure the provider:
+   - **Name**: `openvpn-auth-oauth2`
+   - **Client Type**: `confidential`
+   - **Redirect URIs**: `https://openvpn-auth-oauth2.example.com/oauth2/callback`
+   - **Signing Key**: Select an appropriate certificate
+   - **Subject Mode**: Based on the User's hashed ID
+   - **Issuer Mode**: Each provider has a different issuer, based on the application slug
+5. Under **Advanced protocol settings**, add `offline_access` to the **Scopes** list (defaults are typically email, openid, and profile). This is only needed if you intend to use [non-interactive session refresh](Non-interactive%20session%20refresh.md)
+6. Save and note the **Client ID** and **Client Secret**
+7. Create an Application:
+   - Navigate to **Applications** → **Applications**
+   - Click **Create**
+   - **Name**: `OpenVPN OAuth2`
+   - **Slug**: `openvpn-oauth2`
+   - **Provider**: Select the provider created above
+8. Configure group/user access as needed in the **Policy Bindings** tab
+
+### Configuration
+
+<table>
+<thead><tr><td>env/sysconfig configuration</td></tr></thead>
+<tbody><tr><td>
+
+```ini
+CONFIG_OAUTH2_PROVIDER=authentik
+CONFIG_OAUTH2_ISSUER=https://auth.example.com/application/o/openvpn-oauth2/
+CONFIG_OAUTH2_CLIENT_ID=<client_id>
+CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
+# The scopes openid profile are required, but configured by default.
+# offline_access is required for non-interactive session refresh.
+#CONFIG_OAUTH2_SCOPES=openid profile offline_access
+```
+</td></tr></tbody>
+<thead><tr><td>yaml configuration</td></tr></thead>
+<tbody><tr><td>
+
+```yaml
+oauth2:
+  provider: "authentik"
+  issuer: "https://auth.example.com/application/o/openvpn-oauth2/"
+  client:
+    id: "<client_id>"
+    secret: "<client_secret>"
+  # The scopes openid profile are required, but configured by default.
+  # offline_access is required for non-interactive session refresh.
+  #scopes:
+  #  - "openid"
+  #  - "profile"
   #  - "offline_access"
 ```
 </td></tr></tbody>

--- a/internal/oauth2/provider_test.go
+++ b/internal/oauth2/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/authentik"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/generic"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/github"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/google"
@@ -144,6 +145,8 @@ func TestNewProvider(t *testing.T) {
 			)
 
 			switch tc.conf.OAuth2.Provider {
+			case authentik.Name:
+				provider, err = authentik.NewProvider(ctx, tc.conf, http.DefaultClient)
 			case generic.Name:
 				provider, err = generic.NewProvider(ctx, tc.conf, http.DefaultClient)
 			case github.Name:

--- a/internal/oauth2/providers/authentik/check.go
+++ b/internal/oauth2/providers/authentik/check.go
@@ -1,0 +1,14 @@
+package authentik
+
+import (
+	"context"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/idtoken"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/state"
+)
+
+// CheckUser implements the [github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2.Provider] interface.
+func (p Provider) CheckUser(ctx context.Context, session state.State, user types.UserInfo, tokens idtoken.IDToken) error {
+	return p.Provider.CheckUser(ctx, session, user, tokens)
+}

--- a/internal/oauth2/providers/authentik/check_test.go
+++ b/internal/oauth2/providers/authentik/check_test.go
@@ -1,0 +1,29 @@
+package authentik_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/authentik"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_GetName(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Config{
+		OAuth2: config.OAuth2{
+			Issuer: types.URL{URL: &url.URL{Scheme: "https", Host: "auth.example.com"}},
+		},
+	}
+
+	provider, err := authentik.NewProvider(context.Background(), conf, http.DefaultClient)
+	require.NoError(t, err)
+
+	assert.Equal(t, "authentik", provider.GetName())
+}

--- a/internal/oauth2/providers/authentik/config.go
+++ b/internal/oauth2/providers/authentik/config.go
@@ -1,0 +1,10 @@
+package authentik
+
+import (
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/types"
+)
+
+// GetProviderConfig implements the [github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2.Provider] interface.
+func (p Provider) GetProviderConfig() (types.ProviderConfig, error) {
+	return p.Provider.GetProviderConfig()
+}

--- a/internal/oauth2/providers/authentik/main.go
+++ b/internal/oauth2/providers/authentik/main.go
@@ -1,0 +1,34 @@
+package authentik
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/generic"
+)
+
+const Name = "authentik"
+
+type Provider struct {
+	*generic.Provider
+}
+
+// NewProvider instantiates the Authentik provider using the generic implementation
+// as a base.
+func NewProvider(ctx context.Context, conf config.Config, client *http.Client) (*Provider, error) {
+	provider, err := generic.NewProvider(ctx, conf, client)
+	if err != nil {
+		return nil, fmt.Errorf("error creating generic provider: %w", err)
+	}
+
+	return &Provider{
+		Provider: provider,
+	}, nil
+}
+
+// GetName returns the provider name used in configuration and logging.
+func (p Provider) GetName() string {
+	return Name
+}

--- a/internal/oauth2/providers/authentik/oidc.go
+++ b/internal/oauth2/providers/authentik/oidc.go
@@ -1,0 +1,37 @@
+package authentik
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/idtoken"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/types"
+	"github.com/zitadel/logging"
+	"github.com/zitadel/oidc/v3/pkg/client/rp"
+)
+
+// GetRefreshToken returns the refresh token from the provided tokens.
+func (p Provider) GetRefreshToken(tokens idtoken.IDToken) (string, error) {
+	return p.Provider.GetRefreshToken(tokens)
+}
+
+// Refresh initiates a non-interactive authentication against the Authentik OIDC provider.
+func (p Provider) Refresh(ctx context.Context, logger *slog.Logger, relyingParty rp.RelyingParty, refreshToken string) (idtoken.IDToken, error) {
+	ctx = logging.ToContext(ctx, logger)
+
+	// Clear nonce for refresh requests
+	ctx = context.WithValue(ctx, types.CtxNonce{}, "")
+
+	tokens, err := rp.RefreshTokens[*idtoken.Claims](ctx, relyingParty, refreshToken, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("error from token exchange via refresh token: %w", err)
+	}
+
+	return tokens, nil
+}
+
+// RevokeRefreshToken revokes the given refresh token.
+func (p Provider) RevokeRefreshToken(ctx context.Context, logger *slog.Logger, relyingParty rp.RelyingParty, refreshToken string) error {
+	return p.Provider.RevokeRefreshToken(ctx, logger, relyingParty, refreshToken)
+}

--- a/internal/oauth2/providers/authentik/user.go
+++ b/internal/oauth2/providers/authentik/user.go
@@ -1,0 +1,14 @@
+package authentik
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/idtoken"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/types"
+)
+
+// GetUser implements the [github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2.Provider] interface.
+func (p Provider) GetUser(ctx context.Context, logger *slog.Logger, tokens idtoken.IDToken, userinfo *types.UserInfo) (types.UserInfo, error) {
+	return p.Provider.GetUser(ctx, logger, tokens, userinfo)
+}

--- a/internal/utils/testutils/main.go
+++ b/internal/utils/testutils/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/httphandler"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/authentik"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/generic"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/github"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2/providers/google"
@@ -346,6 +347,8 @@ func SetupOpenVPNOAuth2Clients(
 	}
 
 	switch conf.OAuth2.Provider {
+	case authentik.Name:
+		provider, err = authentik.NewProvider(ctx, conf, httpClient)
 	case generic.Name:
 		provider, err = generic.NewProvider(ctx, conf, httpClient)
 	case github.Name:


### PR DESCRIPTION
#### What this PR does / why we need it
Adds a new Authentik provider to fix refresh token compatibility issues. I am running openvpn-auth-oauth2 on pfSense 2.8.0 with Authentik as my OIDC provider, and was experiencing "invalid_grant" errors during non-interactive session refresh. After finding your open issue on the zitadel/oidc repo (https://github.com/zitadel/oidc/issues/509), I decided to create a simple provider which avoids the retry logic by clearing the nonce upfront for refresh requests.

#### Which issue this PR fixes
None.

#### Special notes for your reviewer
This provider is minimal - it only overrides the `Refresh()` method to clear the nonce before making the request, preventing duplicate refresh token usage that fails with Authentik's token rotation. All other functionality uses the generic provider.

#### Particularly user-facing changes
- New `authentik` provider option available in configuration
- Users experiencing refresh token issues with Authentik can now use `provider: authentik` instead of workarounds like `nonce: false`
- Updated documentation with Authentik setup instructions

#### Checklist
Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

**Tested configuration:**
```yaml
oauth2:
  provider: authentik
  client:
    id: "my-client-id"
    secret: "file:///usr/local/etc/openvpn-auth-oauth2/client-secret.txt"
  issuer: "https://auth.mydomain.com/application/o/ovpn-oauth2/"
  groups-claim: "groups"
  user-info: true
  validate:
    common-name: "preferred_username"
    common-name-case-sensitive: false
    groups: "OpenVPN Users"
    ipaddr: false
    issuer: true
  nonce: true
  pkce: true
  refresh:
    enabled: true
    expires: 8h0m0s
    secret: "file:///usr/local/etc/openvpn-auth-oauth2/refresh-secret.txt"
    use-session-id: true
    validate-user: true
```