### PR TITLE
fix: Avoid disconnect token lookup when refresh is disabled

### DIFF
--- a/internal/oauth2/refresh.go
+++ b/internal/oauth2/refresh.go
@@ -309,14 +309,11 @@ func (c *Client) logRefreshTokenError(ctx context.Context, logger *slog.Logger, 
 
 // ClientDisconnect purges the refresh token from the [tokenstorage.Storage].
 func (c *Client) ClientDisconnect(ctx context.Context, logger *slog.Logger, client connection.Client) {
-	if c.conf.OAuth2.Refresh.UseSessionID {
+	if !c.conf.OAuth2.Refresh.Enabled || c.conf.OAuth2.Refresh.UseSessionID {
 		return
 	}
 
 	clientID := strconv.FormatUint(client.CID, 10)
-	if c.conf.OAuth2.Refresh.UseSessionID && client.SessionID != "" {
-		clientID = client.SessionID
-	}
 
 	refreshToken, err := c.storage.Get(ctx, clientID)
 	if err != nil {

--- a/internal/oauth2/refresh_test.go
+++ b/internal/oauth2/refresh_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/providers/google"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/openvpn"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/openvpn/connection"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testsuite"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/tokenstorage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -43,6 +45,47 @@ func expectProfileClientAuth(t *testing.T, suite *testsuite.Suite, cid, kid uint
 	suite.ExpectMessage(t, fmt.Sprintf("client-auth %d %d", cid, kid))
 	suite.ExpectMessage(t, `push "route 10.8.0.0 255.255.0.0"`)
 	suite.ExpectMessage(t, "END")
+}
+
+type disconnectTokenStorage struct {
+	getCount int
+}
+
+func (s *disconnectTokenStorage) Get(_ context.Context, _ string) (string, error) {
+	s.getCount++
+
+	return "", tokenstorage.ErrNotExists
+}
+
+func (s *disconnectTokenStorage) Set(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (s *disconnectTokenStorage) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func (s *disconnectTokenStorage) Close() error {
+	return nil
+}
+
+func TestClientDisconnectRefreshDisabledSkipsTokenStorage(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	conf := config.Defaults
+	conf.OAuth2.Refresh.Enabled = false
+
+	storage := &disconnectTokenStorage{}
+	suite := testsuite.New(&conf)
+	oAuth2Client, _ := suite.SetupOpenVPNOAuth2Clients(ctx, t, storage)
+
+	oAuth2Client.ClientDisconnect(ctx, suite.GetLogger(), connection.Client{CID: 7})
+
+	assert.Equal(t, 0, storage.getCount)
+	assert.NotContains(t, suite.Logs(), "error from token store")
 }
 
 func TestRefreshReAuth(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it

Reported: https://github.com/jkroepke/openvpn-auth-oauth2/issues/965#issuecomment-4890481503

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] The PR title has a summary of the changes
- [ ] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
