### PR TITLE
feat: add regexp-based common_name to email transformation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -102,6 +102,10 @@ Usage of openvpn-auth-oauth2:
     	validate common_name from OpenVPN with ID Token claim. For example: preferred_username or sub (env: CONFIG_OAUTH2_VALIDATE_COMMON__NAME)
   --oauth2.validate.common-name-case-sensitive
     	If true, openvpn-auth-oauth2 will validate the common case in sensitive mode (env: CONFIG_OAUTH2_VALIDATE_COMMON__NAME__CASE__SENSITIVE)
+  --oauth2.validate.common-name-email-regexp.pattern string
+    	Regular expression pattern to transform OpenVPN common_name to email address. Used only when oauth2.validate.common-name is set to 'email'. The pattern is applied using Go regexp.ReplaceAllString. Example: ^([^-]+).*$ (env: CONFIG_OAUTH2_VALIDATE_COMMON__NAME__EMAIL__REGEXP_PATTERN)
+  --oauth2.validate.common-name-email-regexp.replacement string
+    	Replacement string for common-name-email-regexp.pattern. Supports regexp capture groups like $1. Example: $1@example.com (env: CONFIG_OAUTH2_VALIDATE_COMMON__NAME__EMAIL__REGEXP_REPLACEMENT)
   --oauth2.validate.groups value
     	oauth2 required user groups. If multiple groups are configured, the user needs to be least in one group. Comma separated list. Example: group1,group2,group3 (env: CONFIG_OAUTH2_VALIDATE_GROUPS)
   --oauth2.validate.ipaddr

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -2,4 +2,10 @@ package config
 
 import "errors"
 
-var ErrRequired = errors.New("required")
+var (
+	ErrRequired                            = errors.New("required")
+	ErrCommonNameEmailRegexpRequiresEmail  = errors.New("oauth2.validate.common-name-email-regexp requires oauth2.validate.common-name to be 'email'")
+	ErrCommonNameEmailRegexpPatternMissing = errors.New("oauth2.validate.common-name-email-regexp.pattern is required")
+	ErrCommonNameEmailRegexpReplaceMissing = errors.New("oauth2.validate.common-name-email-regexp.replacement is required")
+	ErrCommonNameEmailRegexpInvalidPattern = errors.New("oauth2.validate.common-name-email-regexp.pattern is not a valid regexp")
+)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -108,14 +108,20 @@ type OAuth2Endpoints struct {
 	Token     types.URL `json:"token"     yaml:"token"`
 }
 
+type CommonNameEmailRegexp struct {
+	Pattern     string `json:"pattern"     yaml:"pattern"`
+	Replacement string `json:"replacement" yaml:"replacement"`
+}
+
 type OAuth2Validate struct {
-	CommonName              string            `json:"common-name"                yaml:"common-name"`
-	Acr                     types.StringSlice `json:"acr"                        yaml:"acr"`
-	Groups                  types.StringSlice `json:"groups"                     yaml:"groups"`
-	Roles                   types.StringSlice `json:"roles"                      yaml:"roles"`
-	IPAddr                  bool              `json:"ipaddr"                     yaml:"ipaddr"`
-	Issuer                  bool              `json:"issuer"                     yaml:"issuer"`
-	CommonNameCaseSensitive bool              `json:"common-name-case-sensitive" yaml:"common-name-case-sensitive"`
+	CommonName              string                 `json:"common-name"                yaml:"common-name"`
+	CommonNameEmailRegexp   *CommonNameEmailRegexp `json:"common-name-email-regexp"   yaml:"common-name-email-regexp"`
+	Acr                     types.StringSlice      `json:"acr"                        yaml:"acr"`
+	Groups                  types.StringSlice      `json:"groups"                     yaml:"groups"`
+	Roles                   types.StringSlice      `json:"roles"                      yaml:"roles"`
+	IPAddr                  bool                   `json:"ipaddr"                     yaml:"ipaddr"`
+	Issuer                  bool                   `json:"issuer"                     yaml:"issuer"`
+	CommonNameCaseSensitive bool                   `json:"common-name-case-sensitive" yaml:"common-name-case-sensitive"`
 }
 
 type OAuth2Refresh struct {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -235,6 +235,127 @@ func TestValidate(t *testing.T) {
 			},
 			"oauth2.userinfo: cannot be used if oauth2.endpoint.auth and oauth2.endpoint.token is set",
 		},
+		// common-name-email-regexp validation tests
+		{
+			config.Config{
+				HTTP: config.HTTP{
+					BaseURL:  types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Secret:   testutils.Secret,
+					Template: config.Defaults.HTTP.Template,
+				},
+				OAuth2: config.OAuth2{
+					Client: config.OAuth2Client{ID: "ID", Secret: testutils.Secret},
+					Issuer: types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Validate: config.OAuth2Validate{
+						CommonName: "sub",
+						CommonNameEmailRegexp: &config.CommonNameEmailRegexp{
+							Pattern:     "^([^-]+)",
+							Replacement: "$1@example.com",
+						},
+					},
+				},
+				OpenVPN: config.OpenVPN{
+					Addr: types.URL{URL: &url.URL{Scheme: "tcp", Host: "127.0.0.1:9000"}},
+				},
+			},
+			"oauth2.validate.common-name-email-regexp requires oauth2.validate.common-name to be 'email'",
+		},
+		{
+			config.Config{
+				HTTP: config.HTTP{
+					BaseURL:  types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Secret:   testutils.Secret,
+					Template: config.Defaults.HTTP.Template,
+				},
+				OAuth2: config.OAuth2{
+					Client: config.OAuth2Client{ID: "ID", Secret: testutils.Secret},
+					Issuer: types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Validate: config.OAuth2Validate{
+						CommonName: "email",
+						CommonNameEmailRegexp: &config.CommonNameEmailRegexp{
+							Pattern:     "",
+							Replacement: "$1@example.com",
+						},
+					},
+				},
+				OpenVPN: config.OpenVPN{
+					Addr: types.URL{URL: &url.URL{Scheme: "tcp", Host: "127.0.0.1:9000"}},
+				},
+			},
+			"oauth2.validate.common-name-email-regexp.pattern is required",
+		},
+		{
+			config.Config{
+				HTTP: config.HTTP{
+					BaseURL:  types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Secret:   testutils.Secret,
+					Template: config.Defaults.HTTP.Template,
+				},
+				OAuth2: config.OAuth2{
+					Client: config.OAuth2Client{ID: "ID", Secret: testutils.Secret},
+					Issuer: types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Validate: config.OAuth2Validate{
+						CommonName: "email",
+						CommonNameEmailRegexp: &config.CommonNameEmailRegexp{
+							Pattern:     "[invalid",
+							Replacement: "$1@example.com",
+						},
+					},
+				},
+				OpenVPN: config.OpenVPN{
+					Addr: types.URL{URL: &url.URL{Scheme: "tcp", Host: "127.0.0.1:9000"}},
+				},
+			},
+			"-", // error message varies by Go version, just check that it fails
+		},
+		{
+			config.Config{
+				HTTP: config.HTTP{
+					BaseURL:  types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Secret:   testutils.Secret,
+					Template: config.Defaults.HTTP.Template,
+				},
+				OAuth2: config.OAuth2{
+					Client: config.OAuth2Client{ID: "ID", Secret: testutils.Secret},
+					Issuer: types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Validate: config.OAuth2Validate{
+						CommonName: "email",
+						CommonNameEmailRegexp: &config.CommonNameEmailRegexp{
+							Pattern:     "^([^-]+)",
+							Replacement: "",
+						},
+					},
+				},
+				OpenVPN: config.OpenVPN{
+					Addr: types.URL{URL: &url.URL{Scheme: "tcp", Host: "127.0.0.1:9000"}},
+				},
+			},
+			"oauth2.validate.common-name-email-regexp.replacement is required",
+		},
+		{
+			config.Config{
+				HTTP: config.HTTP{
+					BaseURL:  types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Secret:   testutils.Secret,
+					Template: config.Defaults.HTTP.Template,
+				},
+				OAuth2: config.OAuth2{
+					Client: config.OAuth2Client{ID: "ID", Secret: testutils.Secret},
+					Issuer: types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},
+					Validate: config.OAuth2Validate{
+						CommonName: "email",
+						CommonNameEmailRegexp: &config.CommonNameEmailRegexp{
+							Pattern:     "^([^-]+)",
+							Replacement: "$1@example.com",
+						},
+					},
+				},
+				OpenVPN: config.OpenVPN{
+					Addr: types.URL{URL: &url.URL{Scheme: "tcp", Host: "127.0.0.1:9000"}},
+				},
+			},
+			"",
+		},
 	} {
 		t.Run(tc.err, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary
- Add support for transforming OpenVPN client certificate common names to email addresses using regexp pattern and replacement
- This allows validation when common names don't match email format directly (e.g., `user-laptop` → `user@example.com`)
- New configuration options: `oauth2.validate.common-name-email-regexp.pattern` and `oauth2.validate.common-name-email-regexp.replacement`

## Configuration Example
```yaml
oauth2:
  validate:
    common-name: email
    common-name-email-regexp:
      pattern: "^([^-]+).*$"
      replacement: "$1@example.com"
```

## Test plan
- [x] Unit tests for config validation (5 test cases)
- [x] Unit tests for email transformation (7 test cases)
- [x] `make lint` passes with 0 issues
- [x] `make test` passes for affected packages
- [x] Tested on real OpenVPN + Google OIDC setup

First of all thanks a lot for your project it is amazing work. This PR fully made by claude Opus 4.5 🤖
It can be considered as an idea and a trial implementation.  