### PR TITLE
config: openvpn.bypass.common-names accepts regular expressions now

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -117,7 +117,7 @@ Usage of openvpn-auth-oauth2:
   --openvpn.auth-token-user
     	Override the username of a session with the username from the token by using auth-token-user, if the client username is empty (env: CONFIG_OPENVPN_AUTH__TOKEN__USER) (default true)
   --openvpn.bypass.common-names value
-    	Skip OAuth authentication for client certificate common names (CNs) matching any of the given regular expressions. Multiple expressions can be provided as a comma-separated list. Note: regular expressions are used, so for example "client" will also match "client2". (env: CONFIG_OPENVPN_BYPASS_COMMON__NAMES)
+    	Skip OAuth authentication for client certificate common names (CNs) matching any of the given regular expressions. Multiple expressions can be provided as a comma-separated list. Regular expressions are automatically anchored (^…$) by default, so "client" matches only "client". To allow partial matches, specify explicitly (e.g. "client.*"). (env: CONFIG_OPENVPN_BYPASS_COMMON__NAMES)
   --openvpn.client-config.enabled
     	If true, openvpn-auth-oauth2 will read the CCD directory for additional configuration. This function mimic the client-config-dir directive in OpenVPN. (env: CONFIG_OPENVPN_CLIENT__CONFIG_ENABLED)
   --openvpn.client-config.path value

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -117,7 +117,7 @@ Usage of openvpn-auth-oauth2:
   --openvpn.auth-token-user
     	Override the username of a session with the username from the token by using auth-token-user, if the client username is empty (env: CONFIG_OPENVPN_AUTH__TOKEN__USER) (default true)
   --openvpn.bypass.common-names value
-    	bypass oauth authentication for CNs. Comma separated list. (env: CONFIG_OPENVPN_BYPASS_COMMON__NAMES)
+    	Skip OAuth authentication for client certificate common names (CNs) matching any of the given regular expressions. Multiple expressions can be provided as a comma-separated list. Note: regular expressions are used, so for example "client" will also match "client2". (env: CONFIG_OPENVPN_BYPASS_COMMON__NAMES)
   --openvpn.client-config.enabled
     	If true, openvpn-auth-oauth2 will read the CCD directory for additional configuration. This function mimic the client-config-dir directive in OpenVPN. (env: CONFIG_OPENVPN_CLIENT__CONFIG_ENABLED)
   --openvpn.client-config.path value

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"regexp"
 	"slices"
 	"testing"
 	"time"
@@ -177,7 +178,7 @@ http:
 						OmitHost: false,
 					}},
 					Bypass: config.OpenVPNBypass{
-						CommonNames: []string{"test", "test2"},
+						CommonNames: types.RegexpSlice{regexp.MustCompile(`^test$`), regexp.MustCompile(`^test2$`)},
 					},
 					ClientConfig: config.OpenVPNConfig{
 						Enabled:    true,
@@ -322,7 +323,7 @@ func TestConfigFlagSet(t *testing.T) {
 			[]string{"--openvpn.bypass.common-names=a,b"},
 			func() config.Config {
 				conf := config.Defaults
-				conf.OpenVPN.Bypass.CommonNames = []string{"a", "b"}
+				conf.OpenVPN.Bypass.CommonNames = types.RegexpSlice{regexp.MustCompile("a"), regexp.MustCompile("a")}
 
 				return conf
 			}(),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
+//goland:noinspection RegExpUnnecessaryNonCapturingGroup
 func TestConfig(t *testing.T) {
 	t.Parallel()
 
@@ -178,7 +179,7 @@ http:
 						OmitHost: false,
 					}},
 					Bypass: config.OpenVPNBypass{
-						CommonNames: types.RegexpSlice{regexp.MustCompile(`^test$`), regexp.MustCompile(`^test2$`)},
+						CommonNames: types.RegexpSlice{regexp.MustCompile(`^(?:test)$`), regexp.MustCompile(`^(?:test2)$`)},
 					},
 					ClientConfig: config.OpenVPNConfig{
 						Enabled:    true,
@@ -323,7 +324,8 @@ func TestConfigFlagSet(t *testing.T) {
 			[]string{"--openvpn.bypass.common-names=a,b"},
 			func() config.Config {
 				conf := config.Defaults
-				conf.OpenVPN.Bypass.CommonNames = types.RegexpSlice{regexp.MustCompile("a"), regexp.MustCompile("a")}
+				//goland:noinspection RegExpUnnecessaryNonCapturingGroup
+				conf.OpenVPN.Bypass.CommonNames = types.RegexpSlice{regexp.MustCompile("^(?:a)$"), regexp.MustCompile("^(?:b)$")}
 
 				return conf
 			}(),

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -58,7 +58,7 @@ var Defaults = Config{
 		},
 		OverrideUsername: false,
 		Bypass: OpenVPNBypass{
-			CommonNames: make([]string, 0),
+			CommonNames: types.RegexpSlice{},
 		},
 		Passthrough: OpenVPNPassthrough{
 			Enabled: false,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -138,9 +138,10 @@ func (c *Config) flagSetOpenVPN(flagSet *flag.FlagSet) {
 		&c.OpenVPN.Bypass.CommonNames,
 		"openvpn.bypass.common-names",
 		lookupEnvOrDefault("openvpn.bypass.common-names", c.OpenVPN.Bypass.CommonNames),
-		`Skip OAuth authentication for client certificate common names (CNs) matching any of the given regular expressions.
-Multiple expressions can be provided as a comma-separated list.
-Note: regular expressions are used, so for example "client" will also match "client2".`,
+		"Skip OAuth authentication for client certificate common names (CNs) matching any of the given regular expressions. "+
+			"Multiple expressions can be provided as a comma-separated list. "+
+			"Regular expressions are automatically anchored (^…$) by default, so \"client\" matches only \"client\". "+
+			"To allow partial matches, specify explicitly (e.g. \"client.*\").",
 	)
 	flagSet.BoolVar(
 		&c.OpenVPN.ClientConfig.Enabled,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -138,7 +138,9 @@ func (c *Config) flagSetOpenVPN(flagSet *flag.FlagSet) {
 		&c.OpenVPN.Bypass.CommonNames,
 		"openvpn.bypass.common-names",
 		lookupEnvOrDefault("openvpn.bypass.common-names", c.OpenVPN.Bypass.CommonNames),
-		"bypass oauth authentication for CNs. Comma separated list.",
+		`Skip OAuth authentication for client certificate common names (CNs) matching any of the given regular expressions.
+Multiple expressions can be provided as a comma-separated list.
+Note: regular expressions are used, so for example "client" will also match "client2".`,
 	)
 	flagSet.BoolVar(
 		&c.OpenVPN.ClientConfig.Enabled,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -64,7 +64,7 @@ type OpenVPN struct {
 }
 
 type OpenVPNBypass struct {
-	CommonNames types.StringSlice `json:"common-names" yaml:"common-names"`
+	CommonNames types.RegexpSlice `json:"common-names" yaml:"common-names"`
 }
 type OpenVPNConfig struct {
 	Path       types.FS `json:"path"        yaml:"path"`

--- a/internal/config/types/slice.go
+++ b/internal/config/types/slice.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
 	"strings"
 )
 
@@ -40,6 +41,71 @@ func (s *StringSlice) UnmarshalJSON(jsonBytes []byte) error {
 	err := json.NewDecoder(bytes.NewReader(jsonBytes)).Decode(&slice)
 
 	*s = slice
+
+	//nolint:wrapcheck
+	return err
+}
+
+type RegexpSlice []*regexp.Regexp
+
+// String returns the string representation of the [RegexpSlice].
+//
+//goland:noinspection GoMixedReceiverTypes
+func (s RegexpSlice) String() string {
+	stringList := make([]string, 0, len(s))
+	for _, r := range s {
+		stringList = append(stringList, r.String())
+	}
+
+	return strings.Join(stringList, ",")
+}
+
+// MarshalText implements [encoding.TextMarshaler] interface.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (s RegexpSlice) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (s *RegexpSlice) UnmarshalText(text []byte) error {
+	stringList := strings.Split(string(text), ",")
+	regexList := make([]*regexp.Regexp, 0, len(stringList))
+	for _, str := range stringList {
+		r, err := regexp.Compile(str)
+		if err != nil {
+			return err
+		}
+
+		regexList = append(regexList, r)
+	}
+
+	*s = regexList
+
+	return nil
+}
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (s *RegexpSlice) UnmarshalJSON(jsonBytes []byte) error {
+	var stringList []string
+
+	err := json.NewDecoder(bytes.NewReader(jsonBytes)).Decode(&stringList)
+
+	regexList := make([]*regexp.Regexp, 0, len(stringList))
+	for _, str := range stringList {
+		r, err := regexp.Compile(str)
+		if err != nil {
+			return err
+		}
+
+		regexList = append(regexList, r)
+	}
+
+	*s = regexList
 
 	//nolint:wrapcheck
 	return err

--- a/internal/config/types/slice.go
+++ b/internal/config/types/slice.go
@@ -94,7 +94,6 @@ func (s RegexpSlice) MarshalText() ([]byte, error) {
 //
 //goland:noinspection GoMixedReceiverTypes
 func (s *RegexpSlice) UnmarshalText(text []byte) error {
-	//nolint:wrapcheck
 	return s.fromSlice(strings.Split(string(text), ","))
 }
 
@@ -132,13 +131,13 @@ func (s *RegexpSlice) UnmarshalYAML(data *yaml.Node) error {
 func (s *RegexpSlice) fromSlice(stringList []string) error {
 	regexList := make(RegexpSlice, 0, len(stringList))
 	for _, str := range stringList {
-		r, err := regexp.Compile(fmt.Sprintf("^(?:%s)$", str))
+		regexPattern, err := regexp.Compile(fmt.Sprintf("^(?:%s)$", str))
 		if err != nil {
 			//nolint:wrapcheck
 			return err
 		}
 
-		regexList = append(regexList, r)
+		regexList = append(regexList, regexPattern)
 	}
 
 	*s = regexList

--- a/internal/config/types/slice_test.go
+++ b/internal/config/types/slice_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -49,4 +50,48 @@ func TestSliceUnmarshalYAML(t *testing.T) {
 	require.NoError(t, yaml.NewDecoder(strings.NewReader("- a\n- b\n- c\n- d\n")).Decode(&slice))
 
 	assert.Equal(t, types.StringSlice{"a", "b", "c", "d"}, slice)
+}
+
+func TestRegexpSliceUnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	slice := types.RegexpSlice{}
+
+	require.NoError(t, slice.UnmarshalText([]byte("a,b,c,d")))
+
+	assert.Equal(t, types.RegexpSlice{regexp.MustCompile("a"), regexp.MustCompile("b"), regexp.MustCompile("c"), regexp.MustCompile("d")}, slice)
+}
+
+func TestRegexpSliceUnmarshalTextError(t *testing.T) {
+	t.Parallel()
+
+	slice := types.RegexpSlice{}
+
+	require.EqualError(t, slice.UnmarshalText([]byte("^(a,b,c,d")), "error parsing regexp: missing closing ): `^(a`")
+}
+
+func TestRegexpSliceMarshalText(t *testing.T) {
+	t.Parallel()
+
+	slice, err := types.RegexpSlice{regexp.MustCompile("a"), regexp.MustCompile("b"), regexp.MustCompile("c"), regexp.MustCompile("d")}.MarshalText()
+
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("a,b,c,d"), slice)
+}
+
+func TestRegexpSliceUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	slice := types.RegexpSlice{}
+
+	require.EqualError(t, json.NewDecoder(strings.NewReader(`["^(a","b","c","d"]`)).Decode(&slice), "error parsing regexp: missing closing ): `^(a`")
+}
+
+func TestRegexpSliceUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	slice := types.RegexpSlice{}
+
+	require.EqualError(t, yaml.NewDecoder(strings.NewReader("- \"^(a\"\n- b\n- c\n- d\n")).Decode(&slice), "error parsing regexp: missing closing ): `^(a`")
 }

--- a/internal/config/types/slice_test.go
+++ b/internal/config/types/slice_test.go
@@ -59,7 +59,8 @@ func TestRegexpSliceUnmarshalText(t *testing.T) {
 
 	require.NoError(t, slice.UnmarshalText([]byte("a,b,c,d")))
 
-	assert.Equal(t, types.RegexpSlice{regexp.MustCompile("a"), regexp.MustCompile("b"), regexp.MustCompile("c"), regexp.MustCompile("d")}, slice)
+	//goland:noinspection RegExpUnnecessaryNonCapturingGroup
+	assert.Equal(t, types.RegexpSlice{regexp.MustCompile("^(?:a)$"), regexp.MustCompile("^(?:b)$"), regexp.MustCompile("^(?:c)$"), regexp.MustCompile("^(?:d)$")}, slice)
 }
 
 func TestRegexpSliceUnmarshalTextError(t *testing.T) {
@@ -67,7 +68,7 @@ func TestRegexpSliceUnmarshalTextError(t *testing.T) {
 
 	slice := types.RegexpSlice{}
 
-	require.EqualError(t, slice.UnmarshalText([]byte("^(a,b,c,d")), "error parsing regexp: missing closing ): `^(a`")
+	require.EqualError(t, slice.UnmarshalText([]byte("^(a,b,c,d")), "error parsing regexp: missing closing ): `^(?:^(a)$`")
 }
 
 func TestRegexpSliceMarshalText(t *testing.T) {
@@ -85,7 +86,7 @@ func TestRegexpSliceUnmarshalJSON(t *testing.T) {
 
 	slice := types.RegexpSlice{}
 
-	require.EqualError(t, json.NewDecoder(strings.NewReader(`["^(a","b","c","d"]`)).Decode(&slice), "error parsing regexp: missing closing ): `^(a`")
+	require.EqualError(t, json.NewDecoder(strings.NewReader(`["^(a","b","c","d"]`)).Decode(&slice), "error parsing regexp: missing closing ): `^(?:^(a)$`")
 }
 
 func TestRegexpSliceUnmarshalYAML(t *testing.T) {
@@ -93,5 +94,5 @@ func TestRegexpSliceUnmarshalYAML(t *testing.T) {
 
 	slice := types.RegexpSlice{}
 
-	require.EqualError(t, yaml.NewDecoder(strings.NewReader("- \"^(a\"\n- b\n- c\n- d\n")).Decode(&slice), "error parsing regexp: missing closing ): `^(a`")
+	require.EqualError(t, yaml.NewDecoder(strings.NewReader("- \"^(a\"\n- b\n- c\n- d\n")).Decode(&slice), "error parsing regexp: missing closing ): `^(?:^(a)$`")
 }

--- a/internal/oauth2/handler_test.go
+++ b/internal/oauth2/handler_test.go
@@ -44,7 +44,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -68,7 +68,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -95,7 +95,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.IPAddr = false
 				conf.OAuth2.Nonce = true
 				conf.OAuth2.PKCE = true
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -123,7 +123,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -148,7 +148,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
 				conf.OAuth2.UserInfo = true
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -173,7 +173,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
 				conf.OAuth2.UserInfo = true
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -198,7 +198,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
 				conf.OAuth2.UserInfo = true
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -222,7 +222,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -247,7 +247,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -272,7 +272,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -297,7 +297,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -322,7 +322,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 				conf.OpenVPN.ClientConfig.Enabled = true
 				conf.OpenVPN.ClientConfig.Path = types.FS{
@@ -355,7 +355,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 				conf.OpenVPN.ClientConfig.Enabled = true
 				conf.OpenVPN.ClientConfig.Path = types.FS{
@@ -384,7 +384,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf
@@ -409,7 +409,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Roles = make([]string, 0)
 				conf.OAuth2.Validate.Issuer = true
 				conf.OAuth2.Validate.IPAddr = false
-				conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
 
 				return conf

--- a/internal/openvpn/bench_test.go
+++ b/internal/openvpn/bench_test.go
@@ -38,7 +38,7 @@ func BenchmarkOpenVPNHandler(b *testing.B) {
 	conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 	conf.HTTP.Secret = testutils.Secret
 	conf.OpenVPN.Addr = types.URL{URL: &url.URL{Scheme: managementInterface.Addr().Network(), Host: managementInterface.Addr().String()}}
-	conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make([]string, 0)}
+	conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 
 	tokenStorage := tokenstorage.NewInMemory(testutils.Secret, time.Hour)
 	_, openVPNClient := testutils.SetupOpenVPNOAuth2Clients(ctx, b, conf, slog.New(slog.DiscardHandler), http.DefaultClient, tokenStorage)

--- a/internal/openvpn/main_test.go
+++ b/internal/openvpn/main_test.go
@@ -38,7 +38,7 @@ func TestClientInvalidServer(t *testing.T) {
 		},
 		OpenVPN: config.OpenVPN{
 			Addr:   types.URL{URL: &url.URL{Scheme: "tcp", Host: "127.0.0.1:1"}},
-			Bypass: config.OpenVPNBypass{CommonNames: make([]string, 0)},
+			Bypass: config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)},
 		},
 	}
 
@@ -67,7 +67,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make([]string, 0)}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 				conf.OAuth2.Validate.IPAddr = true
 
 				return conf
@@ -82,7 +82,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make([]string, 0)}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 				conf.OpenVPN.Password = testutils.Password
 				conf.OAuth2.Validate.IPAddr = true
 
@@ -99,7 +99,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = "username"
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make([]string, 0)}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 				conf.OAuth2.Validate.IPAddr = true
 
 				return conf
@@ -114,7 +114,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = "012345678910111"
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make([]string, 0)}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -130,7 +130,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make([]string, 0)}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -146,7 +146,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost", Path: strings.Repeat("a", 255)}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make([]string, 0)}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -162,7 +162,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: []string{"bypass"}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 				conf.OpenVPN.AuthTokenUser = false
 
@@ -179,7 +179,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: []string{"bypass"}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 				conf.OpenVPN.AuthTokenUser = false
 
@@ -196,7 +196,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: []string{"bypass"}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -212,7 +212,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: []string{"bypass"}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -228,7 +228,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: []string{"bypass"}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -245,7 +245,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: []string{"bypass"}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -366,7 +366,7 @@ func TestClientInvalidPassword(t *testing.T) {
 		},
 		OpenVPN: config.OpenVPN{
 			Addr:     types.URL{URL: &url.URL{Scheme: managementInterface.Addr().Network(), Host: managementInterface.Addr().String()}},
-			Bypass:   config.OpenVPNBypass{CommonNames: make([]string, 0)},
+			Bypass:   config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)},
 			Password: "invalid",
 		},
 	}
@@ -436,7 +436,7 @@ func TestClientInvalidVersion(t *testing.T) {
 			conf := config.Defaults
 			conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 			conf.HTTP.Secret = testutils.Secret
-			conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: []string{"bypass"}}
+			conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 			conf.OpenVPN.Addr = types.URL{URL: &url.URL{Scheme: managementInterface.Addr().Network(), Host: managementInterface.Addr().String()}}
 
 			tokenStorage := tokenstorage.NewInMemory(testutils.Secret, time.Hour)
@@ -478,7 +478,7 @@ func TestHoldRelease(t *testing.T) {
 			Secret:  testutils.Secret,
 		},
 		OpenVPN: config.OpenVPN{
-			Bypass: config.OpenVPNBypass{CommonNames: make([]string, 0)},
+			Bypass: config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)},
 		},
 	}
 
@@ -532,7 +532,7 @@ func TestCommandTimeout(t *testing.T) {
 			Secret:  testutils.Secret,
 		},
 		OpenVPN: config.OpenVPN{
-			Bypass:         config.OpenVPNBypass{CommonNames: make([]string, 0)},
+			Bypass:         config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)},
 			CommandTimeout: time.Millisecond * 300,
 		},
 	}
@@ -603,7 +603,7 @@ func TestDeadLocks(t *testing.T) {
 			conf := config.Defaults
 			conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 			conf.HTTP.Secret = testutils.Secret
-			conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make([]string, 0)}
+			conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 
 			managementInterface, err := nettest.NewLocalListener("tcp")
 			require.NoError(t, err)
@@ -669,7 +669,7 @@ func TestInvalidCommandResponses(t *testing.T) {
 					Secret:  testutils.Secret,
 				},
 				OpenVPN: config.OpenVPN{
-					Bypass: config.OpenVPNBypass{CommonNames: make([]string, 0)},
+					Bypass: config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)},
 				},
 			}
 

--- a/internal/openvpn/main_test.go
+++ b/internal/openvpn/main_test.go
@@ -173,21 +173,20 @@ func TestClientFull(t *testing.T) {
 			nil,
 		},
 		{
-			"client password mask",
-			func() config.Config {
+			name: "client password mask",
+			conf: func() config.Config {
 				conf := config.Defaults
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 				conf.OpenVPN.AuthTokenUser = false
 
 				return conf
 			}(),
-			">CLIENT:CONNECT,0,1\r\n>CLIENT:ENV,common_name=bypass\r\nCLIENT:ENV,password=important value\n>CLIENT:ENV,END\r\n",
-			"client-auth-nt 0 1",
-			nil,
+			client: ">CLIENT:CONNECT,0,1\r\n>CLIENT:ENV,common_name=bypass\r\nCLIENT:ENV,password=important value\n>CLIENT:ENV,END\r\n",
+			expect: "client-auth-nt 0 1",
 		},
 		{
 			"client established",
@@ -196,7 +195,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -212,7 +211,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -228,7 +227,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -245,7 +244,7 @@ func TestClientFull(t *testing.T) {
 				conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.HTTP.Secret = testutils.Secret
 				conf.OpenVPN.CommonName.EnvironmentVariableName = config.CommonName
-				conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
+				conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 				conf.OpenVPN.Password = testutils.Password
 
 				return conf
@@ -436,7 +435,7 @@ func TestClientInvalidVersion(t *testing.T) {
 			conf := config.Defaults
 			conf.HTTP.BaseURL = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 			conf.HTTP.Secret = testutils.Secret
-			conf.OpenVPN.Bypass = config.OpenVPNBypass{types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
+			conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: types.RegexpSlice{regexp.MustCompile(`^bypass$`)}}
 			conf.OpenVPN.Addr = types.URL{URL: &url.URL{Scheme: managementInterface.Addr().Network(), Host: managementInterface.Addr().String()}}
 
 			tokenStorage := tokenstorage.NewInMemory(testutils.Secret, time.Hour)

--- a/internal/utils/testutils/main.go
+++ b/internal/utils/testutils/main.go
@@ -281,7 +281,7 @@ func SetupMockEnvironment(ctx context.Context, tb testing.TB, conf config.Config
 	conf.OpenVPN.Addr = types.URL{URL: &url.URL{Scheme: managementInterface.Addr().Network(), Host: managementInterface.Addr().String()}}
 
 	if conf.OpenVPN.Bypass.CommonNames == nil {
-		conf.OpenVPN.Bypass.CommonNames = make([]string, 0)
+		conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 	}
 
 	conf.OAuth2.Issuer = resourceServerURL

--- a/packaging/etc/openvpn-auth-oauth2/config.yaml
+++ b/packaging/etc/openvpn-auth-oauth2/config.yaml
@@ -66,6 +66,7 @@
 #    common-names:
 #      - "test"
 #      - "test2"
+#      - "wildcard.*"
 #  ccd:
 #    enabled: false
 #    path: "/etc/openvpn-auth-oauth2/client-config/"


### PR DESCRIPTION
#### What this PR does / why we need it

The flag --openvpn.bypass.common-names now interprets values as regular expressions instead of plain string matches.
To minimize migration effort, expressions are automatically anchored with ^ and $ by default. 
This means existing values like "client" will continue to only match the exact CN "client". 
If you want partial matches, you must now define them explicitly (e.g. "client.*").


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #601 

#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] The PR title has a summary of the changes
- [ ] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
