### PR TITLE
Run pending auth poller asynchronously

### DIFF
--- a/lib/openvpn-auth-oauth2/plugin.go
+++ b/lib/openvpn-auth-oauth2/plugin.go
@@ -281,7 +281,7 @@ func (p *pluginHandle) handleAuthUserPassVerify(envp unsafe.Pointer, perClientCo
 			return C.OPENVPN_PLUGIN_FUNC_ERROR
 		}
 
-		defer func() {
+		go func() {
 			resp, err := p.managementClient.AuthPendingPoller(currentClientID, 5*time.Minute)
 			if err != nil {
 				logger.ErrorContext(p.ctx, "poll deferred auth state",


### PR DESCRIPTION
## Summary
- switch the deferred auth poller in `handleAuthUserPassVerify` to run in a goroutine
- preserve the mutex-protected client context updates once the poller finishes

## Testing
- make fmt *(fails: the formatter suite requires Go 1.25 while the environment provides Go 1.24)*
- make lint *(fails: golangci-lint requires Go 1.25 while the environment provides Go 1.24)*
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f5d0e699f08321bac8bc0df5d3cbbd