### PR TITLE
fix: resolve all matching Google groups

### DIFF
--- a/internal/oauth2/providers/google/check.go
+++ b/internal/oauth2/providers/google/check.go
@@ -25,15 +25,15 @@ func (p Provider) CheckUser(
 	return p.Provider.CheckUser(ctx, session, userData, tokens) //nolint:wrapcheck
 }
 
-// resolveGroupMemberships replaces userData.Groups with the subset of configured
-// required groups that the user is a member of. Membership is resolved either
-// directly (default) or transitively when GroupsTransitive is enabled.
+// resolveGroupMemberships replaces userData.Groups with the configured required
+// groups that the user is a member of. Do not stop after the first match:
+// client-specific configuration can depend on the complete resolved group list.
 func (p Provider) resolveGroupMemberships(ctx context.Context, userData *types.UserInfo, tokens *idtoken.IDToken) error {
 	if tokens.AccessToken == "" {
 		return errors.New("access token is empty")
 	}
 
-	userData.Groups = make([]string, 0)
+	userData.Groups = make([]string, 0, len(p.Conf.OAuth2.Validate.Groups))
 
 	for _, group := range p.Conf.OAuth2.Validate.Groups {
 		isMember, err := p.isGroupMember(ctx, group, *userData, tokens)

--- a/internal/oauth2/providers/google/check_test.go
+++ b/internal/oauth2/providers/google/check_test.go
@@ -1,9 +1,11 @@
 package google_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/internal/config"
@@ -151,6 +153,87 @@ func TestValidateGroups(t *testing.T) {
 				require.Error(t, err)
 				assert.EqualError(t, err, tc.err)
 			}
+		})
+	}
+}
+
+func TestValidateGroupsChecksAllConfiguredGroupsAfterFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		transitive bool
+	}{
+		{
+			name: "direct membership",
+		},
+		{
+			name:       "transitive membership",
+			transitive: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			token := &oidc.Tokens[*idtoken.Claims]{
+				Token: &gooauth2.Token{
+					AccessToken: "TOKEN",
+				},
+				IDTokenClaims: &idtoken.Claims{},
+			}
+
+			conf := config.Config{
+				OAuth2: config.OAuth2{
+					Validate: config.OAuth2Validate{
+						Groups: []string{"000000000000000", "000000000000001"},
+					},
+				},
+				Provider: config.Provider{
+					Google: config.ProviderGoogle{
+						Validate: config.ProviderGoogleValidate{
+							GroupsTransitive: tc.transitive,
+						},
+					},
+				},
+			}
+
+			var requests atomic.Int32
+
+			httpClient := &http.Client{
+				Transport: testsuite.NewRoundTripperFunc(nil, func(_ http.RoundTripper, req *http.Request) (*http.Response, error) {
+					requests.Add(1)
+
+					resp := httptest.NewRecorder()
+
+					if tc.transitive {
+						_, _ = resp.WriteString(`{"hasMembership": true}`)
+					} else {
+						groupID := strings.TrimPrefix(req.URL.Path, "/v1/groups/")
+						groupID = strings.TrimSuffix(groupID, "/memberships")
+
+						_, _ = fmt.Fprintf(
+							resp,
+							`{"memberships": [{"name": "groups/%s/memberships/123456789101112131415"}], "nextPageToken": ""}`,
+							groupID,
+						)
+					}
+
+					return resp.Result(), nil
+				}),
+			}
+
+			provider, err := google.NewProvider(t.Context(), &conf, httpClient)
+			require.NoError(t, err)
+
+			err = provider.CheckUser(
+				t.Context(),
+				state.State{},
+				types.UserInfo{Subject: "123456789101112131415", Email: "user@example.com"},
+				token,
+			)
+
+			require.NoError(t, err)
+			assert.EqualValues(t, 2, requests.Load())
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Documents why Google group resolution must collect all matching configured groups instead of stopping after the first match. Generic group validation only needs one match, but client-specific configuration can depend on the complete resolved group list.

This PR no longer short-circuits Google group checks. It adds regression coverage that verifies all configured groups are checked after the first match for both direct and transitive Google membership validation.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

Local checks from `/Users/jok/GolandProjects/openvpn-auth-oauth2`:

- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache go test ./internal/oauth2/providers/google -run 'TestValidateGroupsChecksAllConfiguredGroupsAfterFirstMatch|TestValidateGroups|TestValidateGroupsTransitive'` passed.
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make fmt` returned exit code 0; formatter helpers logged permission errors while walking denied `tests/.env`, then reported no formatting changes/issues.
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make lint` passed: `0 issues.`
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make test` passed.

#### Particularly user-facing changes

None.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR