### PR TITLE
Fix build command in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ update:  ## Run dependency updates
 build: clean $(PROJECT_NAME)
 
 $(PROJECT_NAME):
-	@go build -o $(PROJECT_NAME)$(EXT) .
+	@go build -o $(PROJECT_NAME)$(EXT) ./cmd/openvpn-auth-oauth2
 
 .PHONY: test
 test:  ## Test the project


### PR DESCRIPTION
#### What this PR does / why we need it
As the main.go was moved to the cmd directory the build command in the makefile is no longer working.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
