### PR TITLE
fix: trust proxy headers only from configured proxies

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -35,7 +35,9 @@ Usage of openvpn-auth-oauth2:
   --http.check.ipaddr
     	Check if client IP in http and VPN is equal (env: CONFIG_HTTP_CHECK_IPADDR)
   --http.enable-proxy-headers
-    	Use X-Forward-For http header for client ips (env: CONFIG_HTTP_ENABLE__PROXY__HEADERS)
+    	Use X-Forwarded-For http header for client ips (env: CONFIG_HTTP_ENABLE__PROXY__HEADERS)
+  --http.trusted-proxies value
+    	Trusted reverse proxy CIDRs allowed to set X-Forwarded-For. Multiple values can be provided as a comma-separated list. (env: CONFIG_HTTP_TRUSTED__PROXIES)
   --http.key string
     	Path to tls server key used for TLS listener. (env: CONFIG_HTTP_KEY)
   --http.listen string

--- a/docs/Security considerations.md
+++ b/docs/Security considerations.md
@@ -41,6 +41,7 @@ An attacker could initiate a VPN connection on their own device and then send th
 To protect against this type of social engineering attack, consider implementing the following measures:
 
 * **Enable IP address validation with `--http.check.ipaddr`**: This ensures that the IP address initiating the VPN connection matches the IP address completing the OIDC authentication flow. This is the most effective technical control, as it prevents the attack even if the employee clicks the link, since the authentication will be rejected due to the IP mismatch.
+  If openvpn-auth-oauth2 runs behind a reverse proxy, enable `--http.enable-proxy-headers` only with `--http.trusted-proxies` set to the proxy CIDR ranges.
   > [!NOTE]
   > While `--http.check.ipaddr` provides strong technical protection against this attack vector, it may not be suitable for all environments (e.g., users behind NAT, mobile users with changing IPs, or organizations using forward proxies). In such cases, compensating controls like user education and enhanced monitoring become even more critical.
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -163,6 +163,7 @@ http:
 						IPAddr: true,
 					},
 					EnableProxyHeaders: false,
+					TrustedProxies:     types.StringSlice{},
 					ShortURL:           false,
 					Listen:             ":9001",
 					Secret:             "1jd93h5b6s82lf03jh5b2hf9",

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -41,7 +41,8 @@ var Defaults = Config{
 		Check: HTTPCheck{
 			IPAddr: false,
 		},
-		Template: types.Template{Template: template.Must(template.New("index.gohtml").ParseFS(ui.Template, "index.gohtml"))},
+		TrustedProxies: types.StringSlice{},
+		Template:       types.Template{Template: template.Must(template.New("index.gohtml").ParseFS(ui.Template, "index.gohtml"))},
 	},
 	OpenVPN: OpenVPN{
 		Addr: types.URL{URL: &url.URL{

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -98,7 +98,13 @@ func (c *Config) flagSetHTTP(flagSet *flag.FlagSet) {
 		&c.HTTP.EnableProxyHeaders,
 		"http.enable-proxy-headers",
 		lookupEnvOrDefault("http.enable-proxy-headers", c.HTTP.EnableProxyHeaders),
-		"Use X-Forward-For http header for client ips",
+		"Use X-Forwarded-For http header for client ips",
+	)
+	flagSet.TextVar(
+		&c.HTTP.TrustedProxies,
+		"http.trusted-proxies",
+		lookupEnvOrDefault("http.trusted-proxies", c.HTTP.TrustedProxies),
+		"Trusted reverse proxy CIDRs allowed to set X-Forwarded-For. Multiple values can be provided as a comma-separated list.",
 	)
 	flagSet.BoolVar(
 		&c.HTTP.ShortURL,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -44,17 +44,18 @@ type ProviderGoogleValidate struct {
 }
 
 type HTTP struct {
-	BaseURL            types.URL      `json:"baseurl"              yaml:"baseurl"`
-	AssetPath          types.FS       `json:"assets-path"          yaml:"assets-path"`
-	Template           types.Template `json:"template"             yaml:"template"`
-	Listen             string         `json:"listen"               yaml:"listen"`
-	CertFile           string         `json:"cert"                 yaml:"cert"`
-	KeyFile            string         `json:"key"                  yaml:"key"`
-	Secret             types.Secret   `json:"secret"               yaml:"secret"`
-	TLS                bool           `json:"tls"                  yaml:"tls"`
-	Check              HTTPCheck      `json:"check"                yaml:"check"`
-	EnableProxyHeaders bool           `json:"enable-proxy-headers" yaml:"enable-proxy-headers"`
-	ShortURL           bool           `json:"short-url"            yaml:"short-url"`
+	BaseURL            types.URL         `json:"baseurl"              yaml:"baseurl"`
+	AssetPath          types.FS          `json:"assets-path"          yaml:"assets-path"`
+	Template           types.Template    `json:"template"             yaml:"template"`
+	Listen             string            `json:"listen"               yaml:"listen"`
+	CertFile           string            `json:"cert"                 yaml:"cert"`
+	KeyFile            string            `json:"key"                  yaml:"key"`
+	Secret             types.Secret      `json:"secret"               yaml:"secret"`
+	TrustedProxies     types.StringSlice `json:"trusted-proxies"      yaml:"trusted-proxies"`
+	TLS                bool              `json:"tls"                  yaml:"tls"`
+	Check              HTTPCheck         `json:"check"                yaml:"check"`
+	EnableProxyHeaders bool              `json:"enable-proxy-headers" yaml:"enable-proxy-headers"`
+	ShortURL           bool              `json:"short-url"            yaml:"short-url"`
 }
 
 type HTTPCheck struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/netip"
 	"slices"
+	"strings"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config/types"
 )
@@ -56,6 +58,19 @@ func validateHTTPConfig(conf *Config) error {
 
 	if err := validateURL(conf.HTTP.BaseURL); err != nil {
 		return fmt.Errorf("http.baseurl: %w", err)
+	}
+
+	if conf.HTTP.EnableProxyHeaders {
+		if len(conf.HTTP.TrustedProxies) == 0 {
+			return fmt.Errorf("http.trusted-proxies is %w when http.enable-proxy-headers is true", ErrRequired)
+		}
+
+		for _, trustedProxy := range conf.HTTP.TrustedProxies {
+			trustedProxy = strings.TrimSpace(trustedProxy)
+			if _, err := netip.ParsePrefix(trustedProxy); err != nil {
+				return fmt.Errorf("http.trusted-proxies: invalid CIDR %q: %w", trustedProxy, err)
+			}
+		}
 	}
 
 	if err := conf.HTTP.Template.Execute(io.Discard, map[string]string{

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -186,6 +186,35 @@ func TestValidate(t *testing.T) {
 			"oauth2.refresh.secret requires a length of 16, 24 or 32",
 		},
 		{
+			func() config.Config {
+				conf := validConfig()
+				conf.HTTP.EnableProxyHeaders = true
+
+				return conf
+			}(),
+			"http.trusted-proxies is required when http.enable-proxy-headers is true",
+		},
+		{
+			func() config.Config {
+				conf := validConfig()
+				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1"}
+
+				return conf
+			}(),
+			`http.trusted-proxies: invalid CIDR "127.0.0.1": netip.ParsePrefix("127.0.0.1"): no '/'`,
+		},
+		{
+			func() config.Config {
+				conf := validConfig()
+				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32", "2001:db8::/64"}
+
+				return conf
+			}(),
+			"",
+		},
+		{
 			config.Config{
 				HTTP: config.HTTP{
 					BaseURL:  types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}},

--- a/internal/oauth2/bench_test.go
+++ b/internal/oauth2/bench_test.go
@@ -64,6 +64,7 @@ func BenchmarkCheckClientIPAddr(b *testing.B) {
 	b.Run("proxy-headers", func(b *testing.B) {
 		conf := config.Defaults
 		conf.HTTP.EnableProxyHeaders = true
+		conf.HTTP.TrustedProxies = append(conf.HTTP.TrustedProxies, "10.0.0.1/32")
 
 		req := &http.Request{RemoteAddr: "10.0.0.1:12345", Header: http.Header{"X-Forwarded-For": []string{"127.0.0.1, 10.0.0.1"}}}
 

--- a/internal/oauth2/handler_test.go
+++ b/internal/oauth2/handler_test.go
@@ -212,6 +212,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -248,12 +249,13 @@ func TestHandler(t *testing.T) {
 			false,
 		},
 		{
-			"with ipaddr + multiple forwarded-for",
+			"with ipaddr + forwarded-for from trusted proxy",
 			func() config.Config {
 				conf := config.Defaults
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -264,7 +266,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -275,6 +277,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -285,7 +288,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "2001:db8::1", IPPort: "12345"},
 			false,
-			"2001:db8::1, 8.8.8.8",
+			"2001:db8::1",
 			true,
 			true,
 		},
@@ -296,6 +299,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OAuth2.Validate.Expression = "false"
@@ -307,7 +311,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			false,
 		},
@@ -318,6 +322,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -337,7 +342,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -348,6 +353,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -367,7 +373,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -378,6 +384,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -393,7 +400,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "client"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -404,6 +411,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -424,7 +432,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -435,6 +443,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -455,7 +464,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -466,6 +475,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -486,7 +496,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -497,6 +507,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -517,7 +528,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -528,6 +539,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -548,7 +560,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "client"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -559,6 +571,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -579,7 +592,7 @@ func TestHandler(t *testing.T) {
 			}(),
 			state.State{Client: state.ClientIdentifier{CID: 0, KID: 1, CommonName: "name"}, IPAddr: "127.0.0.2", IPPort: "12345"},
 			false,
-			"127.0.0.2, 8.8.8.8",
+			"127.0.0.2",
 			true,
 			true,
 		},
@@ -590,6 +603,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
@@ -611,6 +625,7 @@ func TestHandler(t *testing.T) {
 				conf.HTTP.Secret = testsuite.Secret
 				conf.HTTP.Check.IPAddr = true
 				conf.HTTP.EnableProxyHeaders = true
+				conf.HTTP.TrustedProxies = types.StringSlice{"127.0.0.1/32"}
 				conf.OAuth2.Endpoints = config.OAuth2Endpoints{}
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)

--- a/internal/oauth2/utils.go
+++ b/internal/oauth2/utils.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
@@ -22,9 +24,9 @@ func checkClientIPAddr(r *http.Request, conf *config.Config, session state.State
 		return fmt.Errorf("unable to split remote address %s: %w", r.RemoteAddr, err)
 	}
 
-	if conf.HTTP.EnableProxyHeaders {
-		if fwdAddress := r.Header.Get("X-Forwarded-For"); fwdAddress != "" {
-			clientIP = strings.TrimSpace(strings.Split(fwdAddress, ",")[0])
+	if conf.HTTP.EnableProxyHeaders && addrTrustedProxy(clientIP, conf.HTTP.TrustedProxies) {
+		if forwardedFor := r.Header.Values("X-Forwarded-For"); len(forwardedFor) != 0 {
+			clientIP = clientIPFromForwardedChain(clientIP, forwardedFor, conf.HTTP.TrustedProxies)
 		}
 	}
 
@@ -33,6 +35,51 @@ func checkClientIPAddr(r *http.Request, conf *config.Config, session state.State
 	}
 
 	return nil
+}
+
+func clientIPFromForwardedChain(remoteAddr string, forwardedForHeaders, trustedProxies []string) string {
+	forwardedFor := strings.Join(forwardedForHeaders, ",")
+	forwardedAddrs := strings.Split(forwardedFor, ",")
+	currentAddr := remoteAddr
+
+	for _, forwardedAddr := range slices.Backward(forwardedAddrs) {
+		if !addrTrustedProxy(currentAddr, trustedProxies) {
+			return currentAddr
+		}
+
+		forwardedAddr = strings.TrimSpace(forwardedAddr)
+		if forwardedAddr == "" {
+			continue
+		}
+
+		currentAddr = forwardedAddr
+	}
+
+	return currentAddr
+}
+
+func addrTrustedProxy(addrText string, trustedProxies []string) bool {
+	addr, err := netip.ParseAddr(addrText)
+	if err != nil {
+		return false
+	}
+
+	addr = addr.Unmap()
+
+	for _, trustedProxy := range trustedProxies {
+		trustedProxy = strings.TrimSpace(trustedProxy)
+
+		prefix, err := netip.ParsePrefix(trustedProxy)
+		if err != nil {
+			continue
+		}
+
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // getAuthorizeParams parses the authorizeParams string and returns a slice of rp.URLParamOpt.

--- a/internal/oauth2/utils_test.go
+++ b/internal/oauth2/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/internal/config/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/state"
 	"github.com/stretchr/testify/require"
 )
@@ -22,4 +23,82 @@ func TestCheckClientIPAddrIPv6RemoteAddr(t *testing.T) {
 	session := state.State{IPAddr: "2001:db8::1"}
 
 	require.NoError(t, checkClientIPAddr(req, &conf, session))
+}
+
+func TestCheckClientIPAddrProxyHeaders(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		remoteAddr     string
+		trustedProxies []string
+		sessionIP      string
+		expectedErr    string
+	}{
+		{
+			name:           "trusted proxy",
+			remoteAddr:     "10.0.0.1:12345",
+			trustedProxies: []string{"10.0.0.0/24"},
+			sessionIP:      "127.0.0.1",
+		},
+		{
+			name:           "untrusted proxy",
+			remoteAddr:     "10.0.0.1:12345",
+			trustedProxies: []string{"192.0.2.0/24"},
+			sessionIP:      "127.0.0.1",
+			expectedErr:    "client rejected: http client ip 10.0.0.1 and vpn ip 127.0.0.1 is different",
+		},
+		{
+			name:           "trusted proxy with spoofed leading value",
+			remoteAddr:     "10.0.0.1:12345",
+			trustedProxies: []string{"10.0.0.0/24"},
+			sessionIP:      "127.0.0.1",
+			expectedErr:    "client rejected: http client ip 203.0.113.10 and vpn ip 127.0.0.1 is different",
+		},
+		{
+			name:           "trusted proxy with multiple header values",
+			remoteAddr:     "10.0.0.1:12345",
+			trustedProxies: []string{"10.0.0.0/24"},
+			sessionIP:      "203.0.113.10",
+		},
+		{
+			name:           "trusted ipv6 proxy",
+			remoteAddr:     "[2001:db8::2]:12345",
+			trustedProxies: []string{"2001:db8::/64"},
+			sessionIP:      "2001:db8::1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			conf := config.Defaults
+			conf.HTTP.Check.IPAddr = true
+			conf.HTTP.EnableProxyHeaders = true
+			conf.HTTP.TrustedProxies = types.StringSlice(tc.trustedProxies)
+
+			req := &http.Request{
+				RemoteAddr: tc.remoteAddr,
+				Header:     http.Header{"X-Forwarded-For": []string{"127.0.0.1, 10.0.0.1"}},
+			}
+			switch tc.name {
+			case "trusted ipv6 proxy":
+				req.Header.Set("X-Forwarded-For", "2001:db8::1, 2001:db8::2")
+			case "trusted proxy with spoofed leading value":
+				req.Header.Set("X-Forwarded-For", "127.0.0.1, 203.0.113.10")
+			case "trusted proxy with multiple header values":
+				req.Header = http.Header{
+					"X-Forwarded-For": []string{"127.0.0.1", "203.0.113.10"},
+				}
+			}
+
+			err := checkClientIPAddr(req, &conf, state.State{IPAddr: tc.sessionIP})
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.EqualError(t, err, tc.expectedErr)
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Adds `http.trusted-proxies` and uses it to accept `X-Forwarded-For` only from configured reverse proxy CIDRs. When proxy headers are enabled, configuration now fails closed unless trusted proxies are configured.

The forwarded chain is parsed right-to-left so spoofed leading values are ignored and the nearest untrusted client address is used for `http.check.ipaddr`.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

A dedicated sub-agent reviewed the branch diff and found a high issue in the initial X-Forwarded-For parser: trusting the left-most value after a trusted proxy could still allow spoofing. The parser was fixed to walk the chain from right to left, and regression tests were added.

#### Particularly user-facing changes

Deployments using `http.enable-proxy-headers` must now configure `http.trusted-proxies` with CIDR ranges for their reverse proxies.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

#### Testing

- `make fmt`
- `go test ./internal/config ./internal/oauth2`
- `make lint`
- `make test`