### PR TITLE
fix: escape profile selector templates

### DIFF
--- a/docs/Client specific configuration.md
+++ b/docs/Client specific configuration.md
@@ -13,8 +13,10 @@ loaded, including `DEFAULT.conf`.
 
 Each resolved config name loads `<name>.conf` from that directory. Filenames
 must satisfy Go's `fs.ValidPath`; absolute paths and `.` or `..` path elements
-are rejected. Symbolic links are followed only when their targets remain inside
-the configured client config directory.
+are rejected. Config names containing `<`, `>`, `"`, `'`, `&`, `` ` ``, or
+control characters are rejected because names can also be rendered in the
+browser-based profile selector. Symbolic links are followed only when their
+targets remain inside the configured client config directory.
 
 If the expression returns an empty list, openvpn-auth-oauth2 loads
 `DEFAULT.conf`, matching OpenVPN's `client-config-dir` default-file pattern. If

--- a/docs/Layout Customization.md
+++ b/docs/Layout Customization.md
@@ -15,7 +15,9 @@ Available variables:
 - `{{.clientConfigProfiles}}`: List of available profiles, used to render the profile selection screen.
 - `{{.token}}`: An encrypted token to identify the user session, used for profile selection.
 
-The [go template engine](https://pkg.go.dev/text/template) is used to render the HTML file.
+The [Go HTML template engine](https://pkg.go.dev/html/template) is used to
+render the HTML file. Template values are contextually escaped before they are
+written to the rendered HTML.
 
 ## Client Profile Selector
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,9 +1,9 @@
 package config
 
 import (
+	"html/template"
 	"log/slog"
 	"net/url"
-	"text/template"
 	"time"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config/types"

--- a/internal/config/types/template.go
+++ b/internal/config/types/template.go
@@ -3,8 +3,8 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"path"
-	"text/template"
 )
 
 type Template struct {

--- a/internal/config/types/template_test.go
+++ b/internal/config/types/template_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -41,6 +42,23 @@ func TestTemplate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTemplateEscapesHTML(t *testing.T) {
+	t.Parallel()
+
+	tmpl, err := types.NewTemplate("testdata/profile.gohtml")
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+
+	err = tmpl.Execute(&out, map[string]any{
+		"value": `"><script>alert(1)</script>`,
+	})
+
+	require.NoError(t, err)
+	require.NotContains(t, out.String(), `<script>`)
+	require.Contains(t, out.String(), `&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;`)
 }
 
 //nolint:exhaustruct

--- a/internal/config/types/testdata/profile.gohtml
+++ b/internal/config/types/testdata/profile.gohtml
@@ -1,0 +1,1 @@
+<input value="{{ .value }}">

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,10 +1,10 @@
 package config_test
 
 import (
+	"html/template"
 	"net/url"
 	"testing"
 	"testing/fstest"
-	"text/template"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config/types"

--- a/internal/oauth2/client_config.go
+++ b/internal/oauth2/client_config.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/fs"
 	"reflect"
+	"strings"
+	"unicode"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
@@ -106,7 +108,19 @@ func validateClientConfigNames(names []string) ([]string, error) {
 		if !fs.ValidPath(clientConfigPath) {
 			return nil, fmt.Errorf("%w: invalid client config path %q", types.ErrInvalidClaimType, clientConfigPath)
 		}
+
+		if clientConfigNameUnsafe(name) {
+			return nil, fmt.Errorf("%w: unsafe client config name %q", types.ErrInvalidClaimType, name)
+		}
 	}
 
 	return names, nil
+}
+
+func clientConfigNameUnsafe(name string) bool {
+	if strings.ContainsAny(name, `<>"'&`+"`") {
+		return true
+	}
+
+	return strings.ContainsFunc(name, unicode.IsControl)
 }

--- a/internal/oauth2/client_config_test.go
+++ b/internal/oauth2/client_config_test.go
@@ -67,6 +67,22 @@ func TestResolveClientConfigNamesExpressionRejectsInvalidName(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid client config path")
 }
 
+func TestResolveClientConfigNamesExpressionRejectsUnsafeName(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Defaults
+	conf.OpenVPN.ClientConfig.Enabled = true
+	conf.OpenVPN.ClientConfig.Expression = `["profile\" autofocus onfocus=alert(1)"]`
+
+	client := Client{conf: &conf}
+	require.NoError(t, client.initializeClientConfigResolver())
+
+	_, err := client.ResolveClientConfigNames(&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}}, "client-cn", "alice")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsafe client config name")
+}
+
 func TestInitializeClientConfigResolverRejectsScalarExpression(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### What this PR does / why we need it

Switches custom login templates from `text/template` to `html/template` so profile names and other dynamic values are contextually escaped when rendered into HTML. It also rejects client config profile names containing HTML-sensitive characters or control characters before they can reach the browser-based profile selector.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

Dedicated sub-agent review found two documentation gaps: custom templates still referenced `text/template`, and client-specific configuration docs did not mention the new unsafe-name restrictions. Both findings were fixed before this PR was opened.

#### Particularly user-facing changes

Custom layout templates now use Go's HTML template escaping. Client config names containing `<`, `>`, `"`, `'`, `&`, backtick, or control characters are rejected because these names may be rendered as profile selector values.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

Testing:

- `make fmt`
- `go test ./internal/config ./internal/config/types ./internal/oauth2`
- `make lint`
- `make test`