### PR TITLE
chore: parse GitHub pagination links directly

### DIFF
--- a/internal/oauth2/providers/github/api.go
+++ b/internal/oauth2/providers/github/api.go
@@ -6,14 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
-)
-
-// Pagination URL patterns
-// https://developer.GitHub.com/v3/#pagination
-var (
-	reNext = regexp.MustCompile("<([^>]+)>; rel=\"next\"")
-	reLast = regexp.MustCompile("<([^>]+)>; rel=\"last\"")
+	"strings"
 )
 
 // get performs an authenticated GitHub API request and decodes the JSON response.
@@ -56,18 +49,63 @@ func getPagination(apiURL string, resp *http.Response) string {
 	}
 
 	links := resp.Header.Get("Link")
-	if len(reLast.FindStringSubmatch(links)) == 0 {
+
+	nextPageURL, lastPageURL := parsePaginationLinks(links)
+	if lastPageURL == "" {
 		return ""
 	}
 
-	lastPageURL := reLast.FindStringSubmatch(links)[1]
 	if apiURL == lastPageURL {
 		return ""
 	}
 
-	if len(reNext.FindStringSubmatch(links)) > 1 {
-		return reNext.FindStringSubmatch(links)[1]
+	return nextPageURL
+}
+
+func parsePaginationLinks(links string) (string, string) {
+	var nextPageURL, lastPageURL string
+
+	for links != "" {
+		links = strings.TrimSpace(links)
+
+		if !strings.HasPrefix(links, "<") {
+			return nextPageURL, lastPageURL
+		}
+
+		targetEnd := strings.IndexByte(links, '>')
+		if targetEnd < 0 {
+			return nextPageURL, lastPageURL
+		}
+
+		linkURL := links[1:targetEnd]
+		attrs, remaining := splitPaginationLinkAttrs(links[targetEnd+1:])
+
+		for attr := range strings.SplitSeq(attrs, ";") {
+			switch strings.TrimSpace(attr) {
+			case `rel="next"`:
+				nextPageURL = linkURL
+			case `rel="last"`:
+				lastPageURL = linkURL
+			}
+		}
+
+		links = remaining
 	}
 
-	return ""
+	return nextPageURL, lastPageURL
+}
+
+func splitPaginationLinkAttrs(attrs string) (string, string) {
+	for i := range attrs {
+		if attrs[i] != ',' {
+			continue
+		}
+
+		remaining := strings.TrimSpace(attrs[i+1:])
+		if strings.HasPrefix(remaining, "<") {
+			return attrs[:i], remaining
+		}
+	}
+
+	return attrs, ""
 }

--- a/internal/oauth2/providers/github/api_test.go
+++ b/internal/oauth2/providers/github/api_test.go
@@ -51,6 +51,12 @@ func TestGetPagination(t *testing.T) {
 			link:     `<https://api.github.com/user/orgs?page=3>; rel="last", <https://api.github.com/user/orgs?page=2>; rel="next"`,
 			expected: "https://api.github.com/user/orgs?page=2",
 		},
+		{
+			name:     "next url contains separators",
+			apiURL:   "https://api.github.com/user/orgs?affiliation=owner,collaborator;admin&page=1",
+			link:     `<https://api.github.com/user/orgs?affiliation=owner,collaborator;admin&page=2>; rel="next", <https://api.github.com/user/orgs?affiliation=owner,collaborator;admin&page=3>; rel="last"`,
+			expected: "https://api.github.com/user/orgs?affiliation=owner,collaborator;admin&page=2",
+		},
 	}
 
 	for _, testCase := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it

Replaces repeated regexp submatch extraction in `internal/oauth2/providers/github/api.go` with a direct Link header parser. The parser scans link targets before attributes so commas and semicolons inside URL query values are handled correctly.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

Sub-agent review initially caught a comma/semicolon URL parsing edge case; the parser and test were updated, and re-review found no issues. Local checks from `/Users/jok/GolandProjects/openvpn-auth-oauth2`:

- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache go test ./internal/oauth2/providers/github` passed.
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make fmt` returned exit code 0; formatter helpers logged permission errors while walking denied `tests/.env`, then reported no formatting changes/issues.
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make lint` passed: `0 issues.`
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make test` passed.

#### Particularly user-facing changes

None.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR