### PR TITLE
chore: avoid token decrypt copy

### DIFF
--- a/internal/tokenstorage/inmemory.go
+++ b/internal/tokenstorage/inmemory.go
@@ -109,11 +109,7 @@ func (s *InMemory) Get(_ context.Context, client string) (string, error) {
 		return "", ErrNotExists
 	}
 
-	// Copy the encrypted data before decrypting so storage internals cannot be mutated by future cipher changes.
-	encryptedBytes := make([]byte, len(data.Data))
-	copy(encryptedBytes, data.Data)
-
-	token, err := s.cipher.DecryptBytes(encryptedBytes)
+	token, err := s.cipher.DecryptBytes(data.Data)
 	if err != nil {
 		return "", fmt.Errorf("decrypt error: %w", err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it

Removes the defensive encrypted-byte copy from `internal/tokenstorage/inmemory.go` before decrypting in-memory tokens. `crypto.DecryptBytes` reads the ciphertext and decrypts into a fresh plaintext buffer, so the extra copy only adds work on the token `Get` path.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

Sub-agent review found no issues. Local checks from `/Users/jok/GolandProjects/openvpn-auth-oauth2`:

- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make fmt` returned exit code 0; formatter helpers logged permission errors while walking denied `tests/.env`, then reported no formatting changes/issues.
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make lint` passed: `0 issues.`
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make test` passed.

#### Particularly user-facing changes

None.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR