### PR TITLE
feat: Drop existing sessions with same username

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,11 @@ jobs:
       - name: go test -bench
         run: go test ./... -timeout 20s -run='^$' -bench=. -benchmem
 
-      - name: go test (Plugin Integration Tests)
-        run: go test ./lib/openvpn-auth-oauth2 -run '^TestIT$'
+      - name: go test (Integration Tests)
+        run: go test -race -count=1 -timeout=15m -run '^TestIT(EnforceUniqueUser)?$' ./internal ./lib/openvpn-auth-oauth2
+        env:
+          OPENVPN_IT_TEST: '1'
+          PLUGIN_IT_TEST: '1'
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,3 +5,4 @@ oauth2:
     secret: SECRET
 openvpn:
   auth-token-user: true
+  enforce-unique-user: false

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -128,6 +128,8 @@ Usage of openvpn-auth-oauth2:
     	Name of the environment variable in the OpenVPN management interface which contains the common name. If username-as-common-name is enabled, this should be set to 'username' to use the username as common name. Other values like 'X509_0_emailAddress' are supported. See https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/#environmental-variables for more information. (env: CONFIG_OPENVPN_COMMON__NAME_ENVIRONMENT__VARIABLE__NAME) (default "common_name")
   --openvpn.common-name.mode value
     	If common names are too long, use md5/sha1 to hash them or omit to skip them. Values: [plain,omit] (env: CONFIG_OPENVPN_COMMON__NAME_MODE) (default plain)
+  --openvpn.enforce-unique-user
+        Requires OpenVPN Server 2.7 and openvpn.override-username=true. If true, openvpn-auth-oauth2 enforces one active OpenVPN session per username. (env: CONFIG_OPENVPN_ENFORCE__UNIQUE__USER)
   --openvpn.override-username
     	Requires OpenVPN Server 2.7! If true, openvpn-auth-oauth2 use the override-username command to set the username in OpenVPN connection. This is useful to use real usernames in OpenVPN statistics. The username will be set after client configs are read. Read OpenVPN man page for limitations of the override-username. (env: CONFIG_OPENVPN_OVERRIDE__USERNAME)
   --openvpn.pass-through.address value

--- a/docs/OpenVPN Username.md
+++ b/docs/OpenVPN Username.md
@@ -119,6 +119,47 @@ When `openvpn.override-username` is enabled, OpenVPN's native `client-config-dir
 
 For more details, see the OpenVPN man page regarding `override-username` limitations.
 
+### Limiting a Username to One Active Session
+
+OpenVPN checks duplicate common names before `override-username` replaces a
+placeholder username with the identity resolved from OAuth2. As a result,
+OpenVPN's common-name check cannot prevent two clients that use the same shared
+profile from authenticating as the same OAuth2 user.
+
+Enable `openvpn.enforce-unique-user` to replace active sessions based on the
+resolved OAuth2 username. This applies the single-client behavior that OpenVPN
+normally bases on certificate common names, and that `duplicate-cn` disables,
+to the resolved user identity:
+
+```yaml
+openvpn:
+  override-username: true
+  enforce-unique-user: true
+```
+
+The option requires OpenVPN 2.7 or later and a direct management-interface
+connection. It is not compatible with the [OpenVPN Plugin](OpenVPN%20Plugin).
+Configuration validation rejects the option unless `openvpn.override-username`
+is also enabled.
+
+Before accepting a client, openvpn-auth-oauth2 requests `status 3`, finds every
+active client with an exactly matching `Username` field, and sends
+`client-kill <CID>` for each match except the CID currently authenticating. The
+status lookup and client acceptance are serialized so two concurrent logins
+cannot both pass the check. A status, parsing, or kill error prevents the new
+client from being accepted. If a matching CID disconnected after the status
+lookup, authentication continues because the old session is already gone.
+
+The check applies to interactive authentication, silent reauthentication, and
+non-interactive reconnects. When `oauth2.refresh.validate-user=false`, the
+resolved username is retained in encrypted refresh state so these paths use the
+same identity. The current CID is excluded, so a TLS reauthentication does not
+terminate its own session.
+
+This setting limits sessions on the OpenVPN server connected to this
+openvpn-auth-oauth2 process. It does not coordinate sessions across separate
+OpenVPN servers.
+
 ### Alternative: `openvpn.auth-token-user`
 
 If you're using OpenVPN Server < 2.7 or cannot use `override-username`, the `openvpn.auth-token-user` option provides limited username support:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,6 +105,7 @@ openvpn:
     addr: "unix:///run/openvpn/server2.sock"
     auth-token-user: true
     auth-pending-timeout: 2m
+    enforce-unique-user: true
     override-username: true
     bypass:
         common-names:
@@ -197,6 +198,7 @@ http:
 					Password:           "1jd93h5b6s82lf03jh5b2hf9",
 					AuthTokenUser:      true,
 					AuthPendingTimeout: 2 * time.Minute,
+					EnforceUniqueUser:  true,
 					OverrideUsername:   true,
 					CommonName: config.OpenVPNCommonName{
 						EnvironmentVariableName: "X509_0_emailAddress",
@@ -359,6 +361,16 @@ func TestConfigFlagSet(t *testing.T) {
 
 				conf := config.Defaults
 				conf.HTTP.AssetPath = dirFS
+
+				return conf
+			}(),
+		},
+		{
+			"--openvpn.enforce-unique-user",
+			[]string{"--openvpn.enforce-unique-user"},
+			func() config.Config {
+				conf := config.Defaults
+				conf.OpenVPN.EnforceUniqueUser = true
 
 				return conf
 			}(),

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -61,7 +61,8 @@ var Defaults = Config{
 			EnvironmentVariableName: "common_name",
 			Mode:                    CommonNameModePlain,
 		},
-		OverrideUsername: false,
+		EnforceUniqueUser: false,
+		OverrideUsername:  false,
 		Bypass: OpenVPNBypass{
 			CommonNames: types.RegexpSlice{},
 		},

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -210,6 +210,13 @@ func (c *Config) flagSetOpenVPN(flagSet *flag.FlagSet) {
 			"Read OpenVPN man page for limitations of the override-username.",
 	)
 	flagSet.BoolVar(
+		&c.OpenVPN.EnforceUniqueUser,
+		"openvpn.enforce-unique-user",
+		lookupEnvOrDefault("openvpn.enforce-unique-user", c.OpenVPN.EnforceUniqueUser),
+		"Requires OpenVPN Server 2.7 and openvpn.override-username=true. "+
+			"If true, openvpn-auth-oauth2 enforces one active OpenVPN session per username.",
+	)
+	flagSet.BoolVar(
 		&c.OpenVPN.Passthrough.Enabled,
 		"openvpn.pass-through.enabled",
 		lookupEnvOrDefault("openvpn.pass-through.enabled", c.OpenVPN.Passthrough.Enabled),

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -77,6 +77,7 @@ type OpenVPN struct {
 	ClientConfig       OpenVPNConfig      `json:"client-config"        yaml:"client-config"`
 	AuthPendingTimeout time.Duration      `json:"auth-pending-timeout" yaml:"auth-pending-timeout"`
 	CommandTimeout     time.Duration      `json:"command-timeout"      yaml:"command-timeout"`
+	EnforceUniqueUser  bool               `json:"enforce-unique-user"  yaml:"enforce-unique-user"`
 	OverrideUsername   bool               `json:"override-username"    yaml:"override-username"`
 	ReAuthentication   bool               `json:"reauthentication"     yaml:"reauthentication"`
 	AuthTokenUser      bool               `json:"auth-token-user"      yaml:"auth-token-user"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -21,18 +21,28 @@ func Validate(mode int, conf *Config) error {
 		return err
 	}
 
-	if mode == ManagementClient {
-		for key, value := range map[string]types.URL{
-			"openvpn.addr": conf.OpenVPN.Addr,
-		} {
-			if value.IsEmpty() {
-				return fmt.Errorf("%s is %w", key, ErrRequired)
-			}
-		}
+	return validateOpenVPNConfig(mode, conf)
+}
 
-		if !slices.Contains([]string{SchemeTCP, SchemeUNIX}, conf.OpenVPN.Addr.Scheme) {
-			return errors.New("openvpn.addr: invalid URL. only tcp://addr or unix://addr scheme supported")
-		}
+func validateOpenVPNConfig(mode int, conf *Config) error {
+	if conf.OpenVPN.EnforceUniqueUser && !conf.OpenVPN.OverrideUsername {
+		return errors.New("openvpn.enforce-unique-user requires openvpn.override-username=true")
+	}
+
+	if conf.OpenVPN.EnforceUniqueUser && mode != ManagementClient {
+		return errors.New("openvpn.enforce-unique-user requires the OpenVPN management interface")
+	}
+
+	if mode != ManagementClient {
+		return nil
+	}
+
+	if conf.OpenVPN.Addr.IsEmpty() {
+		return fmt.Errorf("openvpn.addr is %w", ErrRequired)
+	}
+
+	if !slices.Contains([]string{SchemeTCP, SchemeUNIX}, conf.OpenVPN.Addr.Scheme) {
+		return errors.New("openvpn.addr: invalid URL. only tcp://addr or unix://addr scheme supported")
 	}
 
 	return nil

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -308,6 +308,27 @@ func TestValidate(t *testing.T) {
 			"",
 		},
 		{
+			"single active session requires override username",
+			func() config.Config {
+				conf := validConfig()
+				conf.OpenVPN.EnforceUniqueUser = true
+
+				return conf
+			}(),
+			"openvpn.enforce-unique-user requires openvpn.override-username=true",
+		},
+		{
+			"valid single active session configuration",
+			func() config.Config {
+				conf := validConfig()
+				conf.OpenVPN.EnforceUniqueUser = true
+				conf.OpenVPN.OverrideUsername = true
+
+				return conf
+			}(),
+			"",
+		},
+		{
 			"valid openvpn passthrough",
 			func() config.Config {
 				conf := validConfig()
@@ -350,4 +371,16 @@ func validConfig() config.Config {
 			Addr: types.URL{URL: &url.URL{Scheme: "tcp", Host: "127.0.0.1:9000"}},
 		},
 	}
+}
+
+func TestValidateEnforceUniqueUserRequiresManagementClient(t *testing.T) {
+	t.Parallel()
+
+	conf := validConfig()
+	conf.OpenVPN.EnforceUniqueUser = true
+	conf.OpenVPN.OverrideUsername = true
+
+	err := config.Validate(config.Plugin, &conf)
+
+	require.EqualError(t, err, "openvpn.enforce-unique-user requires the OpenVPN management interface")
 }

--- a/internal/it_test.go
+++ b/internal/it_test.go
@@ -1,0 +1,427 @@
+//go:build (darwin || linux || openbsd || freebsd) && cgo
+
+package internal_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containerd/errdefs"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/httphandler"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/openvpn"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testsuite"
+	"github.com/moby/moby/api/types/container"
+	dockerclient "github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"golang.org/x/net/nettest"
+)
+
+const (
+	uniqueUserITImage = "testcontainers/openvpn-auth-oauth2-unique-user-it:latest"
+
+	uniqueUserServerEntrypoint = `#!/bin/sh
+set -eu
+
+if [ ! -f /etc/openvpn/pki/ca.crt ]; then
+  /usr/share/easy-rsa/easyrsa init-pki
+  /usr/share/easy-rsa/easyrsa build-ca nopass
+  /usr/share/easy-rsa/easyrsa build-server-full server nopass
+  /usr/share/easy-rsa/easyrsa build-client-full shared-client nopass
+fi
+
+printf password > /etc/openvpn/password.txt
+
+cat > /etc/openvpn/openvpn.conf <<EOF
+dev tun0
+server 100.64.0.0 255.255.255.0
+topology subnet
+proto udp
+port 1194
+
+ca /etc/openvpn/pki/ca.crt
+key /etc/openvpn/pki/private/server.key
+cert /etc/openvpn/pki/issued/server.crt
+dh none
+tls-cert-profile preferred
+verify-client-cert none
+
+management 0.0.0.0 8081 /etc/openvpn/password.txt
+management-client-auth
+management-hold
+
+auth-user-pass-optional
+duplicate-cn
+disable-dco
+explicit-exit-notify
+keepalive 10 60
+persist-key
+persist-tun
+reneg-sec 600
+verb 3
+EOF
+
+for management_port in 8082 8083; do
+  cat > "/etc/openvpn/client-$management_port.ovpn" <<EOF
+client
+dev tun
+setenv IV_SSO webauth
+nobind
+remote 127.0.0.1 1194 udp4
+remote-cert-tls server
+connect-retry-max 2
+tls-cert-profile preferred
+persist-key
+persist-tun
+disable-dco
+reneg-sec 0
+verb 3
+management 0.0.0.0 $management_port
+management-hold
+<key>
+$(cat /etc/openvpn/pki/private/shared-client.key)
+</key>
+<cert>
+$(openssl x509 -in /etc/openvpn/pki/issued/shared-client.crt)
+</cert>
+<ca>
+$(cat /etc/openvpn/pki/ca.crt)
+</ca>
+EOF
+done
+
+exec openvpn --config /etc/openvpn/openvpn.conf --tmp-dir /tmp/
+`
+)
+
+type managedOpenVPNITClient struct {
+	container  testcontainers.Container
+	connection net.Conn
+	management *testsuite.Conn
+}
+
+func TestITEnforceUniqueUser(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	if os.Getenv("CI") == "" && os.Getenv("OPENVPN_IT_TEST") != "1" {
+		t.Skip("skipping integration test, OPENVPN_IT_TEST is not set")
+	}
+
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	volumeName := fmt.Sprintf("openvpn-auth-oauth2-unique-user-it-%d", time.Now().UnixNano())
+	setupUniqueUserITDockerCleanup(t, volumeName)
+	server := startUniqueUserITServer(t, volumeName)
+	client1 := startUniqueUserITClient(t, server, volumeName, 8082)
+	client2 := startUniqueUserITClient(t, server, volumeName, 8083)
+
+	suite, httpServer, openVPNClient, connectErrCh := startUniqueUserITService(t, server)
+	t.Cleanup(func() {
+		openVPNClient.Shutdown(context.Background())
+
+		select {
+		case err := <-connectErrCh:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Errorf("OpenVPN management client stopped with an error: %v\n%s", err, suite.Logs())
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("timeout waiting for OpenVPN management client shutdown\n%s", suite.Logs())
+		}
+	})
+
+	authenticateUniqueUserITClient(t, client1, httpServer, server)
+	authenticateUniqueUserITClient(t, client2, httpServer, server)
+
+	waitForOpenVPNITMessage(t, client1, server, func(line string) bool {
+		return strings.HasPrefix(line, ">HOLD:Waiting for hold release:")
+	})
+}
+
+func setupUniqueUserITDockerCleanup(t *testing.T, volumeName string) {
+	t.Helper()
+
+	dockerClient, err := testcontainers.NewDockerClientWithOpts(t.Context())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = dockerClient.Close()
+	})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		_, err := dockerClient.VolumeRemove(ctx, volumeName, dockerclient.VolumeRemoveOptions{Force: true})
+		if err != nil && !errdefs.IsNotFound(err) {
+			t.Errorf("remove Docker volume %s: %v", volumeName, err)
+		}
+	})
+}
+
+func startUniqueUserITServer(t *testing.T, volumeName string) testcontainers.Container {
+	t.Helper()
+
+	server, err := testcontainers.Run(
+		t.Context(),
+		"",
+		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
+			Context:    "../",
+			Dockerfile: "./tests/Dockerfile",
+			Repo:       "testcontainers/openvpn-auth-oauth2-unique-user-it",
+			Tag:        "latest",
+			KeepImage:  true,
+		}),
+		testcontainers.WithExposedPorts("8081/tcp", "8082/tcp", "8083/tcp"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("MANAGEMENT: TCP Socket listening").WithStartupTimeout(2*time.Minute),
+		),
+		testcontainers.WithLabels(map[string]string{"testcontainers": "true"}),
+		testcontainers.WithMounts(testcontainers.ContainerMount{
+			Source: testcontainers.GenericVolumeMountSource{Name: volumeName},
+			Target: "/etc/openvpn",
+		}),
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			Reader:            strings.NewReader(uniqueUserServerEntrypoint),
+			ContainerFilePath: "/entrypoint.sh",
+			FileMode:          0o755,
+		}),
+		withOpenVPNITContainerPrivileges(""),
+		testcontainers.WithEntrypoint("/entrypoint.sh"),
+	)
+	if server != nil {
+		testcontainers.CleanupContainer(t, server)
+	}
+
+	require.NoError(t, err, openVPNITContainerLogs(t, server))
+	require.NotNil(t, server)
+
+	return server
+}
+
+func startUniqueUserITClient(
+	t *testing.T,
+	server testcontainers.Container,
+	volumeName string,
+	managementPort int,
+) managedOpenVPNITClient {
+	t.Helper()
+
+	clientContainer, err := testcontainers.Run(
+		t.Context(),
+		uniqueUserITImage,
+		testcontainers.WithLabels(map[string]string{"testcontainers": "true"}),
+		testcontainers.WithMounts(testcontainers.ContainerMount{
+			Source: testcontainers.GenericVolumeMountSource{Name: volumeName},
+			Target: "/etc/openvpn",
+		}),
+		withOpenVPNITContainerPrivileges(server.GetContainerID()),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("Need hold release from management interface").WithStartupTimeout(30*time.Second),
+		),
+		testcontainers.WithEntrypoint("openvpn"),
+		testcontainers.WithEntrypointArgs(
+			"--config",
+			fmt.Sprintf("/etc/openvpn/client-%d.ovpn", managementPort),
+			"--echo",
+			"off",
+		),
+	)
+	if clientContainer != nil {
+		testcontainers.CleanupContainer(t, clientContainer)
+	}
+
+	require.NoError(t, err, openVPNITContainerLogs(t, server, clientContainer))
+	require.NotNil(t, clientContainer)
+
+	managementEndpoint, err := server.PortEndpoint(t.Context(), strconv.Itoa(managementPort), "tcp")
+	require.NoError(t, err)
+
+	var dialer net.Dialer
+
+	managementConnection, err := dialer.DialContext(
+		t.Context(),
+		"tcp",
+		strings.TrimPrefix(managementEndpoint, "tcp://"),
+	)
+	require.NoError(t, err, openVPNITContainerLogs(t, server, clientContainer))
+	t.Cleanup(func() {
+		_ = managementConnection.Close()
+	})
+
+	management := testsuite.NewConn(managementConnection).WithLogs(func() string {
+		return openVPNITContainerLogs(t, server, clientContainer)
+	})
+	require.Regexp(
+		t,
+		`^>INFO:OpenVPN Management Interface Version [5-9][0-9]* -- type 'help' for more info$`,
+		management.ReadLine(t),
+	)
+	management.ExpectMessage(t, ">HOLD:Waiting for hold release:0")
+	management.SendAndExpectMessage(t, "state on", "SUCCESS: real-time state notification set to ON")
+
+	return managedOpenVPNITClient{
+		container:  clientContainer,
+		connection: managementConnection,
+		management: management,
+	}
+}
+
+func withOpenVPNITContainerPrivileges(networkContainerID string) testcontainers.CustomizeRequestOption {
+	return testcontainers.WithHostConfigModifier(func(hostConfig *container.HostConfig) {
+		hostConfig.Binds = []string{"/dev/net/tun:/dev/net/tun"}
+
+		hostConfig.CapAdd = []string{"NET_ADMIN"}
+		if networkContainerID != "" {
+			hostConfig.NetworkMode = container.NetworkMode("container:" + networkContainerID)
+		}
+	})
+}
+
+func startUniqueUserITService(
+	t *testing.T,
+	server testcontainers.Container,
+) (*testsuite.Suite, *httptest.Server, *openvpn.Client, <-chan error) {
+	t.Helper()
+
+	clientListener, err := nettest.NewLocalListener("tcp")
+	require.NoError(t, err)
+
+	managementEndpoint, err := server.PortEndpoint(t.Context(), "8081", "tcp")
+	require.NoError(t, err)
+
+	conf := config.Defaults
+	conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+	conf.OpenVPN.Addr = types.URL{
+		URL: &url.URL{Scheme: "tcp", Host: strings.TrimPrefix(managementEndpoint, "tcp://")},
+	}
+	conf.OpenVPN.Password = testsuite.Password
+	conf.OpenVPN.EnforceUniqueUser = true
+	conf.OpenVPN.OverrideUsername = true
+
+	suite := testsuite.New(&conf)
+	suite.SetupOIDCServer(t, clientListener, nil)
+	oAuth2Client, openVPNClient := suite.SetupOpenVPNOAuth2Clients(t.Context(), t, nil)
+
+	connectErrCh := make(chan error, 1)
+	go func() {
+		connectErrCh <- openVPNClient.Connect(t.Context())
+	}()
+
+	httpServer := httptest.NewUnstartedServer(httphandler.New(suite.GetConfig(), oAuth2Client))
+	require.NoError(t, httpServer.Listener.Close())
+
+	httpServer.Listener = clientListener
+	httpServer.Start()
+	t.Cleanup(httpServer.Close)
+
+	return suite, httpServer, openVPNClient, connectErrCh
+}
+
+func authenticateUniqueUserITClient(
+	t *testing.T,
+	client managedOpenVPNITClient,
+	httpServer *httptest.Server,
+	server testcontainers.Container,
+) {
+	t.Helper()
+
+	client.management.SendAndExpectMessage(t, "hold release", "SUCCESS: hold release succeeded")
+
+	webAuthMessage := waitForOpenVPNITMessage(t, client, server, func(line string) bool {
+		return strings.HasPrefix(line, ">INFOMSG:WEB_AUTH::")
+	})
+	webAuthURL := strings.TrimSpace(strings.TrimPrefix(webAuthMessage, ">INFOMSG:WEB_AUTH::"))
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	httpClient := httpServer.Client()
+	httpClient.Jar = jar
+
+	resp, _, err := testsuite.DoHTTPRequest(t, httpClient, "", http.MethodGet, webAuthURL, nil, http.NoBody) //nolint:bodyclose
+	require.NoError(t, err, openVPNITContainerLogs(t, server, client.container))
+	require.Equal(t, http.StatusOK, resp.StatusCode, openVPNITContainerLogs(t, server, client.container))
+
+	waitForOpenVPNITMessage(t, client, server, func(line string) bool {
+		return strings.HasPrefix(line, ">STATE:") && strings.Contains(line, ",CONNECTED,")
+	})
+}
+
+func waitForOpenVPNITMessage(
+	t *testing.T,
+	client managedOpenVPNITClient,
+	server testcontainers.Container,
+	matches func(string) bool,
+) string {
+	t.Helper()
+
+	require.NoError(t, client.connection.SetReadDeadline(time.Now().Add(30*time.Second)))
+
+	var received []string
+
+	for {
+		line, err := client.management.Reader().ReadString('\n')
+		if err != nil {
+			t.Fatalf(
+				"read OpenVPN client management event: %v\nreceived:\n%s\n%s",
+				err,
+				strings.Join(received, "\n"),
+				openVPNITContainerLogs(t, server, client.container),
+			)
+		}
+
+		line = strings.TrimSpace(line)
+		received = append(received, line)
+
+		if matches(line) {
+			return line
+		}
+	}
+}
+
+func openVPNITContainerLogs(t *testing.T, containers ...testcontainers.Container) string {
+	t.Helper()
+
+	var logs strings.Builder
+
+	for _, testContainer := range containers {
+		if testContainer == nil {
+			continue
+		}
+
+		logReader, err := testContainer.Logs(t.Context())
+		if err != nil {
+			_, _ = fmt.Fprintf(&logs, "read container %s logs: %v\n", testContainer.GetContainerID(), err)
+
+			continue
+		}
+
+		containerLogs, readErr := io.ReadAll(logReader)
+		_ = logReader.Close()
+
+		_, _ = fmt.Fprintf(&logs, "container %s:\n%s\n", testContainer.GetContainerID(), containerLogs)
+		if readErr != nil {
+			_, _ = fmt.Fprintf(&logs, "read container log stream: %v\n", readErr)
+		}
+	}
+
+	return logs.String()
+}

--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -226,7 +226,7 @@ func (c *Client) OAuth2ProfileSubmit() http.Handler {
 			return
 		}
 
-		c.storeSelectedProfileRefreshState(ctx, logger, oAuth2State, clientID, clientConfigName)
+		c.storeSelectedProfileRefreshState(ctx, logger, oAuth2State, clientID, username, clientConfigName)
 
 		c.writeHTTPSuccess(ctx, w, logger)
 	})
@@ -242,14 +242,14 @@ func (c *Client) getClientID(session state.State) string {
 }
 
 func (c *Client) storeSelectedProfileRefreshState(
-	ctx context.Context, logger *slog.Logger, session state.State, clientID, clientConfigName string,
+	ctx context.Context, logger *slog.Logger, session state.State, clientID, username, clientConfigName string,
 ) {
 	if !c.conf.OAuth2.Refresh.Enabled {
 		return
 	}
 
 	if !c.conf.OAuth2.Refresh.ValidateUser {
-		c.postCodeExchangeHandlerStoreRefreshToken(ctx, logger, session, clientID, nil, []string{clientConfigName})
+		c.postCodeExchangeHandlerStoreRefreshToken(ctx, logger, session, clientID, username, nil, []string{clientConfigName})
 
 		return
 	}
@@ -475,7 +475,7 @@ func (c *Client) handleClientConfigSelector(ctx context.Context, w http.Response
 		return true
 	default:
 		if c.conf.OAuth2.Refresh.ValidateUser {
-			c.postCodeExchangeHandlerStoreRefreshToken(ctx, req.logger, req.session, req.clientID, req.tokens, nil)
+			c.postCodeExchangeHandlerStoreRefreshToken(ctx, req.logger, req.session, req.clientID, req.username, req.tokens, nil)
 		}
 
 		if err := c.renderClientConfigProfileSelector(ctx, w, req, clientConfigProfiles); err != nil {
@@ -564,20 +564,25 @@ func (c *Client) acceptOAuth2Client(
 		return
 	}
 
-	c.postCodeExchangeHandlerStoreRefreshToken(ctx, req.logger, req.session, req.clientID, req.tokens, clientConfigNames)
+	c.postCodeExchangeHandlerStoreRefreshToken(ctx, req.logger, req.session, req.clientID, req.username, req.tokens, clientConfigNames)
 	c.writeHTTPSuccess(ctx, w, req.logger)
 }
 
 // postCodeExchangeHandlerStoreRefreshToken stores refresh data for future non-interactive authentication.
 func (c *Client) postCodeExchangeHandlerStoreRefreshToken(
-	ctx context.Context, logger *slog.Logger, session state.State, clientID string, tokens *idtoken.IDToken, clientConfigNames []string,
+	ctx context.Context,
+	logger *slog.Logger,
+	session state.State,
+	clientID, username string,
+	tokens *idtoken.IDToken,
+	clientConfigNames []string,
 ) {
 	if !c.conf.OAuth2.Refresh.Enabled {
 		return
 	}
 
 	if !c.conf.OAuth2.Refresh.ValidateUser {
-		c.storeInternalRefreshToken(ctx, logger, clientID, clientConfigNames)
+		c.storeInternalRefreshToken(ctx, logger, clientID, username, clientConfigNames)
 
 		return
 	}
@@ -607,14 +612,16 @@ func (c *Client) postCodeExchangeHandlerStoreRefreshToken(
 	}
 }
 
-func (c *Client) storeInternalRefreshToken(ctx context.Context, logger *slog.Logger, clientID string, clientConfigNames []string) {
-	internalToken, err := encodeInternalRefreshToken(clientConfigNames)
+func (c *Client) storeInternalRefreshToken(
+	ctx context.Context, logger *slog.Logger, clientID, username string, clientConfigNames []string,
+) {
+	internalToken, err := encodeInternalRefreshToken(username, clientConfigNames)
 	if err != nil {
 		logger.LogAttrs(ctx, slog.LevelWarn, err.Error())
 	} else if err := c.storage.Set(ctx, clientID, internalToken); err != nil {
 		logger.LogAttrs(ctx, slog.LevelWarn, err.Error())
 	} else {
-		logger.LogAttrs(ctx, slog.LevelDebug, "empty token for non-interactive re-authentication stored")
+		logger.LogAttrs(ctx, slog.LevelDebug, "internal token for non-interactive re-authentication stored")
 	}
 }
 

--- a/internal/oauth2/handler_profile_refresh_test.go
+++ b/internal/oauth2/handler_profile_refresh_test.go
@@ -28,7 +28,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
 		client := Client{conf: &conf, storage: storage}
 
-		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "selected")
+		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "alice", "selected")
 
 		_, err := storage.Get(ctx, "7")
 		require.ErrorIs(t, err, tokenstorage.ErrNotExists)
@@ -43,13 +43,14 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
 		client := Client{conf: &conf, storage: storage}
 
-		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "selected")
+		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "alice", "selected")
 
 		refreshToken, err := storage.Get(ctx, "7")
 		require.NoError(t, err)
 
-		clientConfigNames, err := decodeInternalRefreshToken(refreshToken)
+		username, clientConfigNames, err := decodeInternalRefreshToken(refreshToken)
 		require.NoError(t, err)
+		require.Equal(t, "alice", username)
 		require.Equal(t, []string{"selected"}, clientConfigNames)
 	})
 
@@ -65,7 +66,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		require.NoError(t, storage.Set(ctx, "7", storedToken))
 
 		client := Client{conf: &conf, storage: storage}
-		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "selected")
+		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "alice", "selected")
 
 		refreshToken, err := storage.Get(ctx, "7")
 		require.NoError(t, err)
@@ -85,7 +86,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		storage := &profileRefreshStorage{getErr: errors.New("get failed")}
 		client := Client{conf: &conf, storage: storage}
 
-		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "selected")
+		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "alice", "selected")
 
 		require.False(t, storage.setCalled)
 	})
@@ -100,7 +101,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		require.NoError(t, storage.Set(ctx, "7", providerRefreshTokenPrefix+"{"))
 
 		client := Client{conf: &conf, storage: storage}
-		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "selected")
+		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "alice", "selected")
 
 		refreshToken, err := storage.Get(ctx, "7")
 		require.NoError(t, err)
@@ -122,7 +123,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		}
 		client := Client{conf: &conf, storage: storage}
 
-		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "selected")
+		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "alice", "selected")
 
 		require.True(t, storage.setCalled)
 

--- a/internal/oauth2/refresh.go
+++ b/internal/oauth2/refresh.go
@@ -23,6 +23,7 @@ const (
 )
 
 type internalRefreshToken struct {
+	Username          string   `json:"username,omitempty"`
 	ClientConfigNames []string `json:"client-config-names,omitempty"`
 }
 
@@ -47,14 +48,20 @@ func (c *Client) RefreshClientAuth(
 	}
 
 	if !c.conf.OAuth2.Refresh.ValidateUser {
-		clientConfigNames, err := decodeInternalRefreshToken(refreshToken)
+		username, clientConfigNames, err := decodeInternalRefreshToken(refreshToken)
 		if err != nil {
 			return types.UserInfo{}, nil, nil, false, err
 		}
 
+		if c.conf.OpenVPN.EnforceUniqueUser && username == "" {
+			logger.LogAttrs(ctx, slog.LevelInfo, "stored internal token has no username; interactive authentication is required")
+
+			return types.UserInfo{}, nil, nil, false, nil
+		}
+
 		logger.LogAttrs(ctx, slog.LevelInfo, "successful non-interactive authentication via internal token")
 
-		return types.UserInfo{}, nil, clientConfigNames, true, nil
+		return types.UserInfo{Username: username}, nil, clientConfigNames, true, nil
 	}
 
 	refreshToken, clientConfigNames, err := decodeProviderRefreshToken(refreshToken)
@@ -83,12 +90,15 @@ func (c *Client) RefreshClientAuth(
 	return user, tokens, clientConfigNames, true, nil
 }
 
-func encodeInternalRefreshToken(clientConfigNames []string) (string, error) {
-	if len(clientConfigNames) == 0 {
+func encodeInternalRefreshToken(username string, clientConfigNames []string) (string, error) {
+	if username == "" && len(clientConfigNames) == 0 {
 		return types.EmptyToken, nil
 	}
 
-	tokenBytes, err := json.Marshal(internalRefreshToken{ClientConfigNames: clientConfigNames})
+	tokenBytes, err := json.Marshal(internalRefreshToken{
+		ClientConfigNames: clientConfigNames,
+		Username:          username,
+	})
 	if err != nil {
 		return "", fmt.Errorf("unable to marshal internal refresh token: %w", err)
 	}
@@ -96,17 +106,19 @@ func encodeInternalRefreshToken(clientConfigNames []string) (string, error) {
 	return internalRefreshTokenPrefix + string(tokenBytes), nil
 }
 
-func decodeInternalRefreshToken(refreshToken string) ([]string, error) {
+func decodeInternalRefreshToken(refreshToken string) (string, []string, error) {
 	if !strings.HasPrefix(refreshToken, internalRefreshTokenPrefix) {
-		return nil, nil
+		return "", nil, nil
 	}
 
 	var token internalRefreshToken
 	if err := json.Unmarshal([]byte(strings.TrimPrefix(refreshToken, internalRefreshTokenPrefix)), &token); err != nil {
-		return nil, fmt.Errorf("unable to parse internal refresh token: %w", err)
+		return "", nil, fmt.Errorf("unable to parse internal refresh token: %w", err)
 	}
 
-	return validateClientConfigNames(token.ClientConfigNames)
+	clientConfigNames, err := validateClientConfigNames(token.ClientConfigNames)
+
+	return token.Username, clientConfigNames, err
 }
 
 func encodeProviderRefreshToken(refreshToken string, clientConfigNames []string) (string, error) {

--- a/internal/oauth2/refresh_internal_test.go
+++ b/internal/oauth2/refresh_internal_test.go
@@ -22,7 +22,7 @@ func TestRefreshClientAuthInternalTokenRestoresClientConfigNames(t *testing.T) {
 	conf.OAuth2.Refresh.ValidateUser = false
 
 	storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
-	internalToken, err := encodeInternalRefreshToken([]string{"profile", "base"})
+	internalToken, err := encodeInternalRefreshToken("alice", []string{"profile", "base"})
 	require.NoError(t, err)
 	require.NoError(t, storage.Set(ctx, "7", internalToken))
 
@@ -31,7 +31,7 @@ func TestRefreshClientAuthInternalTokenRestoresClientConfigNames(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, types.UserInfo{}, user)
+	require.Equal(t, types.UserInfo{Username: "alice"}, user)
 	require.Nil(t, tokens)
 	require.Equal(t, []string{"profile", "base"}, clientConfigNames)
 }
@@ -52,6 +52,65 @@ func TestRefreshClientAuthInternalTokenKeepsLegacyEmptyToken(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, ok)
+	require.Nil(t, tokens)
+	require.Nil(t, clientConfigNames)
+}
+
+func TestRefreshClientAuthInternalTokenKeepsLegacyClientConfigToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conf := config.Defaults
+	conf.OAuth2.Refresh.Enabled = true
+	conf.OAuth2.Refresh.ValidateUser = false
+
+	storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+	require.NoError(t, storage.Set(
+		ctx,
+		"7",
+		internalRefreshTokenPrefix+`{"client-config-names":["profile","base"]}`,
+	))
+
+	client := Client{conf: &conf, storage: storage}
+	user, tokens, clientConfigNames, ok, err := client.RefreshClientAuth(
+		ctx,
+		slog.New(slog.DiscardHandler),
+		connection.Client{CID: 7},
+	)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, types.UserInfo{}, user)
+	require.Nil(t, tokens)
+	require.Equal(t, []string{"profile", "base"}, clientConfigNames)
+}
+
+func TestRefreshClientAuthInternalTokenWithoutUsernameFallsBackToInteractiveAuthentication(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conf := config.Defaults
+	conf.OAuth2.Refresh.Enabled = true
+	conf.OAuth2.Refresh.ValidateUser = false
+	conf.OpenVPN.EnforceUniqueUser = true
+
+	storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+	require.NoError(t, storage.Set(
+		ctx,
+		"7",
+		internalRefreshTokenPrefix+`{"client-config-names":["profile","base"]}`,
+	))
+
+	client := Client{conf: &conf, storage: storage}
+	user, tokens, clientConfigNames, ok, err := client.RefreshClientAuth(
+		ctx,
+		slog.New(slog.DiscardHandler),
+		connection.Client{CID: 7},
+	)
+
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, types.UserInfo{}, user)
 	require.Nil(t, tokens)
 	require.Nil(t, clientConfigNames)
 }
@@ -106,7 +165,7 @@ func TestDecodeInternalRefreshTokenErrors(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			clientConfigNames, err := decodeInternalRefreshToken(testCase.refreshToken)
+			_, clientConfigNames, err := decodeInternalRefreshToken(testCase.refreshToken)
 
 			require.Error(t, err)
 			require.Contains(t, err.Error(), testCase.expectedErr)
@@ -162,13 +221,14 @@ func TestDecodeProviderRefreshTokenErrors(t *testing.T) {
 func TestEncodeInternalRefreshToken(t *testing.T) {
 	t.Parallel()
 
-	emptyToken, err := encodeInternalRefreshToken(nil)
+	emptyToken, err := encodeInternalRefreshToken("", nil)
 	require.NoError(t, err)
 	require.Equal(t, types.EmptyToken, emptyToken)
 
-	encodedToken, err := encodeInternalRefreshToken([]string{"profile"})
+	encodedToken, err := encodeInternalRefreshToken("alice", []string{"profile"})
 	require.NoError(t, err)
 	require.Contains(t, encodedToken, internalRefreshTokenPrefix)
+	require.Contains(t, encodedToken, `"username":"alice"`)
 }
 
 func TestDecodeProviderRefreshTokenPreservesValidationError(t *testing.T) {

--- a/internal/openvpn/callbacks.go
+++ b/internal/openvpn/callbacks.go
@@ -30,6 +30,20 @@ func (c *Client) AcceptClient(ctx context.Context, logger *slog.Logger, client s
 		return err
 	}
 
+	if c.conf.OpenVPN.EnforceUniqueUser {
+		c.acceptMu.Lock()
+		defer c.acceptMu.Unlock()
+
+		if err = c.enforceUniqueUser(ctx, logger, client.CID, username); err != nil {
+			logger.LogAttrs(
+				ctx, slog.LevelWarn, "failed to terminate existing OpenVPN sessions",
+				slog.Any("error", err),
+			)
+
+			return err
+		}
+	}
+
 	err = c.sendClientAuth(ctx, client, clientConfig)
 	if err != nil {
 		logger.LogAttrs(
@@ -68,7 +82,7 @@ func (c *Client) loadClientConfig(
 }
 
 func (c *Client) applyUsernameConfig(clientConfig []string, client state.ClientIdentifier, username string) []string {
-	if !c.conf.OAuth2.Refresh.ValidateUser {
+	if !c.conf.OAuth2.Refresh.ValidateUser && !c.conf.OpenVPN.EnforceUniqueUser {
 		return clientConfig
 	}
 

--- a/internal/openvpn/callbacks_test.go
+++ b/internal/openvpn/callbacks_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"net/url"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -63,6 +64,195 @@ func TestAcceptClientClosesClientConfigFile(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(time.Second):
 		t.Fatalf("timeout waiting for AcceptClient. Logs:\n\n%s", suite.Logs())
+	}
+
+	require.NoError(t, suite.GetManagementInterfaceConn().Close())
+
+	select {
+	case err := <-errOpenVPNClientCh:
+		if err != nil && !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
+	}
+}
+
+func TestAcceptClientEnforcesUniqueUser(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	conf := config.Defaults
+	conf.OAuth2.Refresh.ValidateUser = false
+	conf.OpenVPN.EnforceUniqueUser = true
+	conf.OpenVPN.OverrideUsername = true
+
+	suite := testsuite.New(&conf)
+	errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, t, nil)
+	openVPNClient := suite.GetOpenVPNClient()
+
+	suite.ExpectVersionAndReleaseHold(t)
+
+	acceptDone := make(chan error, 1)
+	go func() {
+		acceptDone <- openVPNClient.AcceptClient(
+			ctx,
+			suite.GetLogger(),
+			state.ClientIdentifier{CID: 10, KID: 2},
+			"alice",
+		)
+	}()
+
+	suite.ExpectMessage(t, "status 3")
+	suite.SendMessagef(
+		t,
+		"HEADER\tCLIENT_LIST\tCommon Name\tReal Address\tVirtual Address\tVirtual IPv6 Address\t"+
+			"Bytes Received\tBytes Sent\tConnected Since\tConnected Since (time_t)\tUsername\tClient ID\tPeer ID\tData Channel Cipher\r\n"+
+			"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.2\t\t1\t2\tnow\t1\talice\t7\t0\tAES-256-GCM\r\n"+
+			"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.3\t\t1\t2\tnow\t1\tbob\t8\t0\tAES-256-GCM\r\n"+
+			"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.4\t\t1\t2\tnow\t1\talice\t10\t0\tAES-256-GCM\r\n"+
+			"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.5\t\t1\t2\tnow\t1\talice\t12\t0\tAES-256-GCM\r\nEND",
+	)
+
+	suite.ExpectMessage(t, "client-kill 7")
+	suite.SendMessagef(t, "SUCCESS: client-kill command succeeded")
+	suite.ExpectMessage(t, "client-kill 12")
+	suite.SendMessagef(t, "ERROR: client-kill command failed")
+	suite.ExpectMessage(t, "client-auth 10 2\r\noverride-username \"alice\"\r\nEND")
+	suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")
+
+	select {
+	case err := <-acceptDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for AcceptClient. Logs:\n\n%s", suite.Logs())
+	}
+
+	require.NoError(t, suite.GetManagementInterfaceConn().Close())
+
+	select {
+	case err := <-errOpenVPNClientCh:
+		if err != nil && !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
+	}
+}
+
+func TestAcceptClientFailsClosedWhenStatusFails(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	conf := config.Defaults
+	conf.OpenVPN.EnforceUniqueUser = true
+	conf.OpenVPN.OverrideUsername = true
+
+	suite := testsuite.New(&conf)
+	errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, t, nil)
+	openVPNClient := suite.GetOpenVPNClient()
+
+	suite.ExpectVersionAndReleaseHold(t)
+
+	acceptDone := make(chan error, 1)
+	go func() {
+		acceptDone <- openVPNClient.AcceptClient(
+			ctx,
+			suite.GetLogger(),
+			state.ClientIdentifier{CID: 10, KID: 2},
+			"alice",
+		)
+	}()
+
+	suite.ExpectMessage(t, "status 3")
+	suite.SendMessagef(t, "ERROR: status command failed")
+
+	select {
+	case err := <-acceptDone:
+		require.ErrorContains(t, err, "query OpenVPN status")
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for AcceptClient. Logs:\n\n%s", suite.Logs())
+	}
+
+	_, err := readOpenVPNManagementLine(t, suite, 100*time.Millisecond)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+
+	require.NoError(t, suite.GetManagementInterfaceConn().Close())
+
+	select {
+	case err := <-errOpenVPNClientCh:
+		if err != nil && !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
+	}
+}
+
+func TestAcceptClientSerializesSessionReplacement(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	conf := config.Defaults
+	conf.OpenVPN.EnforceUniqueUser = true
+	conf.OpenVPN.OverrideUsername = true
+
+	suite := testsuite.New(&conf)
+	errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, t, nil)
+	openVPNClient := suite.GetOpenVPNClient()
+
+	suite.ExpectVersionAndReleaseHold(t)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- openVPNClient.AcceptClient(ctx, suite.GetLogger(), state.ClientIdentifier{CID: 1, KID: 1}, "alice")
+	}()
+
+	suite.ExpectMessage(t, "status 3")
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- openVPNClient.AcceptClient(ctx, suite.GetLogger(), state.ClientIdentifier{CID: 2, KID: 1}, "alice")
+	}()
+
+	_, err := readOpenVPNManagementLine(t, suite, 100*time.Millisecond)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+
+	statusHeader := "HEADER\tCLIENT_LIST\tCommon Name\tReal Address\tVirtual Address\tVirtual IPv6 Address\t" +
+		"Bytes Received\tBytes Sent\tConnected Since\tConnected Since (time_t)\tUsername\tClient ID\tPeer ID\tData Channel Cipher"
+	suite.SendMessagef(t, statusHeader+"\r\nEND")
+	suite.ExpectMessage(t, "client-auth 1 1\r\noverride-username \"alice\"\r\nEND")
+	suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")
+
+	select {
+	case err := <-firstDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for first AcceptClient. Logs:\n\n%s", suite.Logs())
+	}
+
+	suite.ExpectMessage(t, "status 3")
+	suite.SendMessagef(
+		t,
+		statusHeader+"\r\n"+
+			"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.2\t\t1\t2\tnow\t1\talice\t1\t0\tAES-256-GCM\r\nEND",
+	)
+	suite.ExpectMessage(t, "client-kill 1")
+	suite.SendMessagef(t, "SUCCESS: client-kill command succeeded")
+	suite.ExpectMessage(t, "client-auth 2 1\r\noverride-username \"alice\"\r\nEND")
+	suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")
+
+	select {
+	case err := <-secondDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for second AcceptClient. Logs:\n\n%s", suite.Logs())
 	}
 
 	require.NoError(t, suite.GetManagementInterfaceConn().Close())

--- a/internal/openvpn/client.go
+++ b/internal/openvpn/client.go
@@ -59,8 +59,7 @@ func (c *Client) handleClientAuthentication(ctx context.Context, logger *slog.Lo
 
 	// Check if the client is allowed to bypass authentication. If so, accept the client.
 	if c.checkAuthBypass(client) {
-		logger.LogAttrs(ctx, slog.LevelInfo, "client bypass authentication")
-		_ = c.AcceptClient(ctx, logger, state.ClientIdentifier{CID: client.CID, KID: client.KID}, client.CommonName, "")
+		c.acceptBypassedClient(ctx, logger, client)
 
 		return
 	}
@@ -86,18 +85,10 @@ func (c *Client) handleClientAuthentication(ctx context.Context, logger *slog.Lo
 		)
 
 		return
-	} else if ok {
-		if tokens != nil && len(clientConfigNames) == 0 {
-			clientConfigNames, err = c.oauth2.ResolveClientConfigNames(tokens, client.CommonName, user.Username)
-			if err != nil {
-				logger.LogAttrs(ctx, slog.LevelWarn, "failed to resolve client config", slog.Any("err", err))
-				c.DenyClient(ctx, logger, state.ClientIdentifier{CID: client.CID, KID: client.KID}, "invalid client config")
+	}
 
-				return
-			}
-		}
-
-		_ = c.AcceptClient(ctx, logger, state.ClientIdentifier{CID: client.CID, KID: client.KID}, user.Username, clientConfigNames...)
+	if ok {
+		c.acceptSilentlyReAuthenticatedClient(ctx, logger, client, user, tokens, clientConfigNames)
 
 		return
 	}
@@ -111,6 +102,53 @@ func (c *Client) handleClientAuthentication(ctx context.Context, logger *slog.Lo
 		)
 
 		c.DenyClient(ctx, logger, state.ClientIdentifier{CID: client.CID, KID: client.KID}, "internal error")
+	}
+}
+
+func (c *Client) acceptBypassedClient(ctx context.Context, logger *slog.Logger, client connection.Client) {
+	logger.LogAttrs(ctx, slog.LevelInfo, "client bypass authentication")
+
+	clientIdentifier := stateClientIdentifier(client)
+	if err := c.AcceptClient(ctx, logger, clientIdentifier, client.CommonName, ""); err != nil {
+		logger.LogAttrs(ctx, slog.LevelWarn, "failed to accept bypassed client", slog.Any("err", err))
+		c.DenyClient(ctx, logger, clientIdentifier, "authentication acceptance failed")
+	}
+}
+
+func (c *Client) acceptSilentlyReAuthenticatedClient(
+	ctx context.Context,
+	logger *slog.Logger,
+	client connection.Client,
+	user types.UserInfo,
+	tokens *idtoken.IDToken,
+	clientConfigNames []string,
+) {
+	if tokens != nil && len(clientConfigNames) == 0 {
+		var err error
+
+		clientConfigNames, err = c.oauth2.ResolveClientConfigNames(tokens, client.CommonName, user.Username)
+		if err != nil {
+			logger.LogAttrs(ctx, slog.LevelWarn, "failed to resolve client config", slog.Any("err", err))
+			c.DenyClient(ctx, logger, stateClientIdentifier(client), "invalid client config")
+
+			return
+		}
+	}
+
+	clientIdentifier := stateClientIdentifier(client)
+	if err := c.AcceptClient(ctx, logger, clientIdentifier, user.Username, clientConfigNames...); err != nil {
+		logger.LogAttrs(ctx, slog.LevelWarn, "failed to accept silently re-authenticated client", slog.Any("err", err))
+		c.DenyClient(ctx, logger, clientIdentifier, "authentication acceptance failed")
+	}
+}
+
+func stateClientIdentifier(client connection.Client) state.ClientIdentifier {
+	return state.ClientIdentifier{
+		SessionID:         client.SessionID,
+		CommonName:        client.CommonName,
+		CID:               client.CID,
+		KID:               client.KID,
+		UsernameIsDefined: client.UsernameIsDefined,
 	}
 }
 

--- a/internal/openvpn/client_refresh_test.go
+++ b/internal/openvpn/client_refresh_test.go
@@ -128,6 +128,60 @@ func TestClientAuthenticationEventsKeepSameClientOrder(t *testing.T) {
 	suite.SendMessagef(t, "SUCCESS: client-pending-auth command succeeded")
 }
 
+func TestSilentAuthenticationEnforcesUniqueUser(t *testing.T) {
+	t.Parallel()
+
+	for _, reason := range []string{"CONNECT", "REAUTH"} {
+		t.Run(reason, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(cancel)
+
+			conf := config.Defaults
+			conf.OAuth2.Refresh.Enabled = true
+			conf.OAuth2.Refresh.ValidateUser = true
+			conf.OpenVPN.EnforceUniqueUser = true
+			conf.OpenVPN.OverrideUsername = true
+
+			suite := testsuite.New(&conf)
+			errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, t, nil)
+			suite.GetOpenVPNClient().SetOAuth2Client(&storedProfileOAuth2Client{})
+			suite.ExpectVersionAndReleaseHold(t)
+
+			suite.SendMessagef(
+				t,
+				">CLIENT:%s,10,3\r\n>CLIENT:ENV,untrusted_ip=127.0.0.1\r\n>CLIENT:ENV,common_name=test\r\n"+
+					">CLIENT:ENV,session_id=session_id\r\n>CLIENT:ENV,session_state=Authenticated\r\n"+
+					">CLIENT:ENV,IV_SSO=webauth\r\n>CLIENT:ENV,END",
+				reason,
+			)
+
+			suite.ExpectMessage(t, "status 3")
+			suite.SendMessagef(
+				t,
+				"HEADER\tCLIENT_LIST\tCommon Name\tReal Address\tVirtual Address\tVirtual IPv6 Address\t"+
+					"Bytes Received\tBytes Sent\tConnected Since\tConnected Since (time_t)\tUsername\tClient ID\tPeer ID\tData Channel Cipher\r\n"+
+					"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.2\t\t1\t2\tnow\t1\talice\t7\t0\tAES-256-GCM\r\n"+
+					"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.3\t\t1\t2\tnow\t1\talice\t10\t0\tAES-256-GCM\r\nEND",
+			)
+			suite.ExpectMessage(t, "client-kill 7")
+			suite.SendMessagef(t, "SUCCESS: client-kill command succeeded")
+			suite.ExpectMessage(t, "client-auth 10 3\r\noverride-username \"alice\"\r\nEND")
+			suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")
+
+			require.NoError(t, suite.GetManagementInterfaceConn().Close())
+
+			select {
+			case err := <-errOpenVPNClientCh:
+				require.NoError(t, err, suite.Logs())
+			case <-time.After(time.Second):
+				t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
+			}
+		})
+	}
+}
+
 func TestSilentReAuthenticationUsesStoredSelectedProfile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openvpn/errors.go
+++ b/internal/openvpn/errors.go
@@ -14,7 +14,10 @@ var (
 	ErrUnknownClientReason                  = errors.New("unknown client reason")
 	ErrUnexpectedResponseFromVersionCommand = errors.New("unexpected response from version command")
 	ErrRequireManagementInterfaceVersion5   = errors.New("openvpn-auth-oauth2 requires OpenVPN management interface version 5 or higher")
-	ErrClientSessionStateInvalidOrExpired   = errors.New(ReasonStateExpiredOrInvalid)
+	ErrEnforceUniqueUserUnsupported         = errors.New(
+		"openvpn.enforce-unique-user requires a direct OpenVPN management interface; the OpenVPN plugin shim is not supported",
+	)
+	ErrClientSessionStateInvalidOrExpired = errors.New(ReasonStateExpiredOrInvalid)
 )
 
 const (

--- a/internal/openvpn/main.go
+++ b/internal/openvpn/main.go
@@ -22,6 +22,8 @@ import (
 // OpenVPN management interface.
 const minManagementInterfaceVersion = 5
 
+const managementPluginVersionPrefix = "OpenVPN Version: openvpn-auth-oauth2"
+
 const WelcomeBanner = ">INFO:OpenVPN Management Interface Version 5 -- type 'help' for more info"
 
 // New creates a new Client configured with the provided logger and
@@ -180,6 +182,10 @@ func (c *Client) checkManagementInterfaceVersion(ctx context.Context) error {
 	}
 
 	c.logger.LogAttrs(ctx, slog.LevelInfo, strings.Join(versionParts[0:1], " - "))
+
+	if c.conf.OpenVPN.EnforceUniqueUser && strings.HasPrefix(versionParts[0], managementPluginVersionPrefix) {
+		return ErrEnforceUniqueUserUnsupported
+	}
 
 	managementInterfaceVersion, err := strconv.Atoi(versionParts[1][len(versionParts[1])-1:])
 	if err != nil {

--- a/internal/openvpn/main_test.go
+++ b/internal/openvpn/main_test.go
@@ -408,6 +408,33 @@ func TestClientInvalidVersion(t *testing.T) {
 	}
 }
 
+func TestClientEnforceUniqueUserRejectsPluginShim(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	conf := config.Defaults
+	conf.OpenVPN.EnforceUniqueUser = true
+	conf.OpenVPN.OverrideUsername = true
+
+	suite := testsuite.New(&conf)
+	errOpenVPNClientCh := suite.SetupMockEnvironment(ctx, t, nil)
+	suite.SendMessagef(t, openvpn.WelcomeBanner)
+	suite.ExpectMessage(t, "version")
+	suite.SendMessagef(
+		t,
+		"OpenVPN Version: openvpn-auth-oauth2 2.0.0\r\nManagement Interface Version: 5\r\nEND",
+	)
+
+	select {
+	case err := <-errOpenVPNClientCh:
+		require.ErrorIs(t, err, openvpn.ErrEnforceUniqueUserUnsupported)
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
+	}
+}
+
 func TestHoldRelease(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openvpn/status.go
+++ b/internal/openvpn/status.go
@@ -1,0 +1,139 @@
+package openvpn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const clientKillMissingResponse = "ERROR: client-kill command failed"
+
+func (c *Client) enforceUniqueUser(ctx context.Context, logger *slog.Logger, currentCID uint64, username string) error {
+	if username == "" {
+		return errors.New("cannot enforce a single active session: username is empty")
+	}
+
+	status, err := c.SendCommand(ctx, "status 3", false)
+	if err != nil {
+		return fmt.Errorf("query OpenVPN status: %w", err)
+	}
+
+	if strings.HasPrefix(status, "ERROR:") {
+		return fmt.Errorf("query OpenVPN status: %w: %s", ErrErrorResponse, strings.TrimSpace(status))
+	}
+
+	clientIDs, err := statusClientIDsByUsername(status, username, currentCID)
+	if err != nil {
+		return fmt.Errorf("parse OpenVPN status: %w", err)
+	}
+
+	for _, clientID := range clientIDs {
+		logger.LogAttrs(
+			ctx, slog.LevelInfo, "terminate existing OpenVPN session",
+			slog.String("user_username", username),
+			slog.Uint64("existing_cid", clientID),
+		)
+
+		response, err := c.SendCommandf(ctx, "client-kill %d", clientID)
+		if err != nil {
+			return fmt.Errorf("terminate OpenVPN client %d: %w", clientID, err)
+		}
+
+		response = strings.TrimSpace(response)
+		if response == clientKillMissingResponse {
+			logger.LogAttrs(
+				ctx, slog.LevelDebug, "existing OpenVPN session already terminated",
+				slog.Uint64("existing_cid", clientID),
+			)
+
+			continue
+		}
+
+		if strings.HasPrefix(response, "ERROR:") {
+			return fmt.Errorf("terminate OpenVPN client %d: %w: %s", clientID, ErrErrorResponse, response)
+		}
+	}
+
+	return nil
+}
+
+func statusClientIDsByUsername(status, username string, currentCID uint64) ([]uint64, error) {
+	usernameIndex, clientIDIndex, err := statusClientListColumns(status)
+	if err != nil {
+		return nil, err
+	}
+
+	clientIDs := make([]uint64, 0)
+	seenClientIDs := make(map[uint64]struct{})
+
+	for line := range strings.SplitSeq(status, "\n") {
+		fields := strings.Split(strings.TrimSuffix(line, "\r"), "\t")
+		if len(fields) == 0 || fields[0] != "CLIENT_LIST" {
+			continue
+		}
+
+		clientID, matches, err := statusClientID(fields, usernameIndex, clientIDIndex, username, currentCID)
+		if err != nil {
+			return nil, err
+		}
+
+		if !matches {
+			continue
+		}
+
+		if _, ok := seenClientIDs[clientID]; ok {
+			continue
+		}
+
+		seenClientIDs[clientID] = struct{}{}
+		clientIDs = append(clientIDs, clientID)
+	}
+
+	return clientIDs, nil
+}
+
+func statusClientListColumns(status string) (int, int, error) {
+	for line := range strings.SplitSeq(status, "\n") {
+		fields := strings.Split(strings.TrimSuffix(line, "\r"), "\t")
+		if len(fields) < 2 || fields[0] != "HEADER" || fields[1] != "CLIENT_LIST" {
+			continue
+		}
+
+		var (
+			usernameIndex = slices.Index(fields, "Username") - 1
+			clientIDIndex = slices.Index(fields, "Client ID") - 1
+		)
+		if usernameIndex < 0 || clientIDIndex < 0 {
+			break
+		}
+
+		return usernameIndex, clientIDIndex, nil
+	}
+
+	return 0, 0, errors.New("client list header is missing Username or Client ID")
+}
+
+func statusClientID(fields []string, usernameIndex, clientIDIndex int, username string, currentCID uint64) (uint64, bool, error) {
+	if usernameIndex >= len(fields) || clientIDIndex >= len(fields) {
+		return 0, false, fmt.Errorf(
+			"client list record has %d fields, expected at least %d",
+			len(fields),
+			max(usernameIndex, clientIDIndex)+1,
+		)
+	}
+
+	if fields[usernameIndex] != username {
+		return 0, false, nil
+	}
+
+	clientID, err := strconv.ParseUint(fields[clientIDIndex], 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("parse client list client ID %q: %w", fields[clientIDIndex], err)
+	}
+
+	return clientID, clientID != currentCID, nil
+}

--- a/internal/openvpn/status_test.go
+++ b/internal/openvpn/status_test.go
@@ -1,0 +1,78 @@
+package openvpn //nolint:testpackage // Exercise the status parser directly with malformed management output.
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const status3ClientHeader = "HEADER\tCLIENT_LIST\tCommon Name\tReal Address\tVirtual Address\tVirtual IPv6 Address\t" +
+	"Bytes Received\tBytes Sent\tConnected Since\tConnected Since (time_t)\tUsername\tClient ID\tPeer ID\tData Channel Cipher"
+
+func TestStatusClientIDsByUsername(t *testing.T) {
+	t.Parallel()
+
+	status := status3ClientHeader + "\r\n" +
+		status3ClientLine("alice", 7) + "\r\n" +
+		status3ClientLine("Alice", 8) + "\r\n" +
+		status3ClientLine("alice", 10) + "\r\n" +
+		status3ClientLine("alice", 12) + "\r\n" +
+		status3ClientLine("alice", 12) + "\r\nEND\r\n"
+
+	clientIDs, err := statusClientIDsByUsername(status, "alice", 10)
+
+	require.NoError(t, err)
+	require.Equal(t, []uint64{7, 12}, clientIDs)
+}
+
+func TestStatusClientIDsByUsernameRejectsInvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status string
+		err    string
+	}{
+		{
+			name:   "missing header",
+			status: status3ClientLine("alice", 7) + "\nEND\n",
+			err:    "client list header is missing Username or Client ID",
+		},
+		{
+			name:   "missing client ID column",
+			status: "HEADER\tCLIENT_LIST\tUsername\nEND\n",
+			err:    "client list header is missing Username or Client ID",
+		},
+		{
+			name:   "short client record",
+			status: status3ClientHeader + "\nCLIENT_LIST\talice\nEND\n",
+			err:    "client list record has 2 fields",
+		},
+		{
+			name:   "invalid client ID",
+			status: status3ClientHeader + "\n" + status3ClientLineWithID("alice", "invalid") + "\nEND\n",
+			err:    `parse client list client ID "invalid"`,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			clientIDs, err := statusClientIDsByUsername(testCase.status, "alice", 10)
+
+			require.ErrorContains(t, err, testCase.err)
+			require.Nil(t, clientIDs)
+		})
+	}
+}
+
+func status3ClientLine(username string, clientID uint64) string {
+	return status3ClientLineWithID(username, strconv.FormatUint(clientID, 10))
+}
+
+func status3ClientLineWithID(username, clientID string) string {
+	return "CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.2\t\t1\t2\t2026-07-19 12:00:00\t1784455200\t" +
+		username + "\t" + clientID + "\t0\tAES-256-GCM"
+}

--- a/internal/openvpn/types.go
+++ b/internal/openvpn/types.go
@@ -33,6 +33,7 @@ type Client struct {
 	passThroughCh        chan string
 	conf                 *config.Config
 	commandsBuffer       bytes.Buffer
+	acceptMu             sync.Mutex
 	commandMu            sync.Mutex
 	connMu               sync.Mutex
 	closed               atomic.Uint32

--- a/lib/openvpn-auth-oauth2/plugin_it_test.go
+++ b/lib/openvpn-auth-oauth2/plugin_it_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -119,7 +120,10 @@ socat TCP-LISTEN:8081,reuseaddr,fork UNIX-CONNECT:${PLUGIN_SOCKET} &
 exec openvpn --config "/etc/openvpn/openvpn.conf" --tmp-dir /tmp/
 `
 
-const pluginSocketPath = "/run/openvpn/openvpn-oauth2.sock"
+const (
+	pluginITImage    = "testcontainers/openvpn-auth-oauth2:latest"
+	pluginSocketPath = "/run/openvpn/openvpn-oauth2.sock"
+)
 
 func TestIT(t *testing.T) {
 	t.Parallel()
@@ -134,9 +138,24 @@ func TestIT(t *testing.T) {
 
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 
+	dockerClient, err := testcontainers.NewDockerClientWithOpts(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dockerClient.Close() })
+
+	volumeName := fmt.Sprintf("openvpn-auth-oauth2-plugin-it-%d", time.Now().UnixNano())
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		_, err := dockerClient.VolumeRemove(ctx, volumeName, client.VolumeRemoveOptions{Force: true})
+		if err != nil && !errdefs.IsNotFound(err) {
+			t.Errorf("remove Docker volume %s: %v", volumeName, err)
+		}
+	})
+
 	containerServer, err := testcontainers.Run(
 		t.Context(), "",
-		testcontainers.WithName("openvpn-auth-oauth2-it-server"),
 		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
 			Context:    `../../`,
 			Dockerfile: `./tests/plugin/Dockerfile`,
@@ -153,7 +172,7 @@ func TestIT(t *testing.T) {
 			"UPN": "user@example.com",
 		}),
 		testcontainers.WithMounts(testcontainers.ContainerMount{
-			Source: testcontainers.GenericVolumeMountSource{Name: "openvpn-auth-oauth2-it-data"},
+			Source: testcontainers.GenericVolumeMountSource{Name: volumeName},
 			Target: "/etc/openvpn",
 		}),
 		testcontainers.WithFiles(testcontainers.ContainerFile{
@@ -167,6 +186,9 @@ func TestIT(t *testing.T) {
 		}),
 		testcontainers.WithEntrypoint("/entrypoint.sh"),
 	)
+	if containerServer != nil {
+		testcontainers.CleanupContainer(t, containerServer)
+	}
 
 	if containerServer == nil {
 		require.NoError(t, err)
@@ -174,26 +196,22 @@ func TestIT(t *testing.T) {
 		return
 	}
 
-	testcontainers.CleanupContainer(t, containerServer)
-
 	containerServerLogs, _ := getContainerLogs(t, containerServer)
 	require.NoError(t, err, containerServerLogs)
 
+	pluginManagementEndpoint, err := containerServer.PortEndpoint(t.Context(), "8081", "tcp")
+	require.NoError(t, err)
+
+	clientManagementEndpoint, err := containerServer.PortEndpoint(t.Context(), "8082", "tcp")
+	require.NoError(t, err)
+
 	containerClient, err := testcontainers.Run(
-		t.Context(), "",
-		testcontainers.WithName("openvpn-auth-oauth2-it-client"),
-		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
-			Context:    `../../`,
-			Dockerfile: `./tests/plugin/Dockerfile`,
-			Repo:       "testcontainers/openvpn-auth-oauth2",
-			Tag:        "latest",
-			KeepImage:  true,
-		}),
+		t.Context(), pluginITImage,
 		testcontainers.WithLabels(map[string]string{
 			"testcontainers": "true",
 		}),
 		testcontainers.WithMounts(testcontainers.ContainerMount{
-			Source: testcontainers.GenericVolumeMountSource{Name: "openvpn-auth-oauth2-it-data"},
+			Source: testcontainers.GenericVolumeMountSource{Name: volumeName},
 			Target: "/etc/openvpn",
 		}),
 		testcontainers.WithHostConfigModifier(func(hostConfig *container.HostConfig) {
@@ -205,6 +223,9 @@ func TestIT(t *testing.T) {
 		testcontainers.WithEntrypoint("openvpn"),
 		testcontainers.WithEntrypointArgs("--config", "/etc/openvpn/user@example.com.ovpn", "--echo", "off"),
 	)
+	if containerClient != nil {
+		testcontainers.CleanupContainer(t, containerClient)
+	}
 
 	if containerClient == nil {
 		require.NoError(t, err)
@@ -212,16 +233,11 @@ func TestIT(t *testing.T) {
 		return
 	}
 
-	testcontainers.CleanupContainer(t, containerClient)
-
 	containerClientLogs, _ := getContainerLogs(t, containerClient)
 	require.NoError(t, err, containerClientLogs)
 
 	// clientListener must not be closed, because it is used by the httpClientListener.
 	clientListener, err := nettest.NewLocalListener("tcp")
-	require.NoError(t, err)
-
-	pluginManagementEndpoint, err := containerServer.PortEndpoint(t.Context(), "8081", "tcp")
 	require.NoError(t, err)
 
 	conf := config.Defaults
@@ -258,9 +274,6 @@ func TestIT(t *testing.T) {
 	httpClientListener.Listener = clientListener
 	httpClientListener.Start()
 	t.Cleanup(httpClientListener.Close)
-
-	clientManagementEndpoint, err := containerServer.PortEndpoint(t.Context(), "8082", "tcp")
-	require.NoError(t, err)
 
 	var dial net.Dialer
 
@@ -304,10 +317,6 @@ func TestIT(t *testing.T) {
 	containerClientLogs, _ = getContainerLogs(t, containerClient)
 	require.Contains(t, line, ">PASSWORD:Auth-Token:", "server logs:\n%s\nclient logs:\n%s", containerServerLogs, containerClientLogs)
 
-	dockerClient, err := testcontainers.NewDockerClientWithOpts(t.Context())
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = dockerClient.Close() })
-
 	_, err = dockerClient.ContainerStatPath(t.Context(), containerServer.GetContainerID(), client.ContainerStatPathOptions{Path: pluginSocketPath})
 	require.NoError(t, err)
 
@@ -325,18 +334,13 @@ func TestIT(t *testing.T) {
 func getContainerLogs(t *testing.T, ctr testcontainers.Container) (string, error) {
 	t.Helper()
 
-	cli, err := testcontainers.NewDockerClientWithOpts(t.Context())
-	if err != nil {
-		return "", fmt.Errorf("failed to create Docker client: %w", err)
-	}
-
-	logReader, err := cli.ContainerLogs(t.Context(), ctr.GetContainerID(), client.ContainerLogsOptions{
-		ShowStderr: true,
-		ShowStdout: true,
-	})
+	logReader, err := ctr.Logs(t.Context())
 	if err != nil {
 		return "", fmt.Errorf("failed to get container logs: %w", err)
 	}
+	defer func() {
+		_ = logReader.Close()
+	}()
 
 	containerLogs, err := io.ReadAll(logReader)
 	if err != nil {

--- a/packaging/etc/openvpn-auth-oauth2/config.yaml
+++ b/packaging/etc/openvpn-auth-oauth2/config.yaml
@@ -66,6 +66,7 @@
 #    environment-variable-name: common_name
 #    mode: plain
 #  password: ""
+#  enforce-unique-user: false # (requires OpenVPN 2.7 server and override-username)
 #  override-username: false # (requires OpenVPN 2.7 server)
 #  reauthentication: true
 #pass-through:


### PR DESCRIPTION
#### What this PR does / why we need it

Adds the opt-in `openvpn.enforce-unique-user` setting to limit each resolved OAuth2 username to one active OpenVPN session.

OpenVPN's duplicate common-name check happens before `override-username` replaces a shared profile's placeholder username. Consequently, multiple clients can otherwise authenticate with the same profile as the same OAuth2 user. This feature applies equivalent single-session behavior to the resolved OAuth2 username.

Before a client is accepted, openvpn-auth-oauth2:

1. Requests `status 3` from the OpenVPN management interface.
2. Finds active clients whose `Username` exactly matches the authenticated OAuth2 username.
3. Sends `client-kill <CID>` for every matching session except the client currently authenticating.
4. Accepts the new client only after the previous matching sessions have been removed.

The status lookup, session removal, and client acceptance are serialized to prevent concurrent logins from both passing the check. Status, parsing, and client-kill errors reject the new authentication, except when the matching client has already disconnected.

The check covers interactive authentication, silent reauthentication, and non-interactive reconnects. The resolved username is retained in encrypted refresh state so those paths enforce the same identity. Older refresh state without a username falls back to interactive authentication once.

This setting requires OpenVPN 2.7 or later, `openvpn.override-username=true`, and a direct OpenVPN management-interface connection. Configuration validation rejects plugin mode, and startup also exits if the connected management endpoint is the OpenVPN plugin shim.

#### Which issue this PR fixes

- fixes #992

#### Special notes for your reviewer

The focused integration test starts one OpenVPN server and two clients held through their management interfaces. It connects the clients in a controlled order and verifies that authenticating the second client with the same OAuth2 username replaces the first session.

GitHub Actions runs this test and the existing plugin integration test through one `go test` command, allowing the two package tests to execute in parallel. The plugin test uses isolated container resources so both integration tests can run concurrently.

#### Particularly user-facing changes

A new configuration option is available:

```yaml
openvpn:
  override-username: true
  enforce-unique-user: true
```

When enabled, a newly authenticated connection replaces any existing connection on the same OpenVPN server with the same resolved OAuth2 username.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
