### PR TITLE
fix: bind pprof default to loopback

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -23,7 +23,7 @@ Usage of openvpn-auth-oauth2:
   --config string
     	path to one .yaml config file (env: CONFIG_CONFIG)
   --debug.listen string
-    	listen address for go profiling endpoint (env: CONFIG_DEBUG_LISTEN) (default ":9001")
+    	listen address for go profiling endpoint (env: CONFIG_DEBUG_LISTEN) (default "127.0.0.1:9001")
   --debug.pprof
     	Enables go profiling endpoint. This should be never exposed. (env: CONFIG_DEBUG_PPROF)
   --http.assets-path value

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -23,7 +23,7 @@ const (
 //nolint:gochecknoglobals
 var Defaults = Config{
 	Debug: Debug{
-		Listen: ":9001",
+		Listen: "127.0.0.1:9001",
 	},
 	Log: Log{
 		Format:      "console",

--- a/packaging/etc/openvpn-auth-oauth2/config.yaml
+++ b/packaging/etc/openvpn-auth-oauth2/config.yaml
@@ -1,6 +1,6 @@
 #debug:
 #  pprof: false
-#  listen: :9001
+#  listen: 127.0.0.1:9001
 #http:
 #  assets-path: "" # Example: "/etc/openvpn-auth-oauth2/assets/"
 #  baseurl: "http://localhost:9000/"


### PR DESCRIPTION
#### What this PR does / why we need it

Changes the default debug pprof listen address from `:9001` to `127.0.0.1:9001` so enabling `debug.pprof` does not expose Go profiling endpoints on every interface by default.

The generated configuration documentation and packaged example config comment were updated to match the safer default.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

Dedicated sub-agent review found no issues in this change.

#### Particularly user-facing changes

Users who enable `debug.pprof` without overriding `debug.listen` now get a loopback-only listener. Set `debug.listen` explicitly if remote profiling access is intentionally required.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

Testing:

- `make fmt`
- `go test ./internal/config`
- `make lint`
- `make test`