### PR TITLE
fix: restrict OIDC HTTP redirects

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -63,7 +63,7 @@ func newDebugServer(logger *slog.Logger, conf *config.Config) *httpserver.Server
 func setupOpenVPNClient(
 	ctx context.Context, logger *slog.Logger, conf *config.Config, tokenStorage tokenstorage.Storage,
 ) (*openvpn.Client, *http.ServeMux, error) {
-	httpClient := &http.Client{Transport: utils.NewUserAgentTransport(http.DefaultTransport)}
+	httpClient := utils.NewOAuth2HTTPClient(http.DefaultTransport)
 
 	provider, err := providers.New(ctx, conf, httpClient)
 	if err != nil {

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -1,6 +1,18 @@
 package utils
 
-import "net/http"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const oAuth2HTTPClientTimeout = 30 * time.Second
+
+var (
+	ErrOAuth2ProviderRedirectHost      = errors.New("oauth2 provider redirect changes host")
+	ErrOAuth2ProviderRedirectDowngrade = errors.New("oauth2 provider redirect downgrades HTTPS")
+)
 
 type UserAgentTransport struct {
 	rt http.RoundTripper
@@ -14,6 +26,38 @@ func NewUserAgentTransport(rt http.RoundTripper) *UserAgentTransport {
 	}
 
 	return &UserAgentTransport{rt}
+}
+
+// NewOAuth2HTTPClient returns the outbound HTTP client used for provider calls.
+func NewOAuth2HTTPClient(rt http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport:     NewUserAgentTransport(rt),
+		CheckRedirect: CheckOAuth2ProviderRedirect,
+		Timeout:       oAuth2HTTPClientTimeout,
+	}
+}
+
+// CheckOAuth2ProviderRedirect restricts provider redirects to the original host.
+func CheckOAuth2ProviderRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+
+	originalURL := via[0].URL
+
+	if req.URL.Host != originalURL.Host {
+		return fmt.Errorf("%w: %s to %s", ErrOAuth2ProviderRedirectHost, originalURL.Host, req.URL.Host)
+	}
+
+	if originalURL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("%w: %s to %s", ErrOAuth2ProviderRedirectDowngrade, originalURL.Scheme, req.URL.Scheme)
+	}
+
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+
+	return nil
 }
 
 // RoundTrip implements http.RoundTripper, adding the User-Agent header before

--- a/internal/utils/http_test.go
+++ b/internal/utils/http_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
 	"github.com/stretchr/testify/assert"
@@ -35,4 +36,72 @@ func TestNewUserAgentTransport(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "openvpn-auth-oauth2", string(body))
+}
+
+func TestNewOAuth2HTTPClient(t *testing.T) {
+	t.Parallel()
+
+	client := utils.NewOAuth2HTTPClient(nil)
+
+	require.NotNil(t, client.Transport)
+	require.NotNil(t, client.CheckRedirect)
+	assert.Equal(t, 30*time.Second, client.Timeout)
+}
+
+func TestCheckOAuth2ProviderRedirect(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		originalURL string
+		redirectURL string
+		expectedErr error
+	}{
+		{
+			name:        "same host",
+			originalURL: "https://provider.example.com/token",
+			redirectURL: "https://provider.example.com/token-v2",
+		},
+		{
+			name:        "http to https same host",
+			originalURL: "http://provider.example.com/token",
+			redirectURL: "https://provider.example.com/token",
+		},
+		{
+			name:        "cross host",
+			originalURL: "https://provider.example.com/token",
+			redirectURL: "https://metadata.internal/token",
+			expectedErr: utils.ErrOAuth2ProviderRedirectHost,
+		},
+		{
+			name:        "subdomain",
+			originalURL: "https://provider.example.com/token",
+			redirectURL: "https://attacker.provider.example.com/token",
+			expectedErr: utils.ErrOAuth2ProviderRedirectHost,
+		},
+		{
+			name:        "https downgrade",
+			originalURL: "https://provider.example.com/token",
+			redirectURL: "http://provider.example.com/token",
+			expectedErr: utils.ErrOAuth2ProviderRedirectDowngrade,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.redirectURL, nil)
+			via := []*http.Request{httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.originalURL, nil)}
+
+			err := utils.CheckOAuth2ProviderRedirect(req, via)
+
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tc.expectedErr)
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Adds a dedicated outbound OAuth2/OIDC HTTP client with a 30 second timeout and a redirect policy that rejects cross-host provider redirects and HTTPS-to-HTTP downgrades. This reduces SSRF and bearer-token forwarding risk during discovery, token, userinfo, revocation, and provider API calls.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

A dedicated sub-agent reviewed the branch diff and reported no findings. The policy intentionally disallows providers that depend on cross-host redirects; those should be handled with an explicit allow-list if needed.

#### Particularly user-facing changes

Misconfigured or redirecting OIDC provider endpoints may now fail instead of following redirects to a different host or HTTPS downgrade.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

#### Testing

- `make fmt`
- `make lint`
- `make test`