### PR TITLE
feat: require plugin management password

### DIFF
--- a/docs/OpenVPN Plugin.md
+++ b/docs/OpenVPN Plugin.md
@@ -32,10 +32,10 @@ Add the plugin to your OpenVPN server configuration:
 
 ```
 # Load the plugin with listen socket address and password file
-plugin /path/to/openvpn-auth-oauth2.so "tcp://127.0.0.1:9000" "/etc/openvpn-auth-oauth2/plugin-password.txt"
+plugin /path/to/openvpn-auth-oauth2.so "tcp://127.0.0.1:9000" "/etc/openvpn/oauth2-plugin-password.txt"
 
 # Or use Unix socket
-plugin /path/to/openvpn-auth-oauth2.so "unix:///var/run/openvpn-oauth2.sock" "/etc/openvpn-auth-oauth2/plugin-password.txt"
+plugin /path/to/openvpn-auth-oauth2.so "unix:///var/run/openvpn-oauth2.sock" "/etc/openvpn/oauth2-plugin-password.txt"
 ```
 
 Plugin arguments:
@@ -44,11 +44,13 @@ Plugin arguments:
   - Unix: `unix:///path/to/socket` (e.g., `unix:///var/run/openvpn-oauth2.sock`)
 2. **Password file** (required): File containing the management interface password
 
-For package installations, place the password file below `/etc/openvpn-auth-oauth2/`.
-The shipped AppArmor profile allows `openvpn-auth-oauth2` to read this directory,
-and the systemd service runs with the `openvpn-auth-oauth2` supplementary group.
-Create the file with restrictive ownership and permissions, for example
-`root:openvpn-auth-oauth2` and mode `0640`.
+For package installations, the shipped AppArmor profile allows
+`openvpn-auth-oauth2` to read `/etc/openvpn/oauth2-plugin-password.txt`.
+Create the file so both the OpenVPN process and `openvpn-auth-oauth2` can read
+it, for example `root:openvpn-auth-oauth2` and mode `0640` when OpenVPN loads
+the plugin as root. If OpenVPN is also running unprivileged before plugin load,
+use a group that both processes can read, or adjust the file path and local
+AppArmor rules together.
 
 ### openvpn-auth-oauth2 Configuration
 
@@ -60,7 +62,7 @@ Configure openvpn-auth-oauth2 to connect to the plugin's management socket inste
 
 ```ini
 CONFIG_OPENVPN_ADDR=unix:///var/run/openvpn-oauth2.sock
-CONFIG_OPENVPN_PASSWORD=file:///etc/openvpn-auth-oauth2/plugin-password.txt
+CONFIG_OPENVPN_PASSWORD=file:///etc/openvpn/oauth2-plugin-password.txt
 CONFIG_OAUTH2_REFRESH_ENABLED=true
 CONFIG_OAUTH2_REFRESH_EXPIRES=8h
 CONFIG_OAUTH2_REFRESH_SECRET= # a static secret to encrypt token. Must be 16, 24 or 32
@@ -74,7 +76,7 @@ CONFIG_OPENVPN_AUTH__TOKEN__USER=true
 ```yaml
 openvpn:
   addr: unix:///var/run/openvpn-oauth2.sock
-  password: "file:///etc/openvpn-auth-oauth2/plugin-password.txt"
+  password: "file:///etc/openvpn/oauth2-plugin-password.txt"
 oauth2:
   refresh:
     enabled: true

--- a/docs/OpenVPN Plugin.md
+++ b/docs/OpenVPN Plugin.md
@@ -45,12 +45,17 @@ Plugin arguments:
 2. **Password file** (required): File containing the management interface password
 
 For package installations, the shipped AppArmor profile allows
-`openvpn-auth-oauth2` to read `/etc/openvpn/oauth2-plugin-password.txt`.
-Create the file so both the OpenVPN process and `openvpn-auth-oauth2` can read
-it, for example `root:openvpn-auth-oauth2` and mode `0640` when OpenVPN loads
-the plugin as root. If OpenVPN is also running unprivileged before plugin load,
-use a group that both processes can read, or adjust the file path and local
-AppArmor rules together.
+`openvpn-auth-oauth2` to read `/etc/openvpn-auth-oauth2/**`, while OpenVPN
+installations commonly keep plugin-readable files below `/etc/openvpn/`.
+Use two dedicated password files with identical contents instead of making one
+file readable across both confined contexts:
+
+- `/etc/openvpn/oauth2-plugin-password.txt` for the OpenVPN plugin argument.
+- `/etc/openvpn-auth-oauth2/oauth2-plugin-password.txt` for
+  `openvpn-auth-oauth2`.
+
+Create each file with restrictive ownership and permissions for the process that
+must read it, for example mode `0640` with the appropriate service group.
 
 ### openvpn-auth-oauth2 Configuration
 
@@ -62,7 +67,7 @@ Configure openvpn-auth-oauth2 to connect to the plugin's management socket inste
 
 ```ini
 CONFIG_OPENVPN_ADDR=unix:///var/run/openvpn-oauth2.sock
-CONFIG_OPENVPN_PASSWORD=file:///etc/openvpn/oauth2-plugin-password.txt
+CONFIG_OPENVPN_PASSWORD=file:///etc/openvpn-auth-oauth2/oauth2-plugin-password.txt
 CONFIG_OAUTH2_REFRESH_ENABLED=true
 CONFIG_OAUTH2_REFRESH_EXPIRES=8h
 CONFIG_OAUTH2_REFRESH_SECRET= # a static secret to encrypt token. Must be 16, 24 or 32
@@ -76,7 +81,7 @@ CONFIG_OPENVPN_AUTH__TOKEN__USER=true
 ```yaml
 openvpn:
   addr: unix:///var/run/openvpn-oauth2.sock
-  password: "file:///etc/openvpn/oauth2-plugin-password.txt"
+  password: "file:///etc/openvpn-auth-oauth2/oauth2-plugin-password.txt"
 oauth2:
   refresh:
     enabled: true

--- a/docs/OpenVPN Plugin.md
+++ b/docs/OpenVPN Plugin.md
@@ -32,10 +32,10 @@ Add the plugin to your OpenVPN server configuration:
 
 ```
 # Load the plugin with listen socket address and password file
-plugin /path/to/openvpn-auth-oauth2.so "tcp://127.0.0.1:9000" "/etc/openvpn/oauth2-plugin-password.txt"
+plugin /path/to/openvpn-auth-oauth2.so "tcp://127.0.0.1:9000" "/etc/openvpn-auth-oauth2/plugin-password.txt"
 
 # Or use Unix socket
-plugin /path/to/openvpn-auth-oauth2.so "unix:///var/run/openvpn-oauth2.sock" "/etc/openvpn/oauth2-plugin-password.txt"
+plugin /path/to/openvpn-auth-oauth2.so "unix:///var/run/openvpn-oauth2.sock" "/etc/openvpn-auth-oauth2/plugin-password.txt"
 ```
 
 Plugin arguments:
@@ -44,7 +44,11 @@ Plugin arguments:
   - Unix: `unix:///path/to/socket` (e.g., `unix:///var/run/openvpn-oauth2.sock`)
 2. **Password file** (required): File containing the management interface password
 
-Create the password file with restrictive ownership and permissions so only the OpenVPN process and `openvpn-auth-oauth2` can read it, for example mode `0600`.
+For package installations, place the password file below `/etc/openvpn-auth-oauth2/`.
+The shipped AppArmor profile allows `openvpn-auth-oauth2` to read this directory,
+and the systemd service runs with the `openvpn-auth-oauth2` supplementary group.
+Create the file with restrictive ownership and permissions, for example
+`root:openvpn-auth-oauth2` and mode `0640`.
 
 ### openvpn-auth-oauth2 Configuration
 
@@ -56,7 +60,7 @@ Configure openvpn-auth-oauth2 to connect to the plugin's management socket inste
 
 ```ini
 CONFIG_OPENVPN_ADDR=unix:///var/run/openvpn-oauth2.sock
-CONFIG_OPENVPN_PASSWORD=file:///etc/openvpn/oauth2-plugin-password.txt
+CONFIG_OPENVPN_PASSWORD=file:///etc/openvpn-auth-oauth2/plugin-password.txt
 CONFIG_OAUTH2_REFRESH_ENABLED=true
 CONFIG_OAUTH2_REFRESH_EXPIRES=8h
 CONFIG_OAUTH2_REFRESH_SECRET= # a static secret to encrypt token. Must be 16, 24 or 32
@@ -70,7 +74,7 @@ CONFIG_OPENVPN_AUTH__TOKEN__USER=true
 ```yaml
 openvpn:
   addr: unix:///var/run/openvpn-oauth2.sock
-  password: "file:///etc/openvpn/oauth2-plugin-password.txt"
+  password: "file:///etc/openvpn-auth-oauth2/plugin-password.txt"
 oauth2:
   refresh:
     enabled: true

--- a/docs/OpenVPN Plugin.md
+++ b/docs/OpenVPN Plugin.md
@@ -31,18 +31,20 @@ Due limitation on Go site, this plugin runs only under Linux.
 Add the plugin to your OpenVPN server configuration:
 
 ```
-# Load the plugin with listen socket address and optional password
-plugin /path/to/openvpn-auth-oauth2.so "tcp://127.0.0.1:9000" "optional-password"
+# Load the plugin with listen socket address and password file
+plugin /path/to/openvpn-auth-oauth2.so "tcp://127.0.0.1:9000" "/etc/openvpn/oauth2-plugin-password.txt"
 
 # Or use Unix socket
-plugin /path/to/openvpn-auth-oauth2.so "unix:///var/run/openvpn-oauth2.sock"
+plugin /path/to/openvpn-auth-oauth2.so "unix:///var/run/openvpn-oauth2.sock" "/etc/openvpn/oauth2-plugin-password.txt"
 ```
 
 Plugin arguments:
 1. **Listen socket** (required): The address where the management interface will listen
   - TCP: `tcp://host:port` (e.g., `tcp://127.0.0.1:9000`)
   - Unix: `unix:///path/to/socket` (e.g., `unix:///var/run/openvpn-oauth2.sock`)
-2. **Password** (optional): Password for management interface authentication
+2. **Password file** (required): File containing the management interface password
+
+Create the password file with restrictive ownership and permissions so only the OpenVPN process and `openvpn-auth-oauth2` can read it, for example mode `0600`.
 
 ### openvpn-auth-oauth2 Configuration
 
@@ -54,7 +56,7 @@ Configure openvpn-auth-oauth2 to connect to the plugin's management socket inste
 
 ```ini
 CONFIG_OPENVPN_ADDR=unix:///var/run/openvpn-oauth2.sock
-CONFIG_OPENVPN_PASSWORD=optional-password
+CONFIG_OPENVPN_PASSWORD=file:///etc/openvpn/oauth2-plugin-password.txt
 CONFIG_OAUTH2_REFRESH_ENABLED=true
 CONFIG_OAUTH2_REFRESH_EXPIRES=8h
 CONFIG_OAUTH2_REFRESH_SECRET= # a static secret to encrypt token. Must be 16, 24 or 32
@@ -68,7 +70,7 @@ CONFIG_OPENVPN_AUTH__TOKEN__USER=true
 ```yaml
 openvpn:
   addr: unix:///var/run/openvpn-oauth2.sock
-  password: "optional-password"  # Must match plugin password if set
+  password: "file:///etc/openvpn/oauth2-plugin-password.txt"
 oauth2:
   refresh:
     enabled: true

--- a/lib/openvpn-auth-oauth2/AGENTS.md
+++ b/lib/openvpn-auth-oauth2/AGENTS.md
@@ -108,29 +108,19 @@ plugin /path/to/plugin.so "arg1" "arg2" "arg3"
                            +---------------- argv[1] (socket address)
 ```
 
-**Systemd/AppArmor lockdown note:** The plugin password file is consumed by two
-different processes with different confinement rules:
+**Shared password file permissions:** The plugin password file is consumed by
+two different processes:
 
 - OpenVPN reads it when loading the plugin from its own configuration context.
 - `openvpn-auth-oauth2` reads the same secret via `openvpn.password=file://...`
-  from the packaged systemd service.
+  when connecting to the plugin management socket.
 
-Do not move the documented shared password file only to
-`/etc/openvpn-auth-oauth2/` without checking OpenVPN's confinement, because
-OpenVPN may only be allowed to read `/etc/openvpn/**`. The current packaged
-pattern keeps the file at `/etc/openvpn/oauth2-plugin-password.txt` and grants
-`openvpn-auth-oauth2` a narrow AppArmor read rule for that exact file in
-`packaging/etc/apparmor.d/usr.bin.openvpn-auth-oauth2`.
-
-When changing plugin password paths, permissions, or packaging hardening,
-validate all of these together:
-
-1. OpenVPN can read the password file before or during plugin load.
-2. The `openvpn-auth-oauth2` systemd service can read the same file under
-   `DynamicUser=true`, `SupplementaryGroups=openvpn-auth-oauth2`,
-   `ProtectSystem=strict`, and the shipped AppArmor profile.
-3. The file remains group-readable only to the required processes, e.g. mode
-   `0640` with a group shared by both readers, or a documented local override.
+When changing the password file path, owner, group, or mode, validate the
+filesystem permissions for both readers. Both processes need read permission on
+the file and execute/search permission on every parent directory. The file must
+not be readable by unrelated users. A typical setup uses a group shared by the
+two readers and mode `0640`, or a documented local override when the deployment
+uses different service identities.
 
 #### 4. `openvpn_plugin_func_v3()`
 Called for each plugin event. We handle:

--- a/lib/openvpn-auth-oauth2/AGENTS.md
+++ b/lib/openvpn-auth-oauth2/AGENTS.md
@@ -108,19 +108,20 @@ plugin /path/to/plugin.so "arg1" "arg2" "arg3"
                            +---------------- argv[1] (socket address)
 ```
 
-**Shared password file permissions:** The plugin password file is consumed by
-two different processes:
+**Plugin password file permissions:** The plugin management password is consumed
+by two different processes:
 
 - OpenVPN reads it when loading the plugin from its own configuration context.
-- `openvpn-auth-oauth2` reads the same secret via `openvpn.password=file://...`
+- `openvpn-auth-oauth2` reads the same password via `openvpn.password=file://...`
   when connecting to the plugin management socket.
 
-When changing the password file path, owner, group, or mode, validate the
-filesystem permissions for both readers. Both processes need read permission on
-the file and execute/search permission on every parent directory. The file must
-not be readable by unrelated users. A typical setup uses a group shared by the
-two readers and mode `0640`, or a documented local override when the deployment
-uses different service identities.
+The two readers do not need to use the same filesystem path. When their
+filesystem permissions or confinement differ, prefer two dedicated files with
+identical contents, each located and permissioned for the process that reads it.
+For every configured password file, validate that the intended process has read
+permission on the file and execute/search permission on every parent directory.
+The files must not be readable by unrelated users. A typical setup uses mode
+`0640` with the appropriate service group for each reader.
 
 #### 4. `openvpn_plugin_func_v3()`
 Called for each plugin event. We handle:

--- a/lib/openvpn-auth-oauth2/AGENTS.md
+++ b/lib/openvpn-auth-oauth2/AGENTS.md
@@ -93,7 +93,7 @@ We use `PRE_DAEMON` because we need to create sockets that require root privileg
 
 #### 3. `openvpn_plugin_open_v3()`
 Called when OpenVPN loads the plugin. Our implementation:
-- Parses plugin arguments (socket address, optional password)
+- Parses plugin arguments (socket address, password file)
 - Creates management server socket
 - Starts listening for openvpn-auth-oauth2 connection
 - Returns plugin handle (pointer to our context struct)
@@ -104,7 +104,7 @@ plugin /path/to/plugin.so "arg1" "arg2" "arg3"
                            ^      ^      ^
                            |      |      |
                            |      |      +-- argv[3]
-                           |      +--------- argv[2] (password)
+                           |      +--------- argv[2] (password file)
                            +---------------- argv[1] (socket address)
 ```
 

--- a/lib/openvpn-auth-oauth2/AGENTS.md
+++ b/lib/openvpn-auth-oauth2/AGENTS.md
@@ -108,6 +108,30 @@ plugin /path/to/plugin.so "arg1" "arg2" "arg3"
                            +---------------- argv[1] (socket address)
 ```
 
+**Systemd/AppArmor lockdown note:** The plugin password file is consumed by two
+different processes with different confinement rules:
+
+- OpenVPN reads it when loading the plugin from its own configuration context.
+- `openvpn-auth-oauth2` reads the same secret via `openvpn.password=file://...`
+  from the packaged systemd service.
+
+Do not move the documented shared password file only to
+`/etc/openvpn-auth-oauth2/` without checking OpenVPN's confinement, because
+OpenVPN may only be allowed to read `/etc/openvpn/**`. The current packaged
+pattern keeps the file at `/etc/openvpn/oauth2-plugin-password.txt` and grants
+`openvpn-auth-oauth2` a narrow AppArmor read rule for that exact file in
+`packaging/etc/apparmor.d/usr.bin.openvpn-auth-oauth2`.
+
+When changing plugin password paths, permissions, or packaging hardening,
+validate all of these together:
+
+1. OpenVPN can read the password file before or during plugin load.
+2. The `openvpn-auth-oauth2` systemd service can read the same file under
+   `DynamicUser=true`, `SupplementaryGroups=openvpn-auth-oauth2`,
+   `ProtectSystem=strict`, and the shipped AppArmor profile.
+3. The file remains group-readable only to the required processes, e.g. mode
+   `0640` with a group shared by both readers, or a documented local override.
+
 #### 4. `openvpn_plugin_func_v3()`
 Called for each plugin event. We handle:
 - `OPENVPN_PLUGIN_UP` - Server is ready

--- a/lib/openvpn-auth-oauth2/openvpn/plugin.go
+++ b/lib/openvpn-auth-oauth2/openvpn/plugin.go
@@ -56,28 +56,29 @@ func PluginOpenV3(v3structver c.Int, args *c.OpenVPNPluginArgsOpenIn, ret *c.Ope
 
 	logger := slog.New(pluginlog.NewOpenVPNPluginLogger(args.Callbacks))
 
-	if len(pluginArgs) > 3 || len(pluginArgs) < 2 {
-		logger.Error("Invalid amount of arguments! openvpn-auth-oauth2.so <listen socket> [<password-file>]")
+	if len(pluginArgs) != 3 {
+		logger.Error("Invalid amount of arguments! openvpn-auth-oauth2.so <listen socket> <password-file>")
 
 		return c.OpenVPNPluginFuncError
 	}
 
 	listenSocketAddr := pluginArgs[1]
 
-	var listenSocketPassword string
+	password, err := os.ReadFile(pluginArgs[2])
+	if err != nil {
+		logger.Error(
+			"Failed to read password file",
+			slog.Any("err", err),
+		)
 
-	if len(pluginArgs) == 3 {
-		password, err := os.ReadFile(pluginArgs[2])
-		if err != nil {
-			logger.Error(
-				"Failed to read password file",
-				slog.Any("err", err),
-			)
+		return c.OpenVPNPluginFuncError
+	}
 
-			return c.OpenVPNPluginFuncError
-		}
+	listenSocketPassword := strings.TrimSpace(string(password))
+	if listenSocketPassword == "" {
+		logger.Error("Password file is empty")
 
-		listenSocketPassword = strings.TrimSpace(string(password))
+		return c.OpenVPNPluginFuncError
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/lib/openvpn-auth-oauth2/openvpn/plugin_test.go
+++ b/lib/openvpn-auth-oauth2/openvpn/plugin_test.go
@@ -408,6 +408,75 @@ func TestPluginOpenV3_InvalidArgs(t *testing.T) {
 
 	status := PluginOpenV3(0, nil, nil)
 	require.Equal(t, c.OpenVPNPluginFuncError, status)
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "missing password file",
+			args: []string{"openvpn-auth-oauth2", "unix:///tmp/openvpn-auth-oauth2.sock"},
+		},
+		{
+			name: "too many args",
+			args: []string{
+				"openvpn-auth-oauth2",
+				"unix:///tmp/openvpn-auth-oauth2.sock",
+				"/tmp/openvpn-auth-oauth2-password",
+				"extra",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			argv, argvCStrings := testutil.CreateCStringArray(tc.args)
+
+			t.Cleanup(func() {
+				testutil.FreeCStringArray(argv, argvCStrings)
+			})
+
+			openArgs := &c.OpenVPNPluginArgsOpenIn{
+				Callbacks: testutil.Callbacks(),
+				Argv:      argv,
+			}
+			openRet := &c.OpenVPNPluginArgsOpenReturn{}
+
+			status := PluginOpenV3(PluginStructVerMin, openArgs, openRet)
+			require.Equal(t, c.OpenVPNPluginFuncError, status)
+			require.Zero(t, openRet.Handle)
+		})
+	}
+}
+
+func TestPluginOpenV3_EmptyPasswordFile(t *testing.T) {
+	t.Parallel()
+
+	passwordFile, err := os.CreateTemp(t.TempDir(), "openvpn-auth-oauth2-test-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = passwordFile.Close()
+	})
+
+	argv, argvCStrings := testutil.CreateCStringArray([]string{
+		"openvpn-auth-oauth2",
+		"unix:///tmp/openvpn-auth-oauth2.sock",
+		passwordFile.Name(),
+	})
+
+	t.Cleanup(func() {
+		testutil.FreeCStringArray(argv, argvCStrings)
+	})
+
+	openArgs := &c.OpenVPNPluginArgsOpenIn{
+		Callbacks: testutil.Callbacks(),
+		Argv:      argv,
+	}
+	openRet := &c.OpenVPNPluginArgsOpenReturn{}
+
+	status := PluginOpenV3(PluginStructVerMin, openArgs, openRet)
+	require.Equal(t, c.OpenVPNPluginFuncError, status)
+	require.Zero(t, openRet.Handle)
 }
 
 func TestPluginFuncV3_InvalidArgs(t *testing.T) {

--- a/packaging/etc/apparmor.d/usr.bin.openvpn-auth-oauth2
+++ b/packaging/etc/apparmor.d/usr.bin.openvpn-auth-oauth2
@@ -11,6 +11,7 @@ include <tunables/global>
   @{PROC}/sys/kernel/core_pattern r,
 
   @{etc_ro}/openvpn-auth-oauth2/** r,
+  @{etc_ro}/openvpn/oauth2-plugin-password.txt r,
 
   @{run}/openvpn{,-server}/* rw,
 

--- a/packaging/etc/apparmor.d/usr.bin.openvpn-auth-oauth2
+++ b/packaging/etc/apparmor.d/usr.bin.openvpn-auth-oauth2
@@ -11,7 +11,6 @@ include <tunables/global>
   @{PROC}/sys/kernel/core_pattern r,
 
   @{etc_ro}/openvpn-auth-oauth2/** r,
-  @{etc_ro}/openvpn/oauth2-plugin-password.txt r,
 
   @{run}/openvpn{,-server}/* rw,
 


### PR DESCRIPTION
#### What this PR does / why we need it

Requires the OpenVPN plugin shim to receive a password-file argument and rejects empty password files. This prevents the plugin management socket from accepting unauthenticated clients that can send auth decisions to OpenVPN.

The plugin documentation now describes the required password file, daemon-side `file://` password configuration, and restrictive file permissions.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

A dedicated sub-agent reviewed the branch diff and found two low documentation issues. Both were fixed before this commit.

#### Particularly user-facing changes

OpenVPN plugin configurations without a password file now fail to load. Existing plugin users must pass a readable non-empty password file as the second plugin argument and configure `openvpn.password` to match it.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

#### Testing

- `make fmt`
- `make lint`
- `make test`