### PR TITLE
fix: harden management line parsing

### DIFF
--- a/internal/openvpn/handler.go
+++ b/internal/openvpn/handler.go
@@ -115,13 +115,13 @@ func (c *Client) handleMessages(ctx context.Context, errCh chan<- error) {
 //nolint:cyclop
 func (c *Client) handleMessage(ctx context.Context, message string) error {
 	switch {
-	case message[0] == '>':
-		switch message[0:6] {
-		case ">CLIEN":
+	case strings.HasPrefix(message, ">"):
+		switch {
+		case strings.HasPrefix(message, ">CLIEN"):
 			return c.handleClientMessage(ctx, message)
-		case ">HOLD:":
+		case strings.HasPrefix(message, ">HOLD:"):
 			c.commandsCh <- "hold release"
-		case ">INFO:":
+		case strings.HasPrefix(message, ">INFO:"):
 			// welcome message
 			if strings.HasPrefix(message, ">INFO:OpenVPN Management Interface Version") {
 				return nil

--- a/internal/openvpn/main.go
+++ b/internal/openvpn/main.go
@@ -330,9 +330,14 @@ func (c *Client) readMessage(buf *bytes.Buffer) error {
 }
 
 func (c *Client) isMessageLineEOF(line []byte) bool {
-	switch string(line[0:2]) {
+	switch {
 	// SUCCESS, ERROR, END, >HOLD, >INFO, >NOTIFY
-	case "SU", "ER", "EN", ">H", ">I", ">N":
+	case bytes.HasPrefix(line, []byte("SU")),
+		bytes.HasPrefix(line, []byte("ER")),
+		bytes.HasPrefix(line, []byte("EN")),
+		bytes.HasPrefix(line, []byte(">H")),
+		bytes.HasPrefix(line, []byte(">I")),
+		bytes.HasPrefix(line, []byte(">N")):
 		return true
 	default:
 		return bytes.Equal(line, []byte(">CLIENT:ENV,END"))

--- a/internal/openvpn/main_test.go
+++ b/internal/openvpn/main_test.go
@@ -577,6 +577,26 @@ func TestDeadLocks(t *testing.T) {
 			name:    "empty-lines",
 			message: "\r\n",
 		},
+		{
+			name:    "short event marker",
+			message: ">",
+		},
+		{
+			name:    "short hold event",
+			message: ">H",
+		},
+		{
+			name:    "short info event",
+			message: ">I",
+		},
+		{
+			name:    "short notify event",
+			message: ">N",
+		},
+		{
+			name:    "short line",
+			message: "S",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
#### What this PR does / why we need it

Replaces direct short string/byte slices in OpenVPN management message routing with prefix checks. Malformed one-character lines and short `>` event messages can no longer panic the management client.

Regression coverage sends short management messages such as `>`, `>H`, `>I`, `>N`, and `S` through the existing mock management environment.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

Dedicated sub-agent review found no issues. The prefix checks preserve the previous routing behavior for valid OpenVPN management messages while removing the short-slice panic paths.

#### Particularly user-facing changes

The management client is more robust against malformed or truncated management-interface lines.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

Testing:

- `make fmt`
- `go test ./internal/openvpn`
- `make lint`
- `make test`