### PR TITLE
fix: Preserve concurrently refreshed tokens during expiry cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         run: go build ./cmd/openvpn-auth-oauth2
 
       - name: go test
-        run: go test ./... -short -timeout 20s -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./...
+        run: go test ./... -short -shuffle=on -timeout 20s -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./...
         id: test
         shell: bash
         continue-on-error: true
@@ -39,7 +39,7 @@ jobs:
       - name: go test (retry)
         if: steps.test.outcome == 'failure'
         shell: bash
-        run: go test ./... -short  -timeout 20s -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./...
+        run: go test ./... -short -shuffle=on -timeout 20s -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./...
 
       - name: go test -bench
         run: go test ./... -timeout 20s -run='^$' -bench=. -benchmem

--- a/.run/go test openvpn-auth-oauth2.run.xml
+++ b/.run/go test openvpn-auth-oauth2.run.xml
@@ -3,6 +3,7 @@
     <module name="openvpn-auth-oauth2" />
     <working_directory value="$PROJECT_DIR$" />
     <go_parameters value="-race -skip TestPlugin -count 10 -coverprofile coverage.out -coverpkg=./... -covermode=atomic -timeout 60s" />
+    <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />
     <kind value="DIRECTORY" />
     <package value="./..." />
     <directory value="$PROJECT_DIR$" />

--- a/internal/oauth2/providers/generic/oidc_internal_test.go
+++ b/internal/oauth2/providers/generic/oidc_internal_test.go
@@ -41,7 +41,6 @@ type testRevokeRelyingParty struct {
 	httpClient *http.Client
 }
 
-//nolint:revive // HttpClient is required by the upstream rp.RelyingParty interface.
 func (r testRevokeRelyingParty) HttpClient() *http.Client {
 	return r.httpClient
 }

--- a/internal/oauth2/providers/generic/oidc_internal_test.go
+++ b/internal/oauth2/providers/generic/oidc_internal_test.go
@@ -41,6 +41,7 @@ type testRevokeRelyingParty struct {
 	httpClient *http.Client
 }
 
+//nolint:revive // HttpClient is required by the upstream rp.RelyingParty interface.
 func (r testRevokeRelyingParty) HttpClient() *http.Client {
 	return r.httpClient
 }

--- a/internal/tokenstorage/inmemory.go
+++ b/internal/tokenstorage/inmemory.go
@@ -102,9 +102,7 @@ func (s *InMemory) Get(_ context.Context, client string) (string, error) {
 	}
 
 	if data.Expires.Before(now) {
-		s.mu.Lock()
-		delete(s.data, client)
-		s.mu.Unlock()
+		s.deleteExpired(client, now)
 
 		return "", ErrNotExists
 	}
@@ -140,6 +138,19 @@ func (s *InMemory) Close() error {
 	s.gcWg.Wait()
 
 	return nil
+}
+
+// deleteExpired removes the current entry only if it was already expired when
+// the caller observed an expired token. A concurrent refresh has a later
+// expiration and must not be removed based on the caller's stale observation.
+func (s *InMemory) deleteExpired(client string, observedAt time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, ok := s.data[client]
+	if ok && data.Expires.Before(observedAt) {
+		delete(s.data, client)
+	}
 }
 
 // startGC starts the background garbage collection goroutine.

--- a/internal/tokenstorage/inmemory_internal_test.go
+++ b/internal/tokenstorage/inmemory_internal_test.go
@@ -1,0 +1,38 @@
+package tokenstorage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryExpiredLookupPreservesConcurrentRefresh(t *testing.T) {
+	t.Parallel()
+
+	const clientID = "client"
+
+	ctx := t.Context()
+	tokenStorage := NewInMemory("test-secret", time.Hour)
+
+	t.Cleanup(func() {
+		require.NoError(t, tokenStorage.Close())
+	})
+
+	require.NoError(t, tokenStorage.Set(ctx, clientID, "expired"))
+
+	tokenStorage.mu.Lock()
+	expired := tokenStorage.data[clientID]
+	expired.Expires = time.Now().Add(-time.Hour)
+	tokenStorage.data[clientID] = expired
+	tokenStorage.mu.Unlock()
+
+	expiredLookupTime := time.Now()
+
+	require.NoError(t, tokenStorage.Set(ctx, clientID, "refreshed"))
+	tokenStorage.deleteExpired(clientID, expiredLookupTime)
+
+	token, err := tokenStorage.Get(ctx, clientID)
+	require.NoError(t, err)
+	require.Equal(t, "refreshed", token)
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Prevents an expired token lookup from deleting a token that was refreshed concurrently for the same client.

`InMemory.Get` previously read an expired entry under a read lock, released that lock, and then deleted the key under a write lock. A concurrent `Set` between those operations could replace the expired entry before the stale lookup unconditionally deleted the refreshed value.

Expiration cleanup now re-reads the current entry while holding the write lock and deletes it only when that current entry was already expired at the original lookup time. A refresh completed after that observation has a later expiration and is preserved.

#### Which issue this PR fixes

No linked issue.

#### Special notes for your reviewer

A deterministic regression test models the failing interleaving: observe an expired entry, refresh the same client, then execute cleanup from the stale observation and verify that the refreshed token remains available.

Validation:

- `go test -race ./internal/tokenstorage -run '^TestInMemoryExpiredLookupPreservesConcurrentRefresh$' -count=100`
- `go test -race ./internal/tokenstorage -count=10`
- `make fmt`
- `make lint`
- `make test`
- `git diff --check`

#### Particularly user-facing changes

Concurrent token refreshes can no longer be lost when another request discovers the previous token after it expires. This avoids unnecessary missing-token behavior and reauthentication caused by the race.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR