### PR TITLE
fix: redact plugin debug environment logs

### DIFF
--- a/lib/openvpn-auth-oauth2/client/client.go
+++ b/lib/openvpn-auth-oauth2/client/client.go
@@ -56,7 +56,7 @@ func NewClient(clientID uint64, envArray util.List) (*Client, error) {
 			client.AuthControlFile = value
 		default:
 			if strings.ContainsAny(key, "\r\n") || strings.ContainsAny(value, "\r\n") {
-				return nil, fmt.Errorf("%w: %s", ErrUnsafeEnvVar, key)
+				return nil, fmt.Errorf("%w: %q", ErrUnsafeEnvVar, key)
 			}
 
 			client.estimatedSize += len(key) + len(value) + 15

--- a/lib/openvpn-auth-oauth2/client/client_test.go
+++ b/lib/openvpn-auth-oauth2/client/client_test.go
@@ -126,6 +126,8 @@ func TestNewClient_RejectsManagementProtocolLineBreaks(t *testing.T) {
 
 			_, err := client.NewClient(12345, tc.env)
 			require.ErrorIs(t, err, client.ErrUnsafeEnvVar)
+			require.NotContains(t, err.Error(), "\n")
+			require.NotContains(t, err.Error(), "\r")
 		})
 	}
 }

--- a/lib/openvpn-auth-oauth2/openvpn/env_redaction.go
+++ b/lib/openvpn-auth-oauth2/openvpn/env_redaction.go
@@ -1,0 +1,48 @@
+//go:build (darwin || linux || openbsd || freebsd) && cgo
+
+package openvpn
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/lib/openvpn-auth-oauth2/util"
+)
+
+const redactedEnvValue = "***"
+
+func redactedEnvList(env util.List) util.List {
+	redacted := make(util.List, len(env))
+
+	for key, value := range env {
+		key = sanitizeEnvLogValue(key)
+
+		if sensitiveEnvKey(key) {
+			value = redactedEnvValue
+		} else {
+			value = sanitizeEnvLogValue(value)
+		}
+
+		redacted[key] = value
+	}
+
+	return redacted
+}
+
+func sensitiveEnvKey(key string) bool {
+	key = strings.ToLower(key)
+
+	return strings.Contains(key, "password") ||
+		strings.Contains(key, "token") ||
+		strings.Contains(key, "secret")
+}
+
+func sanitizeEnvLogValue(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return '?'
+		}
+
+		return r
+	}, value)
+}

--- a/lib/openvpn-auth-oauth2/openvpn/env_redaction_test.go
+++ b/lib/openvpn-auth-oauth2/openvpn/env_redaction_test.go
@@ -1,0 +1,34 @@
+//go:build (darwin || linux || openbsd || freebsd) && cgo
+
+//nolint:testpackage
+package openvpn
+
+import (
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/lib/openvpn-auth-oauth2/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactedEnvList(t *testing.T) {
+	t.Parallel()
+
+	env := util.List{
+		"common_name":   "alice@example.com",
+		"device":        "tun0\nforged=true",
+		"password":      "openvpn-password",
+		"auth_token":    "auth-token",
+		"client_secret": "client-secret",
+		"bad\nkey":      "value",
+	}
+
+	redacted := redactedEnvList(env)
+
+	require.Equal(t, "alice@example.com", redacted["common_name"])
+	require.Equal(t, "tun0?forged=true", redacted["device"])
+	require.Equal(t, redactedEnvValue, redacted["password"])
+	require.Equal(t, redactedEnvValue, redacted["auth_token"])
+	require.Equal(t, redactedEnvValue, redacted["client_secret"])
+	require.Equal(t, "value", redacted["bad?key"])
+	require.Equal(t, "openvpn-password", env["password"])
+}

--- a/lib/openvpn-auth-oauth2/openvpn/handle.go
+++ b/lib/openvpn-auth-oauth2/openvpn/handle.go
@@ -97,8 +97,6 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 		slog.String("client_ip", fmt.Sprintf("%s:%s", envArray["untrusted_ip"], envArray["untrusted_port"])),
 	)
 
-	logger.DebugContext(p.ctx, "env", slog.Any("env", envArray))
-
 	openVPNClient, err := client.NewClient(currentClientID, envArray)
 	if err != nil {
 		logger.ErrorContext(
@@ -108,6 +106,8 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 
 		return c.OpenVPNPluginFuncError
 	}
+
+	logger.DebugContext(p.ctx, "env", slog.Any("env", redactedEnvList(envArray)))
 
 	resp, err := p.managementClient.ClientAuth(p.ctx, currentClientID, openVPNClient.GetConnectMessage())
 	if err != nil {

--- a/lib/openvpn-auth-oauth2/openvpn/plugin_test.go
+++ b/lib/openvpn-auth-oauth2/openvpn/plugin_test.go
@@ -4,6 +4,7 @@
 package openvpn
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"net/http"
@@ -474,6 +475,49 @@ func TestHandleAuthUserPassVerifyErrors(t *testing.T) {
 			status := handle.handleAuthUserPassVerify(envp, testCase.perClientContext)
 
 			require.Equal(t, c.OpenVPNPluginFuncError, status)
+		})
+	}
+}
+
+//nolint:paralleltest // handleAuthUserPassVerify increments the package-level clientIDCounter.
+func TestHandleAuthUserPassVerifyRejectsUnsafeEnvBeforeDebugLog(t *testing.T) {
+	clientIDCounter.Store(0)
+	t.Cleanup(func() {
+		clientIDCounter.Store(0)
+	})
+
+	for _, tc := range []struct {
+		name        string
+		env         string
+		notContains string
+	}{
+		{
+			name:        "unsafe value",
+			env:         "common_name=alice\nforged=true",
+			notContains: "forged=true",
+		},
+		{
+			name:        "unsafe key",
+			env:         "bad\nkey=value",
+			notContains: "bad\nkey",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var logs bytes.Buffer
+
+			logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			handle := newTestPluginHandle(t)
+			handle.logger = logger
+			handle.managementClient = management.NewServer(logger, "")
+
+			env := append(validAuthUserPassVerifyEnv(), tc.env)
+			envp := newTestEnvp(t, env)
+
+			status := handle.handleAuthUserPassVerify(envp, &ClientContext{})
+
+			require.Equal(t, c.OpenVPNPluginFuncError, status)
+			require.NotContains(t, logs.String(), tc.notContains)
+			require.NotContains(t, logs.String(), "msg=env")
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Redacts OpenVPN plugin environment debug logs before they are emitted. The auth handler now validates the parsed OpenVPN env before logging it, redacts secret-bearing keys such as password, token, and secret values, and sanitizes control characters in the logged copy to prevent forged log lines.

It also quotes unsafe env keys in `ErrUnsafeEnvVar` errors so rejected malformed keys cannot inject raw CR/LF into logs.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

Dedicated sub-agent review found two log-injection edges after the initial redaction change: unsafe env values could be logged before validation, and unsafe env keys could appear raw in validation errors. Both findings were fixed and the reviewer re-checked the final diff with no remaining findings.

#### Particularly user-facing changes

Plugin debug logs no longer include raw OpenVPN password/token/secret environment values. Malformed env keys in validation errors are quoted.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

Testing:

- `make fmt`
- `go test ./lib/openvpn-auth-oauth2/openvpn`
- `go test ./lib/openvpn-auth-oauth2/client ./lib/openvpn-auth-oauth2/openvpn`
- `make lint`
- `make test`