### PR TITLE
chore: tune OAuth2 HTTP transport

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -63,7 +63,7 @@ func newDebugServer(logger *slog.Logger, conf *config.Config) *httpserver.Server
 func setupOpenVPNClient(
 	ctx context.Context, logger *slog.Logger, conf *config.Config, tokenStorage tokenstorage.Storage,
 ) (*openvpn.Client, *http.ServeMux, error) {
-	httpClient := utils.NewOAuth2HTTPClient(http.DefaultTransport)
+	httpClient := utils.NewOAuth2HTTPClient(nil)
 
 	provider, err := providers.New(ctx, conf, httpClient)
 	if err != nil {

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -3,11 +3,21 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 )
 
-const oAuth2HTTPClientTimeout = 30 * time.Second
+const (
+	oAuth2HTTPClientTimeout       = 30 * time.Second
+	oAuth2HTTPDialTimeout         = 30 * time.Second
+	oAuth2HTTPKeepAlive           = 30 * time.Second
+	oAuth2HTTPIdleConnTimeout     = 90 * time.Second
+	oAuth2HTTPHandshakeTimeout    = 10 * time.Second
+	oAuth2HTTPContinueTimeout     = 1 * time.Second
+	oAuth2HTTPMaxIdleConns        = 128
+	oAuth2HTTPMaxIdleConnsPerHost = 32
+)
 
 var (
 	ErrOAuth2ProviderRedirectHost      = errors.New("oauth2 provider redirect changes host")
@@ -30,10 +40,30 @@ func NewUserAgentTransport(rt http.RoundTripper) *UserAgentTransport {
 
 // NewOAuth2HTTPClient returns the outbound HTTP client used for provider calls.
 func NewOAuth2HTTPClient(rt http.RoundTripper) *http.Client {
+	if rt == nil {
+		rt = newOAuth2HTTPTransport()
+	}
+
 	return &http.Client{
 		Transport:     NewUserAgentTransport(rt),
 		CheckRedirect: CheckOAuth2ProviderRedirect,
 		Timeout:       oAuth2HTTPClientTimeout,
+	}
+}
+
+func newOAuth2HTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   oAuth2HTTPDialTimeout,
+			KeepAlive: oAuth2HTTPKeepAlive,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          oAuth2HTTPMaxIdleConns,
+		MaxIdleConnsPerHost:   oAuth2HTTPMaxIdleConnsPerHost,
+		IdleConnTimeout:       oAuth2HTTPIdleConnTimeout,
+		TLSHandshakeTimeout:   oAuth2HTTPHandshakeTimeout,
+		ExpectContinueTimeout: oAuth2HTTPContinueTimeout,
 	}
 }
 

--- a/internal/utils/http_internal_test.go
+++ b/internal/utils/http_internal_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOAuth2HTTPClientUsesTunedDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	client := NewOAuth2HTTPClient(nil)
+
+	userAgentTransport, ok := client.Transport.(*UserAgentTransport)
+	require.True(t, ok)
+
+	transport, ok := userAgentTransport.rt.(*http.Transport)
+	require.True(t, ok)
+
+	assert.NotNil(t, transport.Proxy)
+	assert.NotNil(t, transport.DialContext)
+	assert.True(t, transport.ForceAttemptHTTP2)
+	assert.Equal(t, oAuth2HTTPMaxIdleConns, transport.MaxIdleConns)
+	assert.Equal(t, oAuth2HTTPMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, oAuth2HTTPIdleConnTimeout, transport.IdleConnTimeout)
+	assert.Equal(t, oAuth2HTTPHandshakeTimeout, transport.TLSHandshakeTimeout)
+	assert.Equal(t, oAuth2HTTPContinueTimeout, transport.ExpectContinueTimeout)
+}
+
+func TestNewOAuth2HTTPClientUsesProvidedTransport(t *testing.T) {
+	t.Parallel()
+
+	roundTripper := &testRoundTripper{}
+	client := NewOAuth2HTTPClient(roundTripper)
+
+	userAgentTransport, ok := client.Transport.(*UserAgentTransport)
+	require.True(t, ok)
+	assert.Same(t, roundTripper, userAgentTransport.rt)
+}
+
+type testRoundTripper struct{}
+
+func (t *testRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{}, nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Uses an explicit OAuth2 HTTP transport when the daemon creates the provider HTTP client. The transport keeps Go's default transport behavior while raising idle connection limits for provider concurrency. Caller-supplied transports are still preserved.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

Sub-agent review found no issues. Local checks from `/Users/jok/GolandProjects/openvpn-auth-oauth2`:

- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache go test ./internal/utils -run 'TestNewOAuth2HTTPClientUsesTunedDefaultTransport|TestNewOAuth2HTTPClientUsesProvidedTransport|TestNewOAuth2HTTPClient'` passed.
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make fmt` returned exit code 0; formatter helpers logged permission errors while walking denied `tests/.env`, then reported no formatting changes/issues.
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make lint` passed: `0 issues.`
- `GOCACHE=/private/tmp/openvpn-auth-oauth2-go-cache GOLANGCI_LINT_CACHE=/private/tmp/openvpn-auth-oauth2-golangci-cache make test` passed.

#### Particularly user-facing changes

None.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR