### PR TITLE
fix: secure management pass-through access

### DIFF
--- a/docs/Management Interface pass-through.md
+++ b/docs/Management Interface pass-through.md
@@ -51,11 +51,16 @@ openvpn:
 
 ## Command Filtering
 
-openvpn-auth-oauth2 filters certain commands for security reasons. The following commands are not allowed and will be filtered:
+openvpn-auth-oauth2 allows only a small set of read-only OpenVPN management commands through the pass-through socket:
 
-- `client-deny`
-- `client-auth`
-- `client-auth-nt`
+- `help`
+- `load-stats`
+- `pid`
+- `status [n]`
+- `version`
 
-If a client sends one of these commands, openvpn-auth-oauth2 will respond with "ERROR: command not allowed" and log a warning message.
+The local session commands `hold`, `exit`, and `quit` are handled by openvpn-auth-oauth2 itself and are not forwarded to OpenVPN.
 
+All other commands are filtered for security reasons. This includes authentication and control commands such as `client-auth`, `client-auth-nt`, `client-deny`, `client-kill`, `kill`, `signal`, and `verb`.
+
+If a client sends a filtered command, openvpn-auth-oauth2 will respond with "ERROR: command not allowed" and log a warning message.

--- a/docs/Management Interface pass-through.md
+++ b/docs/Management Interface pass-through.md
@@ -49,18 +49,17 @@ openvpn:
 </td></tr></tbody>
 </table>
 
-## Command Filtering
+## Command Forwarding
 
-openvpn-auth-oauth2 allows only a small set of read-only OpenVPN management commands through the pass-through socket:
-
-- `help`
-- `load-stats`
-- `pid`
-- `status [n]`
-- `version`
+openvpn-auth-oauth2 forwards OpenVPN management commands through the pass-through socket after the client authenticates with the configured pass-through password. Treat this socket as an administrator interface: a client with access can run powerful OpenVPN management commands such as disconnecting clients, changing daemon state, and entering dynamic credentials.
 
 The local session commands `hold`, `exit`, and `quit` are handled by openvpn-auth-oauth2 itself and are not forwarded to OpenVPN.
 
-All other commands are filtered for security reasons. This includes authentication and control commands such as `client-auth`, `client-auth-nt`, `client-deny`, `client-kill`, `kill`, `signal`, and `verb`.
+Authentication decision commands are reserved for openvpn-auth-oauth2 because they are part of its own webauth flow:
 
-If a client sends a filtered command, openvpn-auth-oauth2 will respond with "ERROR: command not allowed" and log a warning message.
+- `client-auth`
+- `client-auth-nt`
+- `client-deny`
+- `client-pending-auth`
+
+If a client sends a reserved command, openvpn-auth-oauth2 will respond with "ERROR: command not allowed" and log a warning message. Use a Unix socket with restrictive filesystem permissions, or otherwise restrict the listener to trusted administrator clients only.

--- a/docs/Management Interface pass-through.md
+++ b/docs/Management Interface pass-through.md
@@ -18,7 +18,7 @@ You can configure the pass-through feature  using the following options:
 openvpn-auth-oauth2 \
   --openvpn.pass-through.enabled=true \
   --openvpn.pass-through.address=unix:///run/openvpn/pass-through.sock  \
-  --openvpn.pass-through.password=secret
+  # --openvpn.pass-through.password=secret # optional
   # --openvpn.pass-through.socket-group=openvpn-auth-oauth2 # optional
   # --openvpn.pass-through.socket-mode=0660 # optional
 ```
@@ -29,7 +29,7 @@ openvpn-auth-oauth2 \
 ```ini
 CONFIG_OPENVPN_PASS__THROUGH_ENABLED=true
 CONFIG_OPENVPN_PASS__THROUGH_ADDRESS=unix:///run/openvpn/pass-through.sock
-CONFIG_OPENVPN_PASS__THROUGH_PASSWORD=secret
+# CONFIG_OPENVPN_PASS__THROUGH_PASSWORD=secret # optional
 # CONFIG_OPENVPN_PASS__THROUGH_SOCKET__GROUP=openvpn-auth-oauth2 # optional
 # CONFIG_OPENVPN_PASS__THROUGH_SOCKET__MODE=0660 # optional
 ```
@@ -42,7 +42,7 @@ openvpn:
   pass-through:
     enabled: true
     address: "unix:///run/openvpn/pass-through.sock"
-    password: "secret"
+    #password: "secret" # optional
     #socket-group: "openvpn-auth-oauth2" # optional
     #socket-mode: 660 # optional
 ```
@@ -51,7 +51,7 @@ openvpn:
 
 ## Command Forwarding
 
-openvpn-auth-oauth2 forwards OpenVPN management commands through the pass-through socket after the client authenticates with the configured pass-through password. Treat this socket as an administrator interface: a client with access can run powerful OpenVPN management commands such as disconnecting clients, changing daemon state, and entering dynamic credentials.
+openvpn-auth-oauth2 forwards OpenVPN management commands through the pass-through socket. If `openvpn.pass-through.password` is configured, the client must authenticate with that password before commands are accepted. If it is not configured, commands are accepted immediately after connecting. Treat this socket as an administrator interface: a client with access can run powerful OpenVPN management commands such as disconnecting clients, changing daemon state, and entering dynamic credentials.
 
 The local session commands `hold`, `exit`, and `quit` are handled by openvpn-auth-oauth2 itself and are not forwarded to OpenVPN.
 
@@ -62,4 +62,4 @@ Authentication decision commands are reserved for openvpn-auth-oauth2 because th
 - `client-deny`
 - `client-pending-auth`
 
-If a client sends a reserved command, openvpn-auth-oauth2 will respond with "ERROR: command not allowed" and log a warning message. Use a Unix socket with restrictive filesystem permissions, or otherwise restrict the listener to trusted administrator clients only.
+If a client sends a reserved command, openvpn-auth-oauth2 will respond with "ERROR: command not allowed" and log a warning message. Use a Unix socket with restrictive filesystem permissions, or otherwise restrict the listener to trusted administrator clients only. This is especially important when no pass-through password is configured.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -70,7 +70,11 @@ func validateHTTPConfig(conf *Config) error {
 }
 
 // validateOpenVPNConfig validates the OpenVPN configuration.
-func validateOpenVPNConfig(_ *Config) error {
+func validateOpenVPNConfig(conf *Config) error {
+	if conf.OpenVPN.Passthrough.Enabled && conf.OpenVPN.Passthrough.Password.String() == "" {
+		return fmt.Errorf("openvpn.pass-through.password is %w", ErrRequired)
+	}
+
 	return nil
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -15,10 +15,6 @@ func Validate(mode int, conf *Config) error {
 		return err
 	}
 
-	if err := validateOpenVPNConfig(conf); err != nil {
-		return err
-	}
-
 	if err := validateHTTPConfig(conf); err != nil {
 		return err
 	}
@@ -64,15 +60,6 @@ func validateHTTPConfig(conf *Config) error {
 		"errorID": "",
 	}); err != nil {
 		return fmt.Errorf("invalid rendering http.template: %w", err)
-	}
-
-	return nil
-}
-
-// validateOpenVPNConfig validates the OpenVPN configuration.
-func validateOpenVPNConfig(conf *Config) error {
-	if conf.OpenVPN.Passthrough.Enabled && conf.OpenVPN.Passthrough.Password.String() == "" {
-		return fmt.Errorf("openvpn.pass-through.password is %w", ErrRequired)
 	}
 
 	return nil

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -258,6 +258,15 @@ func TestValidate(t *testing.T) {
 			}(),
 			"",
 		},
+		{
+			func() config.Config {
+				conf := validConfig()
+				conf.OpenVPN.Passthrough.Enabled = true
+
+				return conf
+			}(),
+			"openvpn.pass-through.password is required",
+		},
 	} {
 		t.Run(tc.err, func(t *testing.T) {
 			t.Parallel()

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -265,7 +265,7 @@ func TestValidate(t *testing.T) {
 
 				return conf
 			}(),
-			"openvpn.pass-through.password is required",
+			"",
 		},
 	} {
 		t.Run(tc.err, func(t *testing.T) {

--- a/internal/managementauth/auth.go
+++ b/internal/managementauth/auth.go
@@ -1,0 +1,77 @@
+package managementauth
+
+import (
+	"bufio"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	passwordPrompt           = "ENTER PASSWORD:"
+	badPasswordResponse      = "ERROR: bad password\r\n"
+	passwordAcceptedResponse = "SUCCESS: password is correct\r\n"
+)
+
+// ErrInvalidPassword reports that a management client provided the wrong password.
+var ErrInvalidPassword = errors.New("client provide invalid password")
+
+// Authenticate validates an optional OpenVPN management password exchange.
+func Authenticate(conn net.Conn, scanner *bufio.Scanner, password string, timeout time.Duration) error {
+	if password == "" {
+		return nil
+	}
+
+	if err := writeWithDeadline(conn, timeout, passwordPrompt); err != nil {
+		return err
+	}
+
+	passwordLine, err := readPasswordLine(conn, scanner, timeout)
+	if err != nil {
+		return err
+	}
+
+	if subtle.ConstantTimeCompare(passwordLine, []byte(password)) == 0 {
+		_ = writeWithDeadline(conn, timeout, badPasswordResponse)
+
+		return ErrInvalidPassword
+	}
+
+	return writeWithDeadline(conn, timeout, passwordAcceptedResponse)
+}
+
+func readPasswordLine(conn net.Conn, scanner *bufio.Scanner, timeout time.Duration) ([]byte, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, fmt.Errorf("unable to set read deadline: %w", err)
+	}
+
+	if !scanner.Scan() {
+		err := scanner.Err()
+		if err == nil {
+			err = io.EOF
+		}
+
+		return nil, fmt.Errorf("unable to read from client: %w", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return nil, fmt.Errorf("unable to clear read deadline: %w", err)
+	}
+
+	return scanner.Bytes(), nil
+}
+
+func writeWithDeadline(conn net.Conn, timeout time.Duration, message string) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+		return fmt.Errorf("unable to set write deadline: %w", err)
+	}
+
+	if _, err := conn.Write([]byte(message)); err != nil {
+		return fmt.Errorf("unable to write to client: %w", err)
+	}
+
+	return nil
+}

--- a/internal/openvpn/bench_test.go
+++ b/internal/openvpn/bench_test.go
@@ -74,6 +74,7 @@ func BenchmarkOpenVPNPassthrough(b *testing.B) {
 	conf := config.Defaults
 	conf.OpenVPN.Passthrough.Enabled = true
 	conf.OpenVPN.Passthrough.Address = types.URL{URL: &url.URL{Scheme: "tcp", Host: "127.0.0.1:0"}}
+	conf.OpenVPN.Passthrough.Password = testsuite.Secret
 
 	suite := testsuite.New(&conf)
 	errOpenVPNClientCh := suite.SetupManagementEnvironment(b.Context(), b, nil)
@@ -104,6 +105,13 @@ func BenchmarkOpenVPNPassthrough(b *testing.B) {
 	require.NoError(b, err)
 
 	passThroughConn := testsuite.NewConn(passThroughNetConn)
+
+	buf := make([]byte, len("ENTER PASSWORD:"))
+	_, err = passThroughNetConn.Read(buf)
+	require.NoError(b, err)
+	require.Equal(b, "ENTER PASSWORD:", string(buf))
+
+	passThroughConn.SendAndExpectMessage(b, testsuite.Secret, "SUCCESS: password is correct")
 
 	tests := []struct {
 		command  string

--- a/internal/openvpn/handler.go
+++ b/internal/openvpn/handler.go
@@ -58,7 +58,7 @@ func (c *Client) handlePassword(ctx context.Context) error {
 
 // sendPassword enters the password on the OpenVPN management interface connection.
 func (c *Client) sendPassword(ctx context.Context) error {
-	if err := c.rawCommand(ctx, c.conf.OpenVPN.Password.String()); err != nil {
+	if err := c.rawCommand(ctx, c.conf.OpenVPN.Password.String(), "management-password"); err != nil {
 		return fmt.Errorf("error from password command: %w", err)
 	}
 
@@ -201,7 +201,7 @@ func (c *Client) handleCommands(ctx context.Context, errCh chan<- error) {
 				return
 			}
 
-			if err := c.rawCommand(ctx, command); err != nil {
+			if err := c.rawCommand(ctx, command, managementCommandName(command)); err != nil {
 				errCh <- err
 
 				return

--- a/internal/openvpn/main.go
+++ b/internal/openvpn/main.go
@@ -248,25 +248,20 @@ func (c *Client) SendCommand(ctx context.Context, cmd string, passthrough bool) 
 		}
 
 		if resp == "" {
-			cmdFirstLine := strings.SplitN(cmd, "\r\n", 2)[0]
-
-			return "", fmt.Errorf("command error '%s': %w", cmdFirstLine, ErrEmptyResponse)
+			return "", fmt.Errorf("command error '%s': %w", managementCommandForError(cmd, passthrough), ErrEmptyResponse)
 		}
 
 		if strings.HasPrefix(resp, "ERROR:") {
-			cmdFirstLine := strings.SplitN(cmd, "\r\n", 2)[0]
 			c.logger.LogAttrs(
 				ctx, slog.LevelWarn, "command error",
-				slog.String("command", cmdFirstLine),
+				slog.String("command", managementCommandForError(cmd, passthrough)),
 				slog.String("response", resp),
 			)
 		}
 
 		return resp, nil
 	case <-time.After(c.conf.OpenVPN.CommandTimeout):
-		cmdFirstLine := strings.SplitN(cmd, "\r\n", 2)[0]
-
-		return "", fmt.Errorf("command error '%s': %w", cmdFirstLine, ErrTimeout)
+		return "", fmt.Errorf("command error '%s': %w", managementCommandForError(cmd, passthrough), ErrTimeout)
 	}
 }
 
@@ -276,9 +271,9 @@ func (c *Client) SendCommandf(ctx context.Context, format string, a ...any) (str
 }
 
 // rawCommand writes a command followed by CRLF to the management interface.
-func (c *Client) rawCommand(ctx context.Context, cmd string) error {
+func (c *Client) rawCommand(ctx context.Context, cmd, logCommand string) error {
 	if c.logger.Enabled(ctx, slog.LevelDebug) {
-		c.logger.LogAttrs(ctx, slog.LevelDebug, "send command", slog.String("command", cmd))
+		c.logger.LogAttrs(ctx, slog.LevelDebug, "send command", slog.String("command", logCommand))
 	}
 
 	c.commandsBuffer.Reset()
@@ -294,6 +289,25 @@ func (c *Client) rawCommand(ctx context.Context, cmd string) error {
 	}
 
 	return nil
+}
+
+func managementCommandForError(cmd string, passthrough bool) string {
+	if passthrough {
+		return managementCommandName(cmd)
+	}
+
+	return strings.SplitN(cmd, "\r\n", 2)[0]
+}
+
+func managementCommandName(cmd string) string {
+	cmdFirstLine := strings.SplitN(cmd, "\r\n", 2)[0]
+
+	fields := strings.Fields(cmdFirstLine)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	return fields[0]
 }
 
 // readMessage .

--- a/internal/openvpn/passthrough.go
+++ b/internal/openvpn/passthrough.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -189,12 +188,12 @@ func (c *Client) handlePassThroughClientCommands(ctx context.Context, conn net.C
 			continue
 		}
 
-		logger.LogAttrs(ctx, slog.LevelDebug, "received command", slog.String("command", passThroughCommandName(line)))
+		logger.LogAttrs(ctx, slog.LevelDebug, "received command", slog.String("command", managementCommandName(line)))
 
 		switch {
-		case strings.HasPrefix(line, "client-deny"), strings.HasPrefix(line, "client-auth"):
+		case passThroughCommandReserved(line):
 			c.writeToPassThroughClient("ERROR: command not allowed")
-			logger.LogAttrs(ctx, slog.LevelWarn, "pass-through: client send client-deny or client-auth message, ignoring...")
+			logger.LogAttrs(ctx, slog.LevelWarn, "pass-through: reserved command rejected", slog.String("command", managementCommandName(line)))
 
 			continue
 		case line == "hold":
@@ -205,16 +204,17 @@ func (c *Client) handlePassThroughClientCommands(ctx context.Context, conn net.C
 			_ = conn.Close()
 
 			return nil
-		case !passThroughCommandAllowed(line):
-			c.writeToPassThroughClient("ERROR: command not allowed")
-			logger.LogAttrs(ctx, slog.LevelWarn, "pass-through: command not allowed", slog.String("command", passThroughCommandName(line)))
-
-			continue
 		}
 
 		resp, err = c.SendCommand(ctx, line, true)
 		if err != nil {
-			logger.LogAttrs(ctx, slog.LevelWarn, fmt.Errorf("pass-through: error from command '%s': %w", line, err).Error())
+			logger.LogAttrs(
+				ctx,
+				slog.LevelWarn,
+				"pass-through: command failed",
+				slog.String("command", managementCommandName(line)),
+				slog.String("err", err.Error()),
+			)
 		} else {
 			c.writeToPassThroughClient(strings.TrimSpace(resp))
 		}
@@ -227,36 +227,10 @@ func (c *Client) handlePassThroughClientCommands(ctx context.Context, conn net.C
 	return nil
 }
 
-func passThroughCommandName(line string) string {
-	fields := strings.Fields(line)
-	if len(fields) == 0 {
-		return ""
-	}
-
-	return fields[0]
-}
-
-func passThroughCommandAllowed(line string) bool {
-	fields := strings.Fields(line)
-	if len(fields) == 0 {
-		return false
-	}
-
-	switch fields[0] {
-	case "help", "load-stats", "pid", "version":
-		return len(fields) == 1
-	case "status":
-		if len(fields) == 1 {
-			return true
-		}
-
-		if len(fields) != 2 {
-			return false
-		}
-
-		statusVersion, err := strconv.Atoi(fields[1])
-
-		return err == nil && statusVersion >= 0
+func passThroughCommandReserved(line string) bool {
+	switch strings.ToLower(managementCommandName(line)) {
+	case "client-auth", "client-auth-nt", "client-deny", "client-pending-auth":
+		return true
 	default:
 		return false
 	}

--- a/internal/openvpn/passthrough.go
+++ b/internal/openvpn/passthrough.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -188,7 +189,7 @@ func (c *Client) handlePassThroughClientCommands(ctx context.Context, conn net.C
 			continue
 		}
 
-		logger.LogAttrs(ctx, slog.LevelDebug, "received command", slog.String("command", line))
+		logger.LogAttrs(ctx, slog.LevelDebug, "received command", slog.String("command", passThroughCommandName(line)))
 
 		switch {
 		case strings.HasPrefix(line, "client-deny"), strings.HasPrefix(line, "client-auth"):
@@ -204,6 +205,11 @@ func (c *Client) handlePassThroughClientCommands(ctx context.Context, conn net.C
 			_ = conn.Close()
 
 			return nil
+		case !passThroughCommandAllowed(line):
+			c.writeToPassThroughClient("ERROR: command not allowed")
+			logger.LogAttrs(ctx, slog.LevelWarn, "pass-through: command not allowed", slog.String("command", passThroughCommandName(line)))
+
+			continue
 		}
 
 		resp, err = c.SendCommand(ctx, line, true)
@@ -221,9 +227,44 @@ func (c *Client) handlePassThroughClientCommands(ctx context.Context, conn net.C
 	return nil
 }
 
+func passThroughCommandName(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	return fields[0]
+}
+
+func passThroughCommandAllowed(line string) bool {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return false
+	}
+
+	switch fields[0] {
+	case "help", "load-stats", "pid", "version":
+		return len(fields) == 1
+	case "status":
+		if len(fields) == 1 {
+			return true
+		}
+
+		if len(fields) != 2 {
+			return false
+		}
+
+		statusVersion, err := strconv.Atoi(fields[1])
+
+		return err == nil && statusVersion >= 0
+	default:
+		return false
+	}
+}
+
 func (c *Client) handlePassThroughClientAuth(_ context.Context, conn net.Conn, scanner *bufio.Scanner) error {
 	if c.conf.OpenVPN.Passthrough.Password.String() == "" {
-		return nil
+		return errors.New("pass-through: password is required")
 	}
 
 	if err := conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
@@ -235,12 +276,20 @@ func (c *Client) handlePassThroughClientAuth(_ context.Context, conn net.Conn, s
 		return fmt.Errorf("unable to write to client: %w", err)
 	}
 
+	if err := conn.SetReadDeadline(time.Now().Add(writeTimeout)); err != nil {
+		return fmt.Errorf("unable to set read deadline: %w", err)
+	}
+
 	if !scanner.Scan() {
 		if err = scanner.Err(); err == nil {
 			err = io.EOF
 		}
 
 		return fmt.Errorf("pass-through: unable to read from client: %w", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return fmt.Errorf("unable to clear read deadline: %w", err)
 	}
 
 	if subtle.ConstantTimeCompare(scanner.Bytes(), []byte(c.conf.OpenVPN.Passthrough.Password.String())) == 0 {

--- a/internal/openvpn/passthrough.go
+++ b/internal/openvpn/passthrough.go
@@ -238,7 +238,7 @@ func passThroughCommandReserved(line string) bool {
 
 func (c *Client) handlePassThroughClientAuth(_ context.Context, conn net.Conn, scanner *bufio.Scanner) error {
 	if c.conf.OpenVPN.Passthrough.Password.String() == "" {
-		return errors.New("pass-through: password is required")
+		return nil
 	}
 
 	if err := conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {

--- a/internal/openvpn/passthrough.go
+++ b/internal/openvpn/passthrough.go
@@ -3,10 +3,8 @@ package openvpn
 import (
 	"bufio"
 	"context"
-	"crypto/subtle"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net"
 	"os"
@@ -15,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/managementauth"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
 )
 
@@ -237,47 +236,9 @@ func passThroughCommandReserved(line string) bool {
 }
 
 func (c *Client) handlePassThroughClientAuth(_ context.Context, conn net.Conn, scanner *bufio.Scanner) error {
-	if c.conf.OpenVPN.Passthrough.Password.String() == "" {
-		return nil
-	}
-
-	if err := conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
-		return fmt.Errorf("unable to set write deadline: %w", err)
-	}
-
-	_, err := conn.Write([]byte("ENTER PASSWORD:"))
+	err := managementauth.Authenticate(conn, scanner, c.conf.OpenVPN.Passthrough.Password.String(), writeTimeout)
 	if err != nil {
-		return fmt.Errorf("unable to write to client: %w", err)
-	}
-
-	if err := conn.SetReadDeadline(time.Now().Add(writeTimeout)); err != nil {
-		return fmt.Errorf("unable to set read deadline: %w", err)
-	}
-
-	if !scanner.Scan() {
-		if err = scanner.Err(); err == nil {
-			err = io.EOF
-		}
-
-		return fmt.Errorf("pass-through: unable to read from client: %w", err)
-	}
-
-	if err := conn.SetReadDeadline(time.Time{}); err != nil {
-		return fmt.Errorf("unable to clear read deadline: %w", err)
-	}
-
-	if subtle.ConstantTimeCompare(scanner.Bytes(), []byte(c.conf.OpenVPN.Passthrough.Password.String())) == 0 {
-		_ = conn.SetWriteDeadline(time.Now().Add(writeTimeout))
-		_, _ = conn.Write([]byte("ERROR: bad password\r\n"))
-
-		return errors.New("pass-through: client provide invalid password")
-	}
-
-	_ = conn.SetWriteDeadline(time.Now().Add(writeTimeout))
-
-	_, err = conn.Write([]byte("SUCCESS: password is correct\r\n"))
-	if err != nil {
-		return fmt.Errorf("unable to write to client: %w", err)
+		return fmt.Errorf("pass-through: %w", err)
 	}
 
 	return nil

--- a/internal/openvpn/passthrough_test.go
+++ b/internal/openvpn/passthrough_test.go
@@ -119,6 +119,7 @@ func TestPassThroughFull(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.Log.Level = slog.LevelDebug
 				conf.OpenVPN.Passthrough.Enabled = true
+				conf.OpenVPN.Passthrough.Password = testsuite.Secret
 
 				return conf
 			}(),
@@ -131,6 +132,7 @@ func TestPassThroughFull(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.Log.Level = slog.LevelDebug
 				conf.OpenVPN.Passthrough.Enabled = true
+				conf.OpenVPN.Passthrough.Password = testsuite.Secret
 				conf.OpenVPN.Passthrough.SocketMode = 0o0600
 				conf.OpenVPN.Passthrough.SocketGroup = strconv.Itoa(os.Getgid())
 
@@ -260,25 +262,23 @@ func TestPassThroughFull(t *testing.T) {
 				passThroughConn.ExpectMessage(t, "SUCCESS: pid=7")
 
 				// unknown command
-				passThroughConn.SendMessagef(t, "foo")
-				suite.ExpectMessage(t, "foo")
-				suite.SendMessagef(t, "ERROR: unknown command, enter 'help' for more options")
-				passThroughConn.ExpectMessage(t, "ERROR: unknown command, enter 'help' for more options")
+				passThroughConn.SendAndExpectMessage(t, "foo", "ERROR: command not allowed")
 
 				// kill 1
-				passThroughConn.SendMessagef(t, "kill 1")
-				suite.ExpectMessage(t, "kill 1")
-				suite.SendMessagef(t, "ERROR: common name '1' not found")
-				passThroughConn.ExpectMessage(t, "ERROR: common name '1' not found")
+				passThroughConn.SendAndExpectMessage(t, "kill 1", "ERROR: command not allowed")
 
 				// client-auth-nt 1
 				passThroughConn.SendAndExpectMessage(t, "client-auth-nt 1", "ERROR: command not allowed")
 
 				// client-kill 1
-				passThroughConn.SendMessagef(t, "client-kill 1")
-				suite.ExpectMessage(t, "client-kill 1")
-				suite.SendMessagef(t, "ERROR: client-kill command failed")
-				passThroughConn.ExpectMessage(t, "ERROR: client-kill command failed")
+				passThroughConn.SendAndExpectMessage(t, "client-kill 1", "ERROR: command not allowed")
+
+				// version with argument changes client version
+				passThroughConn.SendAndExpectMessage(t, "version 3", "ERROR: command not allowed")
+
+				// rejected secret-bearing commands must not log the secret value
+				passThroughConn.SendAndExpectMessage(t, "password Auth super-secret-value", "ERROR: command not allowed")
+				require.NotContains(t, suite.Logs(), "super-secret-value")
 
 				// version
 				passThroughConn.SendMessagef(t, "version")

--- a/internal/openvpn/passthrough_test.go
+++ b/internal/openvpn/passthrough_test.go
@@ -3,6 +3,7 @@ package openvpn_test
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"regexp"
@@ -262,22 +263,40 @@ func TestPassThroughFull(t *testing.T) {
 				passThroughConn.ExpectMessage(t, "SUCCESS: pid=7")
 
 				// unknown command
-				passThroughConn.SendAndExpectMessage(t, "foo", "ERROR: command not allowed")
+				passThroughConn.SendMessagef(t, "foo")
+				suite.ExpectMessage(t, "foo")
+				suite.SendMessagef(t, "ERROR: unknown command, enter 'help' for more options")
+				passThroughConn.ExpectMessage(t, "ERROR: unknown command, enter 'help' for more options")
 
 				// kill 1
-				passThroughConn.SendAndExpectMessage(t, "kill 1", "ERROR: command not allowed")
+				passThroughConn.SendMessagef(t, "kill 1")
+				suite.ExpectMessage(t, "kill 1")
+				suite.SendMessagef(t, "SUCCESS: common name '1' killed")
+				passThroughConn.ExpectMessage(t, "SUCCESS: common name '1' killed")
 
-				// client-auth-nt 1
+				// auth decision commands are owned by openvpn-auth-oauth2.
+				passThroughConn.SendAndExpectMessage(t, "client-auth 1 2", "ERROR: command not allowed")
 				passThroughConn.SendAndExpectMessage(t, "client-auth-nt 1", "ERROR: command not allowed")
+				passThroughConn.SendAndExpectMessage(t, "client-deny 1 2 reason", "ERROR: command not allowed")
+				passThroughConn.SendAndExpectMessage(t, "client-pending-auth 1 2 msg 10", "ERROR: command not allowed")
 
 				// client-kill 1
-				passThroughConn.SendAndExpectMessage(t, "client-kill 1", "ERROR: command not allowed")
+				passThroughConn.SendMessagef(t, "client-kill 1")
+				suite.ExpectMessage(t, "client-kill 1")
+				suite.SendMessagef(t, "ERROR: client-kill command failed")
+				passThroughConn.ExpectMessage(t, "ERROR: client-kill command failed")
 
 				// version with argument changes client version
-				passThroughConn.SendAndExpectMessage(t, "version 3", "ERROR: command not allowed")
+				passThroughConn.SendMessagef(t, "version 3")
+				suite.ExpectMessage(t, "version 3")
+				suite.SendMessagef(t, "SUCCESS: version=3")
+				passThroughConn.ExpectMessage(t, "SUCCESS: version=3")
 
-				// rejected secret-bearing commands must not log the secret value
-				passThroughConn.SendAndExpectMessage(t, "password Auth super-secret-value", "ERROR: command not allowed")
+				// Forwarded secret-bearing commands must not log the secret value.
+				passThroughConn.SendMessagef(t, "password Auth super-secret-value")
+				suite.ExpectMessage(t, "password Auth super-secret-value")
+				suite.SendMessagef(t, "SUCCESS: password is correct")
+				passThroughConn.ExpectMessage(t, "SUCCESS: password is correct")
 				require.NotContains(t, suite.Logs(), "super-secret-value")
 
 				// version
@@ -333,4 +352,79 @@ func TestPassThroughFull(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPassThroughCommandTimeoutSanitizesLogs(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	conf := config.Defaults
+	conf.HTTP.Secret = testsuite.Secret
+	conf.Log.Level = slog.LevelDebug
+	conf.OpenVPN.CommandTimeout = 100 * time.Millisecond
+	conf.OpenVPN.Passthrough.Enabled = true
+	conf.OpenVPN.Passthrough.Address = types.URL{URL: &url.URL{Scheme: openvpn.SchemeTCP, Host: "127.0.0.1:0"}}
+	conf.OpenVPN.Passthrough.Password = testsuite.Secret
+
+	suite := testsuite.New(&conf)
+	errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, t, nil)
+	openVPNClient := suite.GetOpenVPNClient()
+
+	var passThroughNetConn net.Conn
+
+	t.Cleanup(func() {
+		if passThroughNetConn != nil {
+			require.NoError(t, passThroughNetConn.Close())
+		}
+
+		openVPNClient.Shutdown(t.Context())
+
+		select {
+		case err := <-errOpenVPNClientCh:
+			require.NoError(t, err, suite.Logs())
+		case <-time.After(1 * time.Second):
+			t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
+		}
+	})
+
+	suite.ExpectVersionAndReleaseHold(t)
+
+	var passThroughAddr []string
+
+	require.Eventually(t, func() bool {
+		passThroughAddr = rePassThroughLogListen.FindStringSubmatch(suite.Logs())
+
+		return passThroughAddr != nil
+	}, time.Second, 50*time.Millisecond)
+
+	require.Len(t, passThroughAddr, 2, "unexpected log output: %s", suite.Logs())
+
+	var err error
+
+	passThroughNetConn, err = testsuite.WaitUntilListening(ctx, t, openvpn.SchemeTCP, passThroughAddr[1])
+	require.NoError(t, err)
+
+	passThroughConn := testsuite.NewConn(passThroughNetConn).WithLogs(suite.Logs)
+
+	buf := make([]byte, 15)
+	_, err = passThroughNetConn.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "ENTER PASSWORD:", string(buf))
+
+	passThroughConn.SendAndExpectMessage(t, testsuite.Secret, "SUCCESS: password is correct")
+	passThroughConn.ExpectMessage(t, openvpn.WelcomeBanner)
+
+	passThroughConn.SendMessagef(t, "password Auth super-secret-value")
+	suite.ExpectMessage(t, "password Auth super-secret-value")
+
+	require.Eventually(t, func() bool {
+		logs := suite.Logs()
+
+		return strings.Contains(logs, "pass-through: command failed") &&
+			strings.Contains(logs, "command error 'password'")
+	}, time.Second, 10*time.Millisecond, suite.Logs())
+
+	require.NotContains(t, suite.Logs(), "super-secret-value")
 }

--- a/internal/openvpn/passthrough_test.go
+++ b/internal/openvpn/passthrough_test.go
@@ -108,32 +108,21 @@ func TestPassThroughFull(t *testing.T) {
 	t.Parallel()
 
 	configs := []struct {
-		name   string
-		scheme string
-		conf   config.Config
+		name            string
+		scheme          string
+		conf            config.Config
+		invalidPassword bool
 	}{
 		{
-			name:   "tcp default",
+			name:   "tcp without password",
 			scheme: openvpn.SchemeTCP,
-			conf: func() config.Config {
-				conf := config.Defaults
-				conf.HTTP.Secret = testsuite.Secret
-				conf.Log.Level = slog.LevelDebug
-				conf.OpenVPN.Passthrough.Enabled = true
-				conf.OpenVPN.Passthrough.Password = testsuite.Secret
-
-				return conf
-			}(),
+			conf:   newPassThroughTestConfig(""),
 		},
 		{
-			name:   "unix default",
+			name:   "unix with password",
 			scheme: openvpn.SchemeUnix,
 			conf: func() config.Config {
-				conf := config.Defaults
-				conf.HTTP.Secret = testsuite.Secret
-				conf.Log.Level = slog.LevelDebug
-				conf.OpenVPN.Passthrough.Enabled = true
-				conf.OpenVPN.Passthrough.Password = testsuite.Secret
+				conf := newPassThroughTestConfig(testsuite.Secret)
 				conf.OpenVPN.Passthrough.SocketMode = 0o0600
 				conf.OpenVPN.Passthrough.SocketGroup = strconv.Itoa(os.Getgid())
 
@@ -143,28 +132,13 @@ func TestPassThroughFull(t *testing.T) {
 		{
 			name:   "tcp with password",
 			scheme: openvpn.SchemeTCP,
-			conf: func() config.Config {
-				conf := config.Defaults
-				conf.HTTP.Secret = testsuite.Secret
-				conf.Log.Level = slog.LevelDebug
-				conf.OpenVPN.Passthrough.Enabled = true
-				conf.OpenVPN.Passthrough.Password = testsuite.Secret
-
-				return conf
-			}(),
+			conf:   newPassThroughTestConfig(testsuite.Secret),
 		},
 		{
-			name:   "tcp with invalid password",
-			scheme: openvpn.SchemeTCP,
-			conf: func() config.Config {
-				conf := config.Defaults
-				conf.HTTP.Secret = testsuite.Secret
-				conf.Log.Level = slog.LevelDebug
-				conf.OpenVPN.Passthrough.Enabled = true
-				conf.OpenVPN.Passthrough.Password = testsuite.Secret
-
-				return conf
-			}(),
+			name:            "tcp with invalid password",
+			scheme:          openvpn.SchemeTCP,
+			conf:            newPassThroughTestConfig(testsuite.Secret),
+			invalidPassword: true,
 		},
 	}
 
@@ -175,76 +149,9 @@ func TestPassThroughFull(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			t.Cleanup(cancel)
 
-			if tc.scheme == openvpn.SchemeUnix && runtime.GOOS == "windows" {
-				t.Skip("skipping test on windows")
-			}
-
-			switch tc.scheme {
-			case openvpn.SchemeTCP:
-				tc.conf.OpenVPN.Passthrough.Address = types.URL{URL: &url.URL{Scheme: tc.scheme, Host: "127.0.0.1:0"}}
-			case openvpn.SchemeUnix:
-				temp, err := nettest.LocalPath()
-				require.NoError(t, err)
-
-				tc.conf.OpenVPN.Passthrough.Address = types.URL{URL: &url.URL{Scheme: tc.scheme, Path: temp}}
-			}
-
-			suite := testsuite.New(&tc.conf)
-			errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, t, nil)
-			openVPNClient := suite.GetOpenVPNClient()
-
-			t.Cleanup(func() {
-				openVPNClient.Shutdown(t.Context())
-
-				select {
-				case err := <-errOpenVPNClientCh:
-					require.NoError(t, err)
-				case <-time.After(1 * time.Second):
-					t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
-				}
-			})
-
-			if tc.conf.OpenVPN.Password != "" {
-				suite.SendMessagef(t, "ENTER PASSWORD:")
-				suite.ExpectMessage(t, tc.conf.OpenVPN.Password.String())
-
-				suite.SendMessagef(t, "SUCCESS: password is correct")
-			}
-
-			suite.ExpectVersionAndReleaseHold(t)
-			suite.SendMessagef(t, "")
-			suite.SendMessagef(t, "\r\n")
-
-			var passThroughAddr []string
-
-			require.Eventually(t, func() bool {
-				passThroughAddr = rePassThroughLogListen.FindStringSubmatch(suite.Logs())
-
-				return passThroughAddr != nil
-			}, time.Second, 50*time.Millisecond)
-
-			require.Len(t, passThroughAddr, 2, "unexpected log output: %s", suite.Logs())
-
-			passThroughNetConn, err := testsuite.WaitUntilListening(ctx, t, tc.scheme, passThroughAddr[1])
-			require.NoError(t, err)
-
-			passThroughConn := testsuite.NewConn(passThroughNetConn)
-
-			if tc.conf.OpenVPN.Passthrough.Password != "" {
-				buf := make([]byte, 15)
-
-				_, err = passThroughNetConn.Read(buf)
-				require.NoError(t, err)
-
-				require.Equal(t, "ENTER PASSWORD:", string(buf))
-
-				if strings.Contains(tc.name, "invalid") {
-					passThroughConn.SendAndExpectMessage(t, "invalid", "ERROR: bad password")
-
-					return
-				}
-
-				passThroughConn.SendAndExpectMessage(t, tc.conf.OpenVPN.Passthrough.Password.String(), "SUCCESS: password is correct")
+			suite, passThroughConn, passThroughNetConn := setupPassThroughConnection(t, ctx, tc.scheme, &tc.conf)
+			if !authenticatePassThroughConnection(t, tc.conf, passThroughNetConn, passThroughConn, tc.invalidPassword) {
+				return
 			}
 
 			passThroughConn.ExpectMessage(t, openvpn.WelcomeBanner)
@@ -257,22 +164,13 @@ func TestPassThroughFull(t *testing.T) {
 				passThroughConn.SendAndExpectMessage(t, "hold", "SUCCESS: hold release succeeded")
 
 				// PID
-				passThroughConn.SendMessagef(t, "pid")
-				suite.ExpectMessage(t, "pid")
-				suite.SendMessagef(t, "SUCCESS: pid=7")
-				passThroughConn.ExpectMessage(t, "SUCCESS: pid=7")
+				forwardPassThroughCommand(t, suite, passThroughConn, "pid", "SUCCESS: pid=7")
 
 				// unknown command
-				passThroughConn.SendMessagef(t, "foo")
-				suite.ExpectMessage(t, "foo")
-				suite.SendMessagef(t, "ERROR: unknown command, enter 'help' for more options")
-				passThroughConn.ExpectMessage(t, "ERROR: unknown command, enter 'help' for more options")
+				forwardPassThroughCommand(t, suite, passThroughConn, "foo", "ERROR: unknown command, enter 'help' for more options")
 
 				// kill 1
-				passThroughConn.SendMessagef(t, "kill 1")
-				suite.ExpectMessage(t, "kill 1")
-				suite.SendMessagef(t, "SUCCESS: common name '1' killed")
-				passThroughConn.ExpectMessage(t, "SUCCESS: common name '1' killed")
+				forwardPassThroughCommand(t, suite, passThroughConn, "kill 1", "SUCCESS: common name '1' killed")
 
 				// auth decision commands are owned by openvpn-auth-oauth2.
 				passThroughConn.SendAndExpectMessage(t, "client-auth 1 2", "ERROR: command not allowed")
@@ -281,55 +179,31 @@ func TestPassThroughFull(t *testing.T) {
 				passThroughConn.SendAndExpectMessage(t, "client-pending-auth 1 2 msg 10", "ERROR: command not allowed")
 
 				// client-kill 1
-				passThroughConn.SendMessagef(t, "client-kill 1")
-				suite.ExpectMessage(t, "client-kill 1")
-				suite.SendMessagef(t, "ERROR: client-kill command failed")
-				passThroughConn.ExpectMessage(t, "ERROR: client-kill command failed")
+				forwardPassThroughCommand(t, suite, passThroughConn, "client-kill 1", "ERROR: client-kill command failed")
 
 				// version with argument changes client version
-				passThroughConn.SendMessagef(t, "version 3")
-				suite.ExpectMessage(t, "version 3")
-				suite.SendMessagef(t, "SUCCESS: version=3")
-				passThroughConn.ExpectMessage(t, "SUCCESS: version=3")
+				forwardPassThroughCommand(t, suite, passThroughConn, "version 3", "SUCCESS: version=3")
 
 				// Forwarded secret-bearing commands must not log the secret value.
-				passThroughConn.SendMessagef(t, "password Auth super-secret-value")
-				suite.ExpectMessage(t, "password Auth super-secret-value")
-				suite.SendMessagef(t, "SUCCESS: password is correct")
-				passThroughConn.ExpectMessage(t, "SUCCESS: password is correct")
+				forwardPassThroughCommand(t, suite, passThroughConn, "password Auth super-secret-value", "SUCCESS: password is correct")
 				require.NotContains(t, suite.Logs(), "super-secret-value")
 
 				// version
-				passThroughConn.SendMessagef(t, "version")
-				suite.ExpectMessage(t, "version")
-				suite.SendMessagef(t, "OpenVPN Version: openvpn-auth-oauth2\r\nManagement Interface Version: 5\r\nEND")
-				passThroughConn.ExpectMessage(t, "OpenVPN Version: openvpn-auth-oauth2\r\nManagement Interface Version: 5\r\nEND")
+				forwardPassThroughCommand(t, suite, passThroughConn, "version", "OpenVPN Version: openvpn-auth-oauth2\r\nManagement Interface Version: 5\r\nEND")
 
 				// status
-				passThroughConn.SendMessagef(t, "status")
-				suite.ExpectMessage(t, "status")
-				suite.SendMessagef(t, OpenVPNManagementInterfaceCommandResultStatus)
-				passThroughConn.ExpectMessage(t, OpenVPNManagementInterfaceCommandResultStatus)
+				forwardPassThroughCommand(t, suite, passThroughConn, "status", OpenVPNManagementInterfaceCommandResultStatus)
 
 				// status 2
-				passThroughConn.SendMessagef(t, "status 2")
-				suite.ExpectMessage(t, "status 2")
-				suite.SendMessagef(t, OpenVPNManagementInterfaceCommandResultStatus2)
-				passThroughConn.ExpectMessage(t, OpenVPNManagementInterfaceCommandResultStatus2)
+				forwardPassThroughCommand(t, suite, passThroughConn, "status 2", OpenVPNManagementInterfaceCommandResultStatus2)
 
 				// status 3
-				passThroughConn.SendMessagef(t, "status 3")
-				suite.ExpectMessage(t, "status 3")
-				suite.SendMessagef(t, OpenVPNManagementInterfaceCommandResultStatus3)
-				passThroughConn.ExpectMessage(t, OpenVPNManagementInterfaceCommandResultStatus3)
+				forwardPassThroughCommand(t, suite, passThroughConn, "status 3", OpenVPNManagementInterfaceCommandResultStatus3)
 			}
 
 			// help
 			for range 10 {
-				passThroughConn.SendMessagef(t, "help")
-				suite.ExpectMessage(t, "help")
-				suite.SendMessagef(t, OpenVPNManagementInterfaceCommandResultHelp)
-				passThroughConn.ExpectMessage(t, OpenVPNManagementInterfaceCommandResultHelp)
+				forwardPassThroughCommand(t, suite, passThroughConn, "help", OpenVPNManagementInterfaceCommandResultHelp)
 			}
 
 			if tc.scheme == openvpn.SchemeUnix {
@@ -360,60 +234,11 @@ func TestPassThroughCommandTimeoutSanitizesLogs(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
-	conf := config.Defaults
-	conf.HTTP.Secret = testsuite.Secret
-	conf.Log.Level = slog.LevelDebug
+	conf := newPassThroughTestConfig(testsuite.Secret)
 	conf.OpenVPN.CommandTimeout = 100 * time.Millisecond
-	conf.OpenVPN.Passthrough.Enabled = true
-	conf.OpenVPN.Passthrough.Address = types.URL{URL: &url.URL{Scheme: openvpn.SchemeTCP, Host: "127.0.0.1:0"}}
-	conf.OpenVPN.Passthrough.Password = testsuite.Secret
 
-	suite := testsuite.New(&conf)
-	errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, t, nil)
-	openVPNClient := suite.GetOpenVPNClient()
-
-	var passThroughNetConn net.Conn
-
-	t.Cleanup(func() {
-		if passThroughNetConn != nil {
-			require.NoError(t, passThroughNetConn.Close())
-		}
-
-		openVPNClient.Shutdown(t.Context())
-
-		select {
-		case err := <-errOpenVPNClientCh:
-			require.NoError(t, err, suite.Logs())
-		case <-time.After(1 * time.Second):
-			t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
-		}
-	})
-
-	suite.ExpectVersionAndReleaseHold(t)
-
-	var passThroughAddr []string
-
-	require.Eventually(t, func() bool {
-		passThroughAddr = rePassThroughLogListen.FindStringSubmatch(suite.Logs())
-
-		return passThroughAddr != nil
-	}, time.Second, 50*time.Millisecond)
-
-	require.Len(t, passThroughAddr, 2, "unexpected log output: %s", suite.Logs())
-
-	var err error
-
-	passThroughNetConn, err = testsuite.WaitUntilListening(ctx, t, openvpn.SchemeTCP, passThroughAddr[1])
-	require.NoError(t, err)
-
-	passThroughConn := testsuite.NewConn(passThroughNetConn).WithLogs(suite.Logs)
-
-	buf := make([]byte, 15)
-	_, err = passThroughNetConn.Read(buf)
-	require.NoError(t, err)
-	require.Equal(t, "ENTER PASSWORD:", string(buf))
-
-	passThroughConn.SendAndExpectMessage(t, testsuite.Secret, "SUCCESS: password is correct")
+	suite, passThroughConn, passThroughNetConn := setupPassThroughConnection(t, ctx, openvpn.SchemeTCP, &conf)
+	require.True(t, authenticatePassThroughConnection(t, conf, passThroughNetConn, passThroughConn, false))
 	passThroughConn.ExpectMessage(t, openvpn.WelcomeBanner)
 
 	passThroughConn.SendMessagef(t, "password Auth super-secret-value")
@@ -427,4 +252,129 @@ func TestPassThroughCommandTimeoutSanitizesLogs(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, suite.Logs())
 
 	require.NotContains(t, suite.Logs(), "super-secret-value")
+}
+
+func newPassThroughTestConfig(password string) config.Config {
+	conf := config.Defaults
+	conf.HTTP.Secret = testsuite.Secret
+	conf.Log.Level = slog.LevelDebug
+	conf.OpenVPN.Passthrough.Enabled = true
+	conf.OpenVPN.Passthrough.Password = types.Secret(password)
+
+	return conf
+}
+
+func setupPassThroughConnection(
+	t *testing.T,
+	ctx context.Context,
+	scheme string,
+	conf *config.Config,
+) (*testsuite.Suite, *testsuite.Conn, net.Conn) {
+	t.Helper()
+
+	if scheme == openvpn.SchemeUnix && runtime.GOOS == "windows" {
+		t.Skip("skipping test on windows")
+	}
+
+	switch scheme {
+	case openvpn.SchemeTCP:
+		conf.OpenVPN.Passthrough.Address = types.URL{URL: &url.URL{Scheme: scheme, Host: "127.0.0.1:0"}}
+	case openvpn.SchemeUnix:
+		temp, err := nettest.LocalPath()
+		require.NoError(t, err)
+
+		conf.OpenVPN.Passthrough.Address = types.URL{URL: &url.URL{Scheme: scheme, Path: temp}}
+	}
+
+	suite := testsuite.New(conf)
+	errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, t, nil)
+	openVPNClient := suite.GetOpenVPNClient()
+
+	var passThroughNetConn net.Conn
+
+	t.Cleanup(func() {
+		if passThroughNetConn != nil {
+			_ = passThroughNetConn.Close()
+		}
+
+		openVPNClient.Shutdown(t.Context())
+
+		select {
+		case err := <-errOpenVPNClientCh:
+			require.NoError(t, err, suite.Logs())
+		case <-time.After(1 * time.Second):
+			t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
+		}
+	})
+
+	if conf.OpenVPN.Password != "" {
+		suite.SendMessagef(t, "ENTER PASSWORD:")
+		suite.ExpectMessage(t, conf.OpenVPN.Password.String())
+		suite.SendMessagef(t, "SUCCESS: password is correct")
+	}
+
+	suite.ExpectVersionAndReleaseHold(t)
+	suite.SendMessagef(t, "")
+	suite.SendMessagef(t, "\r\n")
+
+	passThroughNetConn = dialPassThroughConnection(t, ctx, suite, scheme)
+
+	return suite, testsuite.NewConn(passThroughNetConn).WithLogs(suite.Logs), passThroughNetConn
+}
+
+func dialPassThroughConnection(t *testing.T, ctx context.Context, suite *testsuite.Suite, scheme string) net.Conn {
+	t.Helper()
+
+	var passThroughAddr []string
+
+	require.Eventually(t, func() bool {
+		passThroughAddr = rePassThroughLogListen.FindStringSubmatch(suite.Logs())
+
+		return passThroughAddr != nil
+	}, time.Second, 50*time.Millisecond)
+
+	require.Len(t, passThroughAddr, 2, "unexpected log output: %s", suite.Logs())
+
+	passThroughNetConn, err := testsuite.WaitUntilListening(ctx, t, scheme, passThroughAddr[1])
+	require.NoError(t, err)
+
+	return passThroughNetConn
+}
+
+func authenticatePassThroughConnection(
+	t *testing.T,
+	conf config.Config,
+	passThroughNetConn net.Conn,
+	passThroughConn *testsuite.Conn,
+	invalidPassword bool,
+) bool {
+	t.Helper()
+
+	if conf.OpenVPN.Passthrough.Password.String() == "" {
+		return true
+	}
+
+	buf := make([]byte, 15)
+	_, err := passThroughNetConn.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "ENTER PASSWORD:", string(buf))
+
+	if invalidPassword {
+		passThroughConn.SendAndExpectMessage(t, "invalid", "ERROR: bad password")
+
+		return false
+	}
+
+	passThroughConn.SendAndExpectMessage(t, conf.OpenVPN.Passthrough.Password.String(), "SUCCESS: password is correct")
+
+	return true
+}
+
+func forwardPassThroughCommand(t *testing.T, suite *testsuite.Suite, passThroughConn *testsuite.Conn, command, response string) {
+	t.Helper()
+
+	passThroughConn.SendMessagef(t, command)
+	suite.ExpectMessage(t, command)
+	suite.SendMessagef(t, response)
+	passThroughConn.ExpectMessage(t, response)
 }

--- a/internal/openvpn/passthrough_test.go
+++ b/internal/openvpn/passthrough_test.go
@@ -149,7 +149,7 @@ func TestPassThroughFull(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			t.Cleanup(cancel)
 
-			suite, passThroughConn, passThroughNetConn := setupPassThroughConnection(t, ctx, tc.scheme, &tc.conf)
+			suite, passThroughConn, passThroughNetConn := setupPassThroughConnection(ctx, t, tc.scheme, &tc.conf)
 			if !authenticatePassThroughConnection(t, tc.conf, passThroughNetConn, passThroughConn, tc.invalidPassword) {
 				return
 			}
@@ -237,7 +237,7 @@ func TestPassThroughCommandTimeoutSanitizesLogs(t *testing.T) {
 	conf := newPassThroughTestConfig(testsuite.Secret)
 	conf.OpenVPN.CommandTimeout = 100 * time.Millisecond
 
-	suite, passThroughConn, passThroughNetConn := setupPassThroughConnection(t, ctx, openvpn.SchemeTCP, &conf)
+	suite, passThroughConn, passThroughNetConn := setupPassThroughConnection(ctx, t, openvpn.SchemeTCP, &conf)
 	require.True(t, authenticatePassThroughConnection(t, conf, passThroughNetConn, passThroughConn, false))
 	passThroughConn.ExpectMessage(t, openvpn.WelcomeBanner)
 
@@ -265,8 +265,8 @@ func newPassThroughTestConfig(password string) config.Config {
 }
 
 func setupPassThroughConnection(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	scheme string,
 	conf *config.Config,
 ) (*testsuite.Suite, *testsuite.Conn, net.Conn) {
@@ -317,12 +317,12 @@ func setupPassThroughConnection(
 	suite.SendMessagef(t, "")
 	suite.SendMessagef(t, "\r\n")
 
-	passThroughNetConn = dialPassThroughConnection(t, ctx, suite, scheme)
+	passThroughNetConn = dialPassThroughConnection(ctx, t, suite, scheme)
 
 	return suite, testsuite.NewConn(passThroughNetConn).WithLogs(suite.Logs), passThroughNetConn
 }
 
-func dialPassThroughConnection(t *testing.T, ctx context.Context, suite *testsuite.Suite, scheme string) net.Conn {
+func dialPassThroughConnection(ctx context.Context, t *testing.T, suite *testsuite.Suite, scheme string) net.Conn {
 	t.Helper()
 
 	var passThroughAddr []string

--- a/lib/openvpn-auth-oauth2/management/management.go
+++ b/lib/openvpn-auth-oauth2/management/management.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/managementauth"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/utils"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/version"
 )
@@ -392,44 +393,8 @@ scan:
 }
 
 func (s *Server) handleManagementClientAuth(_ context.Context, conn net.Conn, scanner *bufio.Scanner) error {
-	if s.password == "" {
-		return nil
-	}
-
-	if err := conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
-		return fmt.Errorf("unable to set writeToClient deadline: %w", err)
-	}
-
-	_, err := conn.Write([]byte("ENTER PASSWORD:"))
-	if err != nil {
-		return fmt.Errorf("unable to writeToClient to client: %w", err)
-	}
-
-	if err := conn.SetReadDeadline(time.Now().Add(writeTimeout)); err != nil {
-		return fmt.Errorf("unable to set read deadline: %w", err)
-	}
-
-	if !scanner.Scan() {
-		if err = scanner.Err(); err == nil {
-			err = io.EOF
-		}
-
-		return fmt.Errorf("unable to read from client: %w", err)
-	}
-
-	if err := conn.SetReadDeadline(time.Time{}); err != nil {
-		return fmt.Errorf("unable to clear read deadline: %w", err)
-	}
-
-	if scanner.Text() != s.password {
-		_, _ = conn.Write([]byte("ERROR: bad password\r\n"))
-
-		return errors.New("client provide invalid password")
-	}
-
-	_, err = conn.Write([]byte("SUCCESS: password is correct\r\n"))
-	if err != nil {
-		return fmt.Errorf("unable to writeToClient to client: %w", err)
+	if err := managementauth.Authenticate(conn, scanner, s.password, writeTimeout); err != nil {
+		return fmt.Errorf("unable to authenticate management client: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
#### What this PR does / why we need it

Keeps the OpenVPN management pass-through listener as a trusted administrator interface for OpenVPN management frontends. Normal OpenVPN management commands are forwarded so trusted admin clients can inspect and control the daemon, including client disconnect workflows.

`openvpn.pass-through.password` remains optional because some admin interfaces do not support a management password prompt. If configured, pass-through clients must authenticate with that password and password entry uses a read deadline. If not configured, pass-through clients are accepted directly and access must be controlled by the listener binding and filesystem permissions.

Authentication decision commands are reserved for openvpn-auth-oauth2 because they are part of its own webauth flow and can conflict with pending client authentication state:

- `client-auth`
- `client-auth-nt`
- `client-deny`
- `client-pending-auth`

Command logging records command names only in the pass-through forwarding path and when writing raw management commands, so secret-bearing commands such as `password ...` do not leak values into logs.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

A dedicated sub-agent reviewed the branch update after the pass-through design correction and found no blocking issues. The review noted two test gaps, which are now covered: exact `client-auth` rejection and timeout-path log sanitization for secret-bearing forwarded commands. The pass-through test setup was also deduplicated after SonarCloud reported duplicated code.

#### Particularly user-facing changes

Pass-through remains an administrator interface and should be protected with restrictive Unix socket filesystem permissions or equivalent network access controls, especially when `openvpn.pass-through.password` is not configured. Auth-decision commands return `ERROR: command not allowed`.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

#### Testing

- `make fmt`
- `go test ./internal/openvpn ./internal/config -run 'TestPassThroughFull|TestPassThroughCommandTimeoutSanitizesLogs|TestValidate'`
- `make lint`
- `make test`