### PR TITLE
feat!: normalize CEL identity context

### DIFF
--- a/cmd/openvpn-auth-oauth2/full_test.go
+++ b/cmd/openvpn-auth-oauth2/full_test.go
@@ -99,7 +99,7 @@ func TestFull(t *testing.T) {
 					"--http.listen=" + httpListener.Addr().String(),
 					"--http.assets-path=../../internal/ui/assets",
 					"--openvpn.addr=tcp://" + managementInterface.Addr().String(),
-					"--oauth2.openvpn-username", "oauth2TokenClaims." + testsuite.SubjectClaim,
+					"--oauth2.openvpn-username", "token.claims." + testsuite.SubjectClaim,
 					"--oauth2.issuer", resourceServer.URL,
 					"--oauth2.client.id", clientCredentials.ID,
 					"--oauth2.client.secret", clientCredentials.Secret.String(),

--- a/cmd/openvpn-auth-oauth2/reload_test.go
+++ b/cmd/openvpn-auth-oauth2/reload_test.go
@@ -57,7 +57,7 @@ func TestReload(t *testing.T) {
 			"--http.listen=" + httpListener.Addr().String(),
 			"--http.assets-path=../../internal/ui/assets",
 			"--openvpn.addr=tcp://" + managementInterface.Addr().String(),
-			"--oauth2.openvpn-username=oauth2TokenClaims.sub",
+			"--oauth2.openvpn-username=token.claims.sub",
 			"--oauth2.issuer", resourceServer.URL,
 			"--oauth2.client.id", clientCredentials.ID,
 			"--oauth2.client.secret", clientCredentials.Secret.String(),

--- a/docs/Article - How OIDC SSO Authentication works with OpenVPN Community Server.md
+++ b/docs/Article - How OIDC SSO Authentication works with OpenVPN Community Server.md
@@ -71,7 +71,7 @@ In the context of `openvpn-auth-oauth2`, the `acr` claim can be used to enforce 
 To configure `acr` validation, set a CEL validation expression in your `openvpn-auth-oauth2` configuration file. Here's an example:
 
 ```ini
-CONFIG_OAUTH2_VALIDATE_EXPRESSION="oauth2TokenClaims.acr == 'phr'"
+CONFIG_OAUTH2_VALIDATE_EXPRESSION="token.claims.acr == 'phr'"
 ```
 
 In this example, `phr` is the `acr` value that represents a specific authentication method. `phr` stands for Phishing Resistant. It's a term used in the context of multi-factor authentication (MFA). Phishing-resistant mechanisms are designed to resist phishing and other fraudulent attempts to steal user credentials. This could be a hardware device that requires a user to physically interact with it, or a biometric authentication method. When used in the `acr` (Authentication Context Class Reference) in OpenID Connect, it indicates that the authentication process should involve a phishing-resistant method.

--- a/docs/CEL Language Features.md
+++ b/docs/CEL Language Features.md
@@ -2,7 +2,7 @@
 
 [CEL, the Common Expression Language](https://cel.dev/), is a small expression language designed for
 fast and safe evaluation of user-defined rules. openvpn-auth-oauth2 uses CEL for
-configuration values that need logic, such as token validation, deriving the
+configuration values that need logic, such as identity validation, deriving the
 OpenVPN username, and resolving client configuration names. CEL expressions can
 inspect the variables provided by openvpn-auth-oauth2, call the documented
 string and list helpers, and return the type required by the specific setting.
@@ -20,30 +20,42 @@ CEL supports many standard operations:
 - `||` (OR)
 - `!` (NOT)
 
-### Available Variables
+### Available context
 
-The available variables depend on the CEL expression being evaluated.
+The same namespaced context is available to `oauth2.openvpn-username`,
+`oauth2.validate.expression`, and `openvpn.client-config.expression`:
 
-#### `oauth2.validate.expression`
+| Field | Type | Description |
+| --- | --- | --- |
+| `auth.mode` | `string` | `interactive` for the initial login or `non-interactive` for token refresh |
+| `openvpn.commonName` | `string` | Common name supplied by OpenVPN |
+| `openvpn.ip` | `string` | OpenVPN client IP address |
+| `openvpn.sessionState` | `string` | Current OpenVPN session state |
+| `token.claims` | `map<string, dynamic>` | Raw OAuth2 ID token claims; an empty map when no parsed ID token is available |
+| `token.ip` | `string` | IP address claim from the OAuth2 ID token; an empty string when unavailable |
+| `user.subject` | `string` | Provider-independent user subject |
+| `user.email` | `string` | Provider-independent email address |
+| `user.username` | `string` | Provider-independent username |
+| `user.groups` | `list<string>` | Provider-independent list of groups |
+| `user.roles` | `list<string>` | Provider-independent list of roles |
 
-- `authMode`: authentication mode, for example `interactive` or
-  `non-interactive`
-- `openVPNSessionState`: OpenVPN session state
-- `openVPNUserCommonName`: common name of the OpenVPN user
-- `openVPNUserIPAddr`: IP address of the OpenVPN user
-- `oauth2TokenIPAddr`: IP address claim from the OAuth2 ID token
-- `oauth2TokenClaims`: OAuth2 ID token claims
+Provider data is normalized before CEL runs. For a generic OIDC provider,
+`user.groups` comes from `oauth2.groups-claim` and `user.roles` comes from the
+`roles` claim. For GitHub, organizations populate `user.groups` and teams
+populate `user.roles` in `org:slug` format when those fields are used. Google
+group validation populates `user.groups` with the configured groups that match
+the user.
 
-#### `oauth2.openvpn-username`
+During `oauth2.openvpn-username`, `user.username` is the provider's username
+candidate, such as `preferred_username` from an ID token or UserInfo response,
+or the GitHub login. The expression result becomes the resolved username.
+`oauth2.validate.expression` and `openvpn.client-config.expression` receive that
+resolved value in `user.username`. An empty expression or an empty expression
+result falls back to `openvpn.commonName`.
 
-- `oauth2TokenClaims`: OAuth2 ID token claims
-
-#### `openvpn.client-config.expression`
-
-- `oauth2TokenClaims`: OAuth2 ID token claims
-- `openVPNUserCommonName`: common name of the OpenVPN user
-- `username`: resolved OpenVPN username after `oauth2.openvpn-username` has
-  been evaluated
+Prefer `user.*` for portable expressions. Use `token.claims.*` when a rule
+depends on a provider-specific raw claim. Raw claims may be absent during a
+refresh or when identity data comes from UserInfo.
 
 ### Extension Libraries
 
@@ -112,17 +124,17 @@ The following string functions are available through the [CEL strings extension]
 - `in` - Check if an element is in a list
 - `size()` - Get the size of a list or map
 - `exists(var, predicate)` - Check if any element matches
-  - Example: `oauth2TokenClaims.groups.exists(g, g == 'vpn-users')`
+  - Example: `user.groups.exists(g, g == 'vpn-users')`
 - `all(var, predicate)` - Check if every element matches
-  - Example: `oauth2TokenClaims.groups.all(g, g.startsWith('vpn-'))`
+  - Example: `user.groups.all(g, g.startsWith('vpn-'))`
 - `exists_one(var, predicate)` - Check if exactly one element matches
-  - Example: `oauth2TokenClaims.groups.exists_one(g, g == 'vpn-admin')`
+  - Example: `user.groups.exists_one(g, g == 'vpn-admin')`
 - `filter(var, predicate)` - Keep matching elements
-  - Example: `oauth2TokenClaims.groups.filter(g, g.startsWith('vpn-'))`
+  - Example: `user.groups.filter(g, g.startsWith('vpn-'))`
 - `map(var, expression)` - Transform elements
-  - Example: `oauth2TokenClaims.groups.map(g, g.lowerAscii())`
+  - Example: `user.groups.map(g, g.lowerAscii())`
 - `map(var, predicate, expression)` - Transform matching elements
-  - Example: `oauth2TokenClaims.groups.map(g, g.startsWith('vpn-'), g.lowerAscii())`
+  - Example: `user.groups.map(g, g.startsWith('vpn-'), g.lowerAscii())`
 
 The CEL lists extension adds more list helpers:
 
@@ -148,11 +160,11 @@ openvpn:
     expression: |
       (
         ['base'] +
-        oauth2TokenClaims.groups
+        user.groups
           .filter(g, g.startsWith('vpn-'))
           .map(g, g.replace('vpn-', ''))
           .sort() +
-        [username]
+        [user.username]
       ).distinct()
 ```
 
@@ -162,7 +174,7 @@ Example that maps each group to one or more shared config files:
 openvpn:
   client-config:
     expression: |
-      oauth2TokenClaims.groups
+      user.groups
         .map(g, {
           'GRP-VPN': ['base-vpn'],
           'GRP-ADMIN': ['base-vpn', 'admin-routes'],
@@ -193,10 +205,10 @@ If you try to access a claim that doesn't exist in the ID token without checking
 ```yaml
 ---
 # ❌ Bad - will fail if 'department' claim doesn't exist
-expression: 'oauth2TokenClaims.department == "engineering"'
+expression: 'token.claims.department == "engineering"'
 ---
 # ✅ Good - safely checks for claim existence first
-expression: 'has(oauth2TokenClaims.department) && oauth2TokenClaims.department == "engineering"'
+expression: 'has(token.claims.department) && token.claims.department == "engineering"'
 ```
 
 ### Invalid Expressions
@@ -209,10 +221,10 @@ The expression must evaluate to a boolean. If it evaluates to another type (stri
 
 ```yaml
 # ❌ Bad - evaluates to a string, not a boolean
-expression: 'openVPNUserCommonName'
+expression: 'openvpn.commonName'
 ---
 # ✅ Good - evaluates to a boolean
-expression: 'openVPNUserCommonName != ""'
+expression: 'openvpn.commonName != ""'
 ```
 
 ## Best Practices

--- a/docs/Client specific configuration.md
+++ b/docs/Client specific configuration.md
@@ -30,17 +30,24 @@ Client config names are resolved with
 `openvpn.client-config.expression`. The expression is [CEL](CEL%20Language%20Features.md) and must return
 an ordered string list.
 
-The expression receives:
+The resolver receives the same normalized context as the other CEL settings.
+The most useful fields are:
 
-- `oauth2TokenClaims`: the OAuth2 ID token claims.
-- `openVPNUserCommonName`: the OpenVPN user common name.
-- `username`: the resolved OpenVPN username.
+- `user.username`: the resolved OpenVPN username.
+- `user.groups`: the normalized provider groups.
+- `user.roles`: the normalized provider roles.
+- `openvpn.commonName`: the OpenVPN user common name.
+- `token.claims`: the raw OAuth2 ID token claims.
+
+The `auth`, `openvpn`, `token`, and `user` namespaces are all available. See
+[CEL Language Features](CEL%20Language%20Features.md) for the complete
+contract.
 
 Example:
 
 ```yaml
 oauth2:
-  openvpn-username: oauth2TokenClaims.preferred_username
+  openvpn-username: user.username
   validate:
     groups:
       - GRP-VPN
@@ -51,12 +58,12 @@ openvpn:
     enabled: true
     path: /etc/openvpn-auth-oauth2/client-config
     expression: |
-        oauth2TokenClaims.groups.filter(g, g in [
+        user.groups.filter(g, g in [
           "GRP-VPN",
           "GRP-ADMIN",
           "GRP-NETWORK"
         ]) +
-        [username]
+        [user.username]
 ```
 
 For `alice@example.edu` with `GRP-VPN` and `GRP-ADMIN`, this loads:
@@ -89,7 +96,7 @@ openvpn:
     path: /etc/openvpn-auth-oauth2/client-config
     strategy: merge
     expression: |
-        (["base-vpn"] + oauth2TokenClaims.roles).distinct()
+        (["base-vpn"] + user.roles).distinct()
 ```
 
 With this configuration, a role named `admin-routes` loads
@@ -106,7 +113,7 @@ openvpn:
     path: /etc/openvpn-auth-oauth2/client-config
     strategy: merge
     expression: |
-        oauth2TokenClaims.groups
+        user.groups
           .map(g, {
             "GRP-VPN": ["base-vpn"],
             "GRP-ADMIN": ["base-vpn", "admin-routes"],
@@ -138,5 +145,5 @@ openvpn:
     strategy: user-selector
     expression: |
         ["corporate", "guest"] +
-        oauth2TokenClaims.groups.filter(g, g.startsWith("vpn-profile-"))
+        user.groups.filter(g, g.startsWith("vpn-profile-"))
 ```

--- a/docs/Client token validation.md
+++ b/docs/Client token validation.md
@@ -1,6 +1,8 @@
 # Client Token Validation with CEL
 
-openvpn-auth-oauth2 supports advanced token validation using the [Common Expression Language (CEL)](https://github.com/google/cel-spec). CEL allows you to write custom validation rules to verify that the OAuth2 ID token claims match the OpenVPN user's context.
+openvpn-auth-oauth2 supports identity validation using the [Common Expression Language (CEL)](https://github.com/google/cel-spec).
+CEL rules can evaluate the normalized user, raw OAuth2 ID token claims, and the
+OpenVPN session context.
 
 ## Overview
 
@@ -20,17 +22,17 @@ To enable CEL validation, configure the `oauth2.validate.expression` property in
 ```yaml
 oauth2:
   validate:
-    expression: 'openVPNUserCommonName == oauth2TokenClaims.preferred_username'
+    expression: 'openvpn.commonName == user.username'
 ```
 
 ### Environment Variable
 
 ```bash
-CONFIG_OAUTH2_VALIDATE_EXPRESSION='openVPNUserCommonName == oauth2TokenClaims.preferred_username'
+CONFIG_OAUTH2_VALIDATE_EXPRESSION='openvpn.commonName == user.username'
 ```
 
 > [!IMPORTANT]
-> CEL validation is performed **both during initial OAuth2 authentication and during token refresh**. This means your validation rules will be continuously enforced throughout the entire lifecycle of a VPN session. Make sure your expressions account for both scenarios using the `authMode` variable if needed.
+> CEL validation is performed **both during initial OAuth2 authentication and during token refresh**. This means your validation rules will be continuously enforced throughout the entire lifecycle of a VPN session. Make sure your expressions account for both scenarios using `auth.mode` if needed.
 
 ## Available Variables
 
@@ -38,12 +40,22 @@ The following variables are available in your CEL expressions:
 
 | Variable | Type | Description |
 |----------|------|-------------|
-| `authMode` | `string` | The authentication mode: `"interactive"` (initial OAuth2 login) or `"non-interactive"` (token refresh) |
-| `openVPNSessionState` | `string` | The OpenVPN session state (e.g., `""`, `"Empty"`, `"Initial"`, `"Authenticated"`, `"Expired"`, `"Invalid"`, `"AuthenticatedEmptyUser"`, `"ExpiredEmptyUser"`) |
-| `openVPNUserCommonName` | `string` | The common name (CN) of the OpenVPN client certificate |
-| `openVPNUserIPAddr` | `string` | The IP address of the OpenVPN client |
-| `oauth2TokenIPAddr` | `string` | The IP address claim from the OAuth2 ID token |
-| `oauth2TokenClaims` | `map<string, dynamic>` | All claims from the OAuth2 ID token |
+| `auth.mode` | `string` | The authentication mode: `"interactive"` (initial OAuth2 login) or `"non-interactive"` (token refresh) |
+| `openvpn.sessionState` | `string` | The OpenVPN session state (e.g., `""`, `"Empty"`, `"Initial"`, `"Authenticated"`, `"Expired"`, `"Invalid"`, `"AuthenticatedEmptyUser"`, `"ExpiredEmptyUser"`) |
+| `openvpn.commonName` | `string` | The common name (CN) of the OpenVPN client certificate |
+| `openvpn.ip` | `string` | The IP address of the OpenVPN client |
+| `token.ip` | `string` | The IP address claim from the OAuth2 ID token |
+| `token.claims` | `map<string, dynamic>` | All claims from the OAuth2 ID token |
+| `user.subject` | `string` | The normalized provider subject |
+| `user.email` | `string` | The normalized email address |
+| `user.username` | `string` | The final username after `oauth2.openvpn-username` and common-name fallback |
+| `user.groups` | `list<string>` | The normalized groups |
+| `user.roles` | `list<string>` | The normalized roles |
+
+Prefer `user.*` for rules that should work with generic OIDC, UserInfo, GitHub,
+and refresh authentication. Use `token.claims.*` for provider-specific claims.
+See [CEL Language Features](CEL%20Language%20Features.md) for the normalization
+rules and the context shared by all CEL settings.
 
 ## Expression Requirements
 
@@ -60,8 +72,8 @@ Use the `has()` function to safely check for claim existence before accessing it
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.department) &&
-      oauth2TokenClaims.department == 'engineering'
+      has(token.claims.department) &&
+      token.claims.department == 'engineering'
 ```
 
 > [!IMPORTANT]
@@ -76,7 +88,7 @@ Ensure the OpenVPN common name matches the OAuth2 username claim:
 ```yaml
 oauth2:
   validate:
-    expression: 'openVPNUserCommonName == oauth2TokenClaims.preferred_username'
+    expression: 'openvpn.commonName == user.username'
 ```
 
 ### Email Domain Validation
@@ -87,8 +99,7 @@ Only allow users with email addresses from specific domains:
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.email) &&
-      oauth2TokenClaims.email.endsWith('@example.com')
+      user.email.endsWith('@example.com')
 ```
 
 ### Multiple Condition Validation
@@ -99,9 +110,9 @@ Combine multiple conditions with logical operators:
 oauth2:
   validate:
     expression: |
-      openVPNUserCommonName == oauth2TokenClaims.preferred_username &&
-      has(oauth2TokenClaims.email_verified) &&
-      oauth2TokenClaims.email_verified == true
+      openvpn.commonName == user.username &&
+      has(token.claims.email_verified) &&
+      token.claims.email_verified == true
 ```
 
 ### Group-Based Validation
@@ -112,8 +123,7 @@ Allow access only if the user belongs to specific groups:
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.groups) &&
-      ('vpn-users' in oauth2TokenClaims.groups || 'administrators' in oauth2TokenClaims.groups)
+      'vpn-users' in user.groups || 'administrators' in user.groups
 ```
 
 ### IP Address Claim Validation
@@ -123,7 +133,7 @@ Validate that the VPN client IP matches the IP address claim from the token:
 ```yaml
 oauth2:
   validate:
-    expression: 'openVPNUserIPAddr == oauth2TokenIPAddr'
+    expression: 'openvpn.ip == token.ip'
 ```
 
 ### Case-Insensitive Username Validation
@@ -134,11 +144,11 @@ Compare usernames in a case-insensitive manner using the `lowerAscii()` function
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.preferred_username) && openVPNUserCommonName.lowerAscii() == string(oauth2TokenClaims.preferred_username).lowerAscii()
+      openvpn.commonName.lowerAscii() == user.username.lowerAscii()
 ```
 
 > [!IMPORTANT]
-> When accessing claims from `oauth2TokenClaims` that you want to use with string functions, you may need to cast them to string using `string()` since claims are stored as dynamic types.
+> When accessing claims from `token.claims` that you want to use with string functions, you may need to cast them to string using `string()` since claims are stored as dynamic types.
 
 ### Complex Custom Logic
 
@@ -148,12 +158,12 @@ Combine multiple conditions for sophisticated validation rules:
 oauth2:
   validate:
     expression: |
-      openVPNUserCommonName == oauth2TokenClaims.sub &&
+      openvpn.commonName == token.claims.sub &&
       (
-        (has(oauth2TokenClaims.role) && oauth2TokenClaims.role == 'admin') ||
-        (has(oauth2TokenClaims.vpn_access) && oauth2TokenClaims.vpn_access == true)
+        (has(token.claims.role) && token.claims.role == 'admin') ||
+        (has(token.claims.vpn_access) && token.claims.vpn_access == true)
       ) &&
-      (!has(oauth2TokenClaims.account_locked) || oauth2TokenClaims.account_locked == false)
+      (!has(token.claims.account_locked) || token.claims.account_locked == false)
 ```
 
 ### Email Prefix Validation
@@ -164,8 +174,7 @@ Extract and validate the prefix of an email address:
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.email) &&
-      string(oauth2TokenClaims.email).split('@')[0] == openVPNUserCommonName
+      user.email.split('@')[0] == openvpn.commonName
 ```
 
 ### Username Format Validation
@@ -176,8 +185,7 @@ Validate that a username contains only allowed characters using regular expressi
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.preferred_username) &&
-      string(oauth2TokenClaims.preferred_username).matches('^[a-zA-Z0-9._-]+$')
+      user.username.matches('^[a-zA-Z0-9._-]+$')
 ```
 
 ### String Length Validation
@@ -188,9 +196,8 @@ Ensure usernames meet minimum length requirements:
 oauth2:
   validate:
     expression: |
-      openVPNUserCommonName.size() >= 3 &&
-      has(oauth2TokenClaims.preferred_username) &&
-      string(oauth2TokenClaims.preferred_username).size() >= 3
+      openvpn.commonName.size() >= 3 &&
+      user.username.size() >= 3
 ```
 
 ### Domain-Based Routing
@@ -201,12 +208,11 @@ Allow different IP ranges based on email domain:
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.email) &&
       (
-        (string(oauth2TokenClaims.email).endsWith('@internal.company.com') &&
-         openVPNUserIPAddr.startsWith('10.0.')) ||
-        (string(oauth2TokenClaims.email).endsWith('@company.com') &&
-         openVPNUserIPAddr.startsWith('192.168.'))
+        (user.email.endsWith('@internal.company.com') &&
+         openvpn.ip.startsWith('10.0.')) ||
+        (user.email.endsWith('@company.com') &&
+         openvpn.ip.startsWith('192.168.'))
       )
 ```
 
@@ -218,8 +224,8 @@ Apply different validation rules based on whether this is an initial login or a 
 oauth2:
   validate:
     expression: |
-      authMode == 'interactive' ||
-      (authMode == 'non-interactive' && has(oauth2TokenClaims.refresh_allowed) && oauth2TokenClaims.refresh_allowed == true)
+      auth.mode == 'interactive' ||
+      (auth.mode == 'non-interactive' && has(token.claims.refresh_allowed) && token.claims.refresh_allowed == true)
 ```
 
 ### Session State Validation
@@ -230,8 +236,8 @@ Validate based on the current OpenVPN session state:
 oauth2:
   validate:
     expression: |
-      openVPNSessionState in ['Initial', 'Authenticated', 'AuthenticatedEmptyUser'] &&
-      openVPNUserCommonName == oauth2TokenClaims.preferred_username
+      openvpn.sessionState in ['Initial', 'Authenticated', 'AuthenticatedEmptyUser'] &&
+      openvpn.commonName == user.username
 ```
 
 ### Combined Mode and State Validation
@@ -242,6 +248,6 @@ Combine authentication mode and session state for fine-grained control:
 oauth2:
   validate:
     expression: |
-      (authMode == 'interactive' && openVPNSessionState == 'Initial') ||
-      (authMode == 'non-interactive' && openVPNSessionState == 'Authenticated')
+      (auth.mode == 'interactive' && openvpn.sessionState == 'Initial') ||
+      (auth.mode == 'non-interactive' && openvpn.sessionState == 'Authenticated')
 ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -81,7 +81,7 @@ Usage of openvpn-auth-oauth2:
   --oauth2.nonce
     	If true, a nonce will be defined on the auth URL which is expected inside the token. (env: CONFIG_OAUTH2_NONCE) (default true)
   --oauth2.openvpn-username string
-	CEL expression to extract the username from the token. The expression must evaluate to a string value. Example: oauth2TokenClaims.sub. If empty, the common name is used. (env: CONFIG_OAUTH2_OPENVPN__USERNAME) (default "oauth2TokenClaims.preferred_username")
+        CEL expression to resolve the username from the normalized identity. The expression must evaluate to a string value. Example: string(token.claims.sub). If empty, the common name is used. (env: CONFIG_OAUTH2_OPENVPN__USERNAME) (default "user.username")
   --oauth2.pkce
     	If true, Proof Key for Code Exchange (PKCE) RFC 7636 is used for token exchange. (env: CONFIG_OAUTH2_PKCE) (default true)
   --oauth2.provider string
@@ -103,7 +103,7 @@ Usage of openvpn-auth-oauth2:
   --oauth2.user-info
     	If true, openvpn-auth-oauth2 uses the OIDC UserInfo endpoint to fetch additional information about the user (e.g. groups). (env: CONFIG_OAUTH2_USER__INFO)
   --oauth2.validate.expression string
-    	CEL expression for custom token validation. The expression must evaluate to a boolean value. Example: openVPNUserCommonName == oauth2TokenClaims.preferred_username (env: CONFIG_OAUTH2_VALIDATE_EXPRESSION)
+        CEL expression for custom identity validation. The expression must evaluate to a boolean value. Example: openvpn.commonName == user.username (env: CONFIG_OAUTH2_VALIDATE_EXPRESSION)
   --oauth2.validate.groups value
     	oauth2 required user groups. If multiple groups are configured, the user needs to be least in one group. Comma separated list. Example: group1,group2,group3 (env: CONFIG_OAUTH2_VALIDATE_GROUPS)
   --openvpn.addr value

--- a/docs/OpenVPN Username.md
+++ b/docs/OpenVPN Username.md
@@ -71,7 +71,9 @@ By default, openvpn-auth-oauth2 does not pass the username from the OAuth2 provi
 
 **Requires OpenVPN Server 2.7+**
 
-The `openvpn.override-username` configuration option enables passing the username from OAuth2 token claims to OpenVPN using the `override-username` command. This allows real usernames to appear in OpenVPN statistics and logs.
+The `openvpn.override-username` configuration option passes the username from
+the normalized OAuth2 identity to OpenVPN using the `override-username` command.
+This allows real usernames to appear in OpenVPN statistics and logs.
 
 #### Configuration
 
@@ -87,24 +89,37 @@ Or via environment variable:
 CONFIG_OPENVPN_OVERRIDE__USERNAME=true
 ```
 
-#### Username Source
+#### Username source
 
-The username is extracted from the OAuth2 ID token using `oauth2.openvpn-username`.
-The value is a CEL expression that must evaluate to a string.
+The username is resolved from the normalized identity using
+`oauth2.openvpn-username`. The value is a CEL expression that must evaluate to
+a string.
 
-By default, the expression is `oauth2TokenClaims.preferred_username`.
+By default, the expression is `user.username`. Before this expression runs,
+`user.username` contains the provider's username candidate:
+
+- the `preferred_username` value from UserInfo or an OIDC ID token;
+- the GitHub login for the GitHub provider.
+
+The same expression is applied during interactive authentication, UserInfo
+authentication, and refresh validation. If the setting is empty, or if the
+expression returns an empty string, the OpenVPN common name is used.
 
 Example configurations:
 
 ```bash
-# Use a specific claim
---oauth2.openvpn-username='oauth2TokenClaims.email'
+# Use the normalized email address
+--oauth2.openvpn-username='user.email'
 
-# Use CEL expression for complex transformations
---oauth2.openvpn-username='oauth2TokenClaims.email.split("@")[0]'
+# Use a provider-specific raw claim
+--oauth2.openvpn-username='string(token.claims.employee_id)'
+
+# Transform normalized identity data
+--oauth2.openvpn-username='user.email.split("@")[0]'
 ```
 
-For more details on CEL expressions, see the [CEL Language Features](CEL%20Language%20Features.md) documentation.
+The complete `auth`, `openvpn`, `token`, and `user` context is available. For
+more details, see [CEL Language Features](CEL%20Language%20Features.md).
 
 #### Important Limitations
 
@@ -114,7 +129,7 @@ When `openvpn.override-username` is enabled, OpenVPN's native `client-config-dir
 
 **Workaround:** Use openvpn-auth-oauth2's built-in [Client specific configuration](Client%20specific%20configuration.md) feature instead, which:
 - Works seamlessly with `openvpn.override-username`
-- Uses `openvpn.client-config.expression` to resolve configuration files from token claims and the resolved username
+- Uses `openvpn.client-config.expression` to resolve configuration files from the normalized identity and raw token claims
 - Can merge several configuration files or show a profile selector with `openvpn.client-config.strategy: user-selector`
 
 For more details, see the OpenVPN man page regarding `override-username` limitations.

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -126,7 +126,7 @@ CONFIG_OAUTH2_PROVIDER=google
 CONFIG_OAUTH2_ISSUER=https://accounts.google.com
 CONFIG_OAUTH2_CLIENT_ID=162738495-xxxxx.apps.googleusercontent.com
 CONFIG_OAUTH2_CLIENT_SECRET=GOCSPX-xxxxxxxx
-CONFIG_OAUTH2_OPENVPN_USERNAME_CLAIM=email
+CONFIG_OAUTH2_OPENVPN__USERNAME=user.email
 
 # The scopes openid profile email are required, but configured by default.
 # https://www.googleapis.com/auth/cloud-identity.groups.readonly is mandatory for group validation.
@@ -145,7 +145,7 @@ oauth2:
   client:
     id: "162738495-xxxxx.apps.googleusercontent.com"
     secret: "GOCSPX-xxxxxxxx"
-  openvpn-username: "oauth2TokenClaims.email"
+  openvpn-username: "user.email"
   # The scopes openid profile email are required, but configured by default.
   # https://www.googleapis.com/auth/cloud-identity.groups.readonly is mandatory for group validation.
   # Enabled by default, if scopes aren't set in the config.

--- a/docs/Upgrade V2.md
+++ b/docs/Upgrade V2.md
@@ -69,6 +69,31 @@ The two password files must contain the same password. They can be separate
 files so OpenVPN and openvpn-auth-oauth2 can each read a file from the path
 allowed by their service permissions.
 
+## CEL context
+
+Version 2 uses one namespaced context for username resolution, validation, and
+client config resolution. Update every CEL expression to use the new names:
+
+| Previous field | Version 2 field |
+| --- | --- |
+| `authMode` | `auth.mode` |
+| `openVPNSessionState` | `openvpn.sessionState` |
+| `openVPNUserCommonName` | `openvpn.commonName` |
+| `openVPNUserIPAddr` | `openvpn.ip` |
+| `oauth2TokenIPAddr` | `token.ip` |
+| `oauth2TokenClaims` | `token.claims` |
+| `username` | `user.username` |
+
+Version 2 also exposes normalized `user.subject`, `user.email`, `user.groups`,
+and `user.roles` fields. Prefer these fields when an expression should work
+across generic OIDC, UserInfo, GitHub, and refresh authentication. Raw
+`token.claims` can be empty when a provider supplies identity data through
+another source.
+
+Provider data and groups or roles are resolved first. The
+`oauth2.openvpn-username` expression then sets the final `user.username`, and
+validation and client config resolution use that final identity.
+
 ## OpenVPN username
 
 The following options were removed or renamed:
@@ -79,7 +104,9 @@ The following options were removed or renamed:
 | `oauth2.openvpn-username-cel` | `oauth2.openvpn-username` |
 
 `oauth2.openvpn-username` is a CEL expression and must evaluate to a string.
-The default changed from the claim name `preferred_username` to the equivalent CEL expression `oauth2TokenClaims.preferred_username`.
+The default changed from the claim name `preferred_username` to
+`user.username`. This uses the provider's normalized username, including
+`preferred_username` for OIDC and the GitHub login for GitHub.
 
 If you used `oauth2.openvpn-username-claim`, convert the claim name into a CEL token claim lookup:
 
@@ -90,10 +117,11 @@ oauth2:
 
 # Version 2
 oauth2:
-  openvpn-username: oauth2TokenClaims.email
+  openvpn-username: user.email
 ```
 
-If you used `oauth2.openvpn-username-cel`, keep the same expression and move it to `oauth2.openvpn-username`:
+If you used `oauth2.openvpn-username-cel`, move it to
+`oauth2.openvpn-username` and translate its fields to the namespaced context:
 
 ```yaml
 # Version 1
@@ -102,10 +130,13 @@ oauth2:
 
 # Version 2
 oauth2:
-  openvpn-username: 'oauth2TokenClaims.email.split("@")[0]'
+  openvpn-username: 'user.email.split("@")[0]'
 ```
 
 The environment variable for the new option is `CONFIG_OAUTH2_OPENVPN__USERNAME`.
+Unlike version 1's provider-specific paths, the expression is applied
+consistently when identity comes from an ID token, UserInfo, or the GitHub API,
+and during validated refresh authentication.
 
 ## Client-specific configuration
 
@@ -121,10 +152,10 @@ The following options are removed:
 | `openvpn.client-config.user-selector.static-values` | `openvpn.client-config.expression`              |
 
 `openvpn.client-config.expression` is a CEL expression and must evaluate
-to an ordered list of strings. It receives `oauth2TokenClaims`, which contains
-the OAuth2 ID token claims, and `openVPNUserCommonName`, which contains the
-OpenVPN common name. It also receives `username`, which contains the resolved
-OpenVPN username after `oauth2.openvpn-username` has been evaluated.
+to an ordered list of strings. It receives the full shared CEL context.
+`user.username` contains the resolved OpenVPN username,
+`user.groups` and `user.roles` contain normalized provider data, and
+`token.claims` contains raw ID token claims.
 
 The default strategy is now `merge`. It loads every resolved config file,
 deduplicates repeated config names and identical config lines, and skips missing
@@ -159,10 +190,10 @@ openvpn:
     enabled: true
     path: /etc/openvpn-auth-oauth2/client-config
     expression: |
-        [openVPNUserCommonName]
+        [openvpn.commonName]
 ```
 
-To use the resolved OpenVPN username instead, use `username`:
+To use the resolved OpenVPN username instead, use `user.username`:
 
 ```yaml
 openvpn:
@@ -170,7 +201,7 @@ openvpn:
     enabled: true
     path: /etc/openvpn-auth-oauth2/client-config
     expression: |
-        [username]
+        [user.username]
 ```
 
 ### Token claim client config
@@ -195,7 +226,7 @@ openvpn:
     enabled: true
     path: /etc/openvpn-auth-oauth2/client-config
     expression: |
-        oauth2TokenClaims.groups
+        token.claims.groups
 ```
 
 If the claim can contain several values, all matching config files are merged by
@@ -226,7 +257,7 @@ openvpn:
     path: /etc/openvpn-auth-oauth2/client-config
     strategy: user-selector
     expression: |
-        oauth2TokenClaims.groups
+        token.claims.groups
 ```
 
 Static selector values also move into the expression:
@@ -271,12 +302,12 @@ openvpn:
     enabled: true
     path: /etc/openvpn-auth-oauth2/client-config
     expression: |
-        oauth2TokenClaims.groups.filter(g, g in [
+        user.groups.filter(g, g in [
           "GRP-VPN",
           "GRP-ADMIN",
           "GRP-NETWORK"
         ]) +
-        [username]
+        [user.username]
 ```
 
 ## Token validation
@@ -316,8 +347,8 @@ Use a CEL expression with `lowerAscii()` for the same case-insensitive behavior:
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.preferred_username) &&
-      openVPNUserCommonName.lowerAscii() == string(oauth2TokenClaims.preferred_username).lowerAscii()
+      has(token.claims.preferred_username) &&
+      openvpn.commonName.lowerAscii() == string(token.claims.preferred_username).lowerAscii()
 ```
 
 If you used case-sensitive common name validation:
@@ -337,8 +368,8 @@ Use a direct CEL comparison:
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.preferred_username) &&
-      openVPNUserCommonName == string(oauth2TokenClaims.preferred_username)
+      has(token.claims.preferred_username) &&
+      openvpn.commonName == string(token.claims.preferred_username)
 ```
 
 ### IP address validation
@@ -352,13 +383,13 @@ oauth2:
     ipaddr: true
 ```
 
-Version 2 exposes the OpenVPN client IP as `openVPNUserIPAddr` and the token IP address claim as `oauth2TokenIPAddr`:
+Version 2 exposes the OpenVPN client IP as `openvpn.ip` and the token IP address claim as `token.ip`:
 
 ```yaml
 # Version 2
 oauth2:
   validate:
-    expression: 'openVPNUserIPAddr == oauth2TokenIPAddr'
+    expression: 'openvpn.ip == token.ip'
 ```
 
 ### Roles validation
@@ -374,21 +405,19 @@ oauth2:
       - vpn-user
 ```
 
-Use CEL to check the `roles` claim directly:
+Use the normalized roles list:
 
 ```yaml
 # Version 2
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.roles) &&
-      ('admin' in oauth2TokenClaims.roles || 'vpn-user' in oauth2TokenClaims.roles)
+      'admin' in user.roles || 'vpn-user' in user.roles
 ```
 
 For GitHub provider configurations, team validation is also migrated to CEL.
-The GitHub provider still fetches teams from the `/user/teams` API and exposes
-them through `oauth2TokenClaims.roles` in the same `org:slug` format used by
-version 1:
+The GitHub provider fetches teams from the `/user/teams` API and exposes them
+through `user.roles` in the same `org:slug` format used by version 1:
 
 ```yaml
 # Version 1
@@ -406,8 +435,7 @@ oauth2:
   provider: github
   validate:
     expression: |
-      has(oauth2TokenClaims.roles) &&
-      ('my-org:vpn-users' in oauth2TokenClaims.roles || 'my-org:admins' in oauth2TokenClaims.roles)
+      'my-org:vpn-users' in user.roles || 'my-org:admins' in user.roles
 ```
 
 Keep organization checks with `oauth2.validate.groups`; for GitHub this still
@@ -433,8 +461,8 @@ Use CEL to check the `acr` claim:
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.acr) &&
-      (oauth2TokenClaims.acr == 'phr' || oauth2TokenClaims.acr == 'phrh')
+      has(token.claims.acr) &&
+      (token.claims.acr == 'phr' || token.claims.acr == 'phrh')
 ```
 
 ### Combining validation rules
@@ -456,11 +484,10 @@ oauth2:
 oauth2:
   validate:
     expression: |
-      has(oauth2TokenClaims.preferred_username) &&
-      openVPNUserCommonName.lowerAscii() == string(oauth2TokenClaims.preferred_username).lowerAscii() &&
-      openVPNUserIPAddr == oauth2TokenIPAddr &&
-      has(oauth2TokenClaims.roles) &&
-      'vpn-user' in oauth2TokenClaims.roles
+      has(token.claims.preferred_username) &&
+      openvpn.commonName.lowerAscii() == string(token.claims.preferred_username).lowerAscii() &&
+      openvpn.ip == token.ip &&
+      'vpn-user' in user.roles
 ```
 
 You can keep `oauth2.validate.groups` alongside CEL:
@@ -471,6 +498,6 @@ oauth2:
     groups:
       - vpn-users
     expression: |
-      has(oauth2TokenClaims.acr) &&
-      oauth2TokenClaims.acr == 'phr'
+      has(token.claims.acr) &&
+      token.claims.acr == 'phr'
 ```

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,7 +84,7 @@ oauth2:
         groups:
         - "test"
         - "test2"
-        expression: "openVPNUserCommonName == oauth2TokenClaims.preferred_username"
+        expression: "openvpn.commonName == token.claims.preferred_username"
     authorize-params: "a=c"
     auth-style: "AuthStyleInHeader"
     scopes:
@@ -100,7 +100,7 @@ oauth2:
         secret: "1jd93h5b6s82lf03jh5b2hf9"
         use-session-id: true
         validate-user: true
-    openvpn-username: "oauth2TokenClaims.sub"
+    openvpn-username: "token.claims.sub"
 openvpn:
     addr: "unix:///run/openvpn/server2.sock"
     auth-token-user: true
@@ -117,7 +117,7 @@ openvpn:
         path: "."
         strategy: user-selector
         expression: |
-            ["default", string(oauth2TokenClaims.sub)]
+            ["default", string(token.claims.sub)]
     common-name:
         environment-variable-name: X509_0_emailAddress
         mode: omit
@@ -193,7 +193,7 @@ http:
 
 							return dirFS
 						}(),
-						Expression: "[\"default\", string(oauth2TokenClaims.sub)]\n",
+						Expression: "[\"default\", string(token.claims.sub)]\n",
 					},
 					Password:           "1jd93h5b6s82lf03jh5b2hf9",
 					AuthTokenUser:      true,
@@ -241,7 +241,7 @@ http:
 					GroupsClaim:     "groups_direct",
 					Scopes:          []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile},
 					AuthStyle:       config.OAuth2AuthStyle(oauth2.AuthStyleInHeader),
-					OpenVPNUsername: "oauth2TokenClaims." + testsuite.SubjectClaim,
+					OpenVPNUsername: "token.claims." + testsuite.SubjectClaim,
 					Refresh: config.OAuth2Refresh{
 						Enabled:      true,
 						Expires:      10 * time.Hour,
@@ -250,7 +250,7 @@ http:
 						ValidateUser: true,
 					},
 					Validate: config.OAuth2Validate{
-						Expression: "openVPNUserCommonName == oauth2TokenClaims.preferred_username",
+						Expression: "openvpn.commonName == token.claims.preferred_username",
 						Groups:     []string{"test", "test2"},
 					},
 				},
@@ -334,10 +334,10 @@ func TestConfigFlagSet(t *testing.T) {
 		},
 		{
 			"--oauth2.validate.expression",
-			[]string{"--oauth2.validate.expression=openVPNUserCommonName == oauth2TokenClaims.preferred_username"},
+			[]string{"--oauth2.validate.expression=openvpn.commonName == token.claims.preferred_username"},
 			func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.Validate.Expression = "openVPNUserCommonName == oauth2TokenClaims.preferred_username"
+				conf.OAuth2.Validate.Expression = "openvpn.commonName == token.claims.preferred_username"
 
 				return conf
 			}(),

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -94,7 +94,7 @@ var Defaults = Config{
 		UserInfo:        false,
 		GroupsClaim:     "groups",
 		Provider:        "generic",
-		OpenVPNUsername: "oauth2TokenClaims.preferred_username",
+		OpenVPNUsername: "user.username",
 		Refresh: OAuth2Refresh{
 			Expires:      time.Hour * 8,
 			ValidateUser: true,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -402,9 +402,9 @@ func (c *Config) flagSetOAuth2(flagSet *flag.FlagSet) {
 		&c.OAuth2.Validate.Expression,
 		"oauth2.validate.expression",
 		lookupEnvOrDefault("oauth2.validate.expression", c.OAuth2.Validate.Expression),
-		"CEL expression for custom token validation. "+
+		"CEL expression for custom identity validation. "+
 			"The expression must evaluate to a boolean value. "+
-			"Example: openVPNUserCommonName == oauth2TokenClaims.preferred_username",
+			"Example: openvpn.commonName == user.username",
 	)
 	flagSet.TextVar(
 		&c.OAuth2.Scopes,
@@ -418,8 +418,8 @@ func (c *Config) flagSetOAuth2(flagSet *flag.FlagSet) {
 		&c.OAuth2.OpenVPNUsername,
 		"oauth2.openvpn-username",
 		lookupEnvOrDefault("oauth2.openvpn-username", c.OAuth2.OpenVPNUsername),
-		"CEL expression to extract the username from the token. The expression must evaluate to a string value. "+
-			"Example: oauth2TokenClaims.sub. If empty, the common name is used.",
+		"CEL expression to resolve the username from the normalized identity. The expression must evaluate to a string value. "+
+			"Example: string(token.claims.sub). If empty, the common name is used.",
 	)
 }
 

--- a/internal/it_test.go
+++ b/internal/it_test.go
@@ -308,7 +308,7 @@ func startUniqueUserITService(
 	require.NoError(t, err)
 
 	conf := config.Defaults
-	conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+	conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 	conf.OpenVPN.Addr = types.URL{
 		URL: &url.URL{Scheme: "tcp", Host: strings.TrimPrefix(managementEndpoint, "tcp://")},
 	}

--- a/internal/oauth2/bench_test.go
+++ b/internal/oauth2/bench_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 	"github.com/stretchr/testify/require"
 )
@@ -79,7 +80,7 @@ func BenchmarkCheckClientIPAddr(b *testing.B) {
 	})
 }
 
-func BenchmarkCheckTokenCEL(b *testing.B) {
+func BenchmarkCheckIdentityCEL(b *testing.B) {
 	for _, tc := range []struct {
 		name       string
 		expression string
@@ -88,7 +89,7 @@ func BenchmarkCheckTokenCEL(b *testing.B) {
 	}{
 		{
 			name:       "equality",
-			expression: "openVPNUserCommonName == oauth2TokenClaims.preferred_username",
+			expression: "openvpn.commonName == user.username",
 			state: state.State{
 				Client: state.ClientIdentifier{CommonName: "test-client"},
 				IPAddr: "127.0.0.1",
@@ -99,7 +100,7 @@ func BenchmarkCheckTokenCEL(b *testing.B) {
 		},
 		{
 			name:       "lower-ascii",
-			expression: "openVPNUserCommonName.lowerAscii() == string(oauth2TokenClaims.preferred_username).lowerAscii()",
+			expression: "openvpn.commonName.lowerAscii() == user.username.lowerAscii()",
 			state: state.State{
 				Client: state.ClientIdentifier{CommonName: "Test-Client"},
 				IPAddr: "127.0.0.1",
@@ -120,7 +121,12 @@ func BenchmarkCheckTokenCEL(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				if err := client.CheckTokenCEL(CELAuthModeInteractive, tc.state, tc.token); err != nil {
+				if err := client.CheckIdentityCEL(
+					CELAuthModeInteractive,
+					tc.state,
+					tc.token,
+					types.UserInfo{Username: "test-client"},
+				); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/internal/oauth2/cel.go
+++ b/internal/oauth2/cel.go
@@ -1,39 +1,155 @@
 package oauth2
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 )
 
-type CELAuthMode string
+type CELAuthMode = types.AuthMode
 
 const (
-	CELAuthModeInteractive    CELAuthMode = "interactive"
-	CELAuthModeNonInteractive CELAuthMode = "non-interactive"
+	CELAuthModeInteractive    = types.AuthModeInteractive
+	CELAuthModeNonInteractive = types.AuthModeNonInteractive
 )
 
-// CheckTokenCEL checks the provided ID token claims against the configured CEL expression.
-func (c *Client) CheckTokenCEL(authMode CELAuthMode, session state.State, tokens *idtoken.IDToken) error {
-	if c.celEvalPrg == nil {
+// newCELEnvironment returns the common CEL environment used by all configurable expressions.
+func newCELEnvironment() (*cel.Env, error) {
+	env, err := cel.NewEnv(
+		cel.VariableWithDoc("auth", cel.MapType(cel.StringType, cel.StringType), "Authentication context"),
+		cel.VariableWithDoc("openvpn", cel.MapType(cel.StringType, cel.StringType), "OpenVPN session context"),
+		cel.VariableWithDoc("token", cel.MapType(cel.StringType, cel.DynType), "OAuth2 token context"),
+		cel.VariableWithDoc("user", cel.MapType(cel.StringType, cel.DynType), "Normalized user context"),
+		ext.Strings(ext.StringsVersion(5)),
+		ext.Lists(ext.ListsVersion(3)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create CEL environment: %w", err)
+	}
+
+	return env, nil
+}
+
+func (c *Client) initializeCELPrograms() error {
+	if err := c.initializeUsernameResolver(); err != nil {
+		return err
+	}
+
+	if err := c.initializeCELValidation(); err != nil {
+		return err
+	}
+
+	return c.initializeClientConfigResolver()
+}
+
+// initializeUsernameResolver compiles the optional CEL expression used to derive the OpenVPN username.
+func (c *Client) initializeUsernameResolver() error {
+	if c.conf.OAuth2.OpenVPNUsername == "" {
 		return nil
 	}
 
-	if tokens == nil || tokens.IDTokenClaims == nil {
-		return ErrNoIDTokenAvailable
+	program, err := compileCELProgram(c.conf.OAuth2.OpenVPNUsername, cel.StringType)
+	if err != nil {
+		return fmt.Errorf("failed to initialize username CEL expression: %w", err)
 	}
 
-	vars := map[string]any{
-		"authMode":              string(authMode),
-		"openVPNSessionState":   session.SessionState,
-		"openVPNUserCommonName": session.Client.CommonName,
-		"openVPNUserIPAddr":     session.IPAddr,
-		"oauth2TokenIPAddr":     tokens.IDTokenClaims.IPAddr,
-		"oauth2TokenClaims":     tokens.IDTokenClaims.Claims,
+	c.usernameCELPrg = program
+
+	return nil
+}
+
+// initializeCELValidation compiles the configured CEL expression used for user validation.
+func (c *Client) initializeCELValidation() error {
+	if c.conf.OAuth2.Validate.Expression == "" {
+		return nil
 	}
 
-	result, _, err := c.celEvalPrg.Eval(vars)
+	program, err := compileCELProgram(c.conf.OAuth2.Validate.Expression, nil)
+	if err != nil {
+		return fmt.Errorf("failed to initialize validation CEL expression: %w", err)
+	}
+
+	c.validationCELPrg = program
+
+	return nil
+}
+
+func compileCELProgram(expression string, expectedType *cel.Type) (cel.Program, error) {
+	env, err := newCELEnvironment()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	ast, issues := env.Compile(expression)
+	if issues.Err() != nil {
+		return nil, fmt.Errorf("failed to compile CEL expression: %w", issues.Err())
+	}
+
+	if expectedType != nil && !ast.OutputType().IsAssignableType(expectedType) {
+		return nil, fmt.Errorf("cel expression must evaluate to %s, got %s", expectedType, ast.OutputType())
+	}
+
+	program, err := env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL program: %w", err)
+	}
+
+	return program, nil
+}
+
+// resolveUsername evaluates the configured username expression against the normalized identity.
+func (c *Client) resolveUsername(
+	authMode CELAuthMode,
+	session state.State,
+	tokens *idtoken.IDToken,
+	user types.UserInfo,
+) (string, error) {
+	if c.conf.OAuth2.OpenVPNUsername == "" {
+		return session.Client.CommonName, nil
+	}
+
+	if c.usernameCELPrg == nil {
+		return "", errors.New("username CEL expression is not initialized")
+	}
+
+	out, _, err := c.usernameCELPrg.Eval(newCELActivation(authMode, session, tokens, user))
+	if err != nil {
+		return "", fmt.Errorf("failed to evaluate CEL expression for username: %w", err)
+	}
+
+	username, ok := out.Value().(string)
+	if !ok {
+		return "", fmt.Errorf(
+			"%w: CEL expression for username did not evaluate to a string: %T",
+			types.ErrInvalidClaimType,
+			out.Value(),
+		)
+	}
+
+	if username == "" {
+		return session.Client.CommonName, nil
+	}
+
+	return username, nil
+}
+
+// CheckIdentityCEL checks the normalized identity against the configured CEL expression.
+func (c *Client) CheckIdentityCEL(
+	authMode CELAuthMode,
+	session state.State,
+	tokens *idtoken.IDToken,
+	user types.UserInfo,
+) error {
+	if c.validationCELPrg == nil {
+		return nil
+	}
+
+	result, _, err := c.validationCELPrg.Eval(newCELActivation(authMode, session, tokens, user))
 	if err != nil {
 		return fmt.Errorf("failed to evaluate CEL expression: %w", err)
 	}
@@ -48,4 +164,54 @@ func (c *Client) CheckTokenCEL(authMode CELAuthMode, session state.State, tokens
 	}
 
 	return nil
+}
+
+func newCELActivation(
+	authMode CELAuthMode,
+	session state.State,
+	tokens *idtoken.IDToken,
+	userInfo types.UserInfo,
+) map[string]any {
+	claims := make(map[string]any)
+	tokenIP := ""
+
+	if tokens != nil && tokens.IDTokenClaims != nil {
+		tokenIP = tokens.IDTokenClaims.IPAddr
+
+		if tokens.IDTokenClaims.Claims != nil {
+			claims = tokens.IDTokenClaims.Claims
+		}
+	}
+
+	groups := userInfo.Groups
+	if groups == nil {
+		groups = make([]string, 0)
+	}
+
+	roles := userInfo.Roles
+	if roles == nil {
+		roles = make([]string, 0)
+	}
+
+	return map[string]any{
+		"auth": map[string]string{
+			"mode": string(authMode),
+		},
+		"openvpn": map[string]string{
+			"commonName":   session.Client.CommonName,
+			"ip":           session.IPAddr,
+			"sessionState": session.SessionState,
+		},
+		"token": map[string]any{
+			"claims": claims,
+			"ip":     tokenIP,
+		},
+		"user": map[string]any{
+			"email":    userInfo.Email,
+			"groups":   groups,
+			"roles":    roles,
+			"subject":  userInfo.Subject,
+			"username": userInfo.Username,
+		},
+	}
 }

--- a/internal/oauth2/cel_test.go
+++ b/internal/oauth2/cel_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/providers/generic"
+	oauth2types "github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testsuite"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheckTokenCEL(t *testing.T) {
+func TestCheckIdentityCEL(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -24,6 +25,7 @@ func TestCheckTokenCEL(t *testing.T) {
 		conf  config.Config
 		state state.State
 		token *idtoken.IDToken
+		user  oauth2types.UserInfo
 		err   string
 	}{
 		{
@@ -65,18 +67,18 @@ func TestCheckTokenCEL(t *testing.T) {
 			}(),
 		},
 		{
-			name: "missing ID token claims",
+			name: "UserInfo identity without ID token claims",
 			conf: func() config.Config {
 				conf := config.Defaults
 				conf.OAuth2.Issuer = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
 				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
-				conf.OAuth2.Validate.Expression = "true"
+				conf.OAuth2.Validate.Expression = "user.username == 'userinfo-user'"
 
 				return conf
 			}(),
-			err: oauth2.ErrNoIDTokenAvailable.Error(),
+			user: oauth2types.UserInfo{Username: "userinfo-user"},
 		},
 		{
 			name: "try access known key",
@@ -86,7 +88,7 @@ func TestCheckTokenCEL(t *testing.T) {
 				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
-				conf.OAuth2.Validate.Expression = "oauth2TokenClaims.unknown == 'test-user'"
+				conf.OAuth2.Validate.Expression = "token.claims.unknown == 'test-user'"
 
 				return conf
 			}(),
@@ -103,7 +105,8 @@ func TestCheckTokenCEL(t *testing.T) {
 					},
 				},
 			},
-			err: "failed to evaluate CEL expression: no such key: unknown",
+			user: oauth2types.UserInfo{Username: "test-client"},
+			err:  "failed to evaluate CEL expression: no such key: unknown",
 		},
 		{
 			name: "try safe access known key",
@@ -113,7 +116,7 @@ func TestCheckTokenCEL(t *testing.T) {
 				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
-				conf.OAuth2.Validate.Expression = "has(oauth2TokenClaims.unknown) && oauth2TokenClaims.unknown == 'test-user'"
+				conf.OAuth2.Validate.Expression = "has(token.claims.unknown) && token.claims.unknown == 'test-user'"
 
 				return conf
 			}(),
@@ -130,7 +133,8 @@ func TestCheckTokenCEL(t *testing.T) {
 					},
 				},
 			},
-			err: "cel validation failed",
+			user: oauth2types.UserInfo{Username: "test-client"},
+			err:  "cel validation failed",
 		},
 		{
 			name: "CEL expression evaluates to true",
@@ -140,7 +144,7 @@ func TestCheckTokenCEL(t *testing.T) {
 				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
-				conf.OAuth2.Validate.Expression = "openVPNUserCommonName == oauth2TokenClaims.preferred_username"
+				conf.OAuth2.Validate.Expression = "openvpn.commonName == token.claims.preferred_username"
 
 				return conf
 			}(),
@@ -157,6 +161,7 @@ func TestCheckTokenCEL(t *testing.T) {
 					},
 				},
 			},
+			user: oauth2types.UserInfo{Username: "test-client"},
 		},
 		{
 			name: "CEL expression evaluates to false",
@@ -166,7 +171,7 @@ func TestCheckTokenCEL(t *testing.T) {
 				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
-				conf.OAuth2.Validate.Expression = "openVPNUserCommonName != oauth2TokenClaims.preferred_username"
+				conf.OAuth2.Validate.Expression = "openvpn.commonName != token.claims.preferred_username"
 
 				return conf
 			}(),
@@ -183,7 +188,8 @@ func TestCheckTokenCEL(t *testing.T) {
 					},
 				},
 			},
-			err: oauth2.ErrCELValidationFailed.Error(),
+			user: oauth2types.UserInfo{Username: "test-client"},
+			err:  oauth2.ErrCELValidationFailed.Error(),
 		},
 		{
 			name: "CEL expression evaluates to string",
@@ -193,7 +199,7 @@ func TestCheckTokenCEL(t *testing.T) {
 				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
-				conf.OAuth2.Validate.Expression = "openVPNUserCommonName"
+				conf.OAuth2.Validate.Expression = "openvpn.commonName"
 
 				return conf
 			}(),
@@ -210,7 +216,8 @@ func TestCheckTokenCEL(t *testing.T) {
 					},
 				},
 			},
-			err: "cel expression did not evaluate to a boolean value",
+			user: oauth2types.UserInfo{Username: "test-client"},
+			err:  "cel expression did not evaluate to a boolean value",
 		},
 		{
 			name: "CEL expression with lowerAscii",
@@ -220,7 +227,7 @@ func TestCheckTokenCEL(t *testing.T) {
 				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
-				conf.OAuth2.Validate.Expression = "openVPNUserCommonName.lowerAscii() == string(oauth2TokenClaims.preferred_username).lowerAscii()"
+				conf.OAuth2.Validate.Expression = "openvpn.commonName.lowerAscii() == string(token.claims.preferred_username).lowerAscii()"
 
 				return conf
 			}(),
@@ -237,6 +244,7 @@ func TestCheckTokenCEL(t *testing.T) {
 					},
 				},
 			},
+			user: oauth2types.UserInfo{Username: "test-client"},
 		},
 		{
 			name: "CEL expression with token IP address",
@@ -246,7 +254,7 @@ func TestCheckTokenCEL(t *testing.T) {
 				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
 				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
-				conf.OAuth2.Validate.Expression = "openVPNUserIPAddr == oauth2TokenIPAddr"
+				conf.OAuth2.Validate.Expression = "openvpn.ip == token.ip"
 
 				return conf
 			}(),
@@ -281,7 +289,7 @@ func TestCheckTokenCEL(t *testing.T) {
 
 			require.NoError(t, err)
 
-			err = oAuth2Client.CheckTokenCEL(oauth2.CELAuthModeInteractive, tc.state, tc.token)
+			err = oAuth2Client.CheckIdentityCEL(oauth2.CELAuthModeInteractive, tc.state, tc.token, tc.user)
 			if tc.err != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tc.err)

--- a/internal/oauth2/client_config.go
+++ b/internal/oauth2/client_config.go
@@ -9,9 +9,9 @@ import (
 	"unicode"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 )
 
 // initializeClientConfigResolver compiles the optional CEL expression used to resolve client configs.
@@ -20,41 +20,23 @@ func (c *Client) initializeClientConfigResolver() error {
 		return nil
 	}
 
-	env, err := cel.NewEnv(
-		cel.VariableWithDoc("openVPNUserCommonName", cel.StringType, "The common name of the OpenVPN user"),
-		cel.VariableWithDoc("oauth2TokenClaims", cel.MapType(cel.StringType, cel.DynType), "The claims of the OAuth2 ID token"),
-		cel.VariableWithDoc("username", cel.StringType, "The resolved OpenVPN username"),
-		ext.Strings(ext.StringsVersion(5)),
-		ext.Lists(ext.ListsVersion(3)),
-	)
+	program, err := compileCELProgram(c.conf.OpenVPN.ClientConfig.Expression, cel.ListType(cel.StringType))
 	if err != nil {
-		return fmt.Errorf("failed to create client config CEL environment: %w", err)
+		return fmt.Errorf("failed to initialize client config CEL expression: %w", err)
 	}
 
-	prg, issues := env.Compile(c.conf.OpenVPN.ClientConfig.Expression)
-	if issues.Err() != nil {
-		return fmt.Errorf("failed to compile client config CEL expression: %w", issues.Err())
-	}
-
-	expectedType := cel.ListType(cel.StringType)
-	if !prg.OutputType().IsAssignableType(expectedType) {
-		return fmt.Errorf(
-			"client config CEL expression must evaluate to %s, got %s",
-			expectedType,
-			prg.OutputType(),
-		)
-	}
-
-	c.configsCELPrg, err = env.Program(prg)
-	if err != nil {
-		return fmt.Errorf("failed to create client config CEL program: %w", err)
-	}
+	c.configsCELPrg = program
 
 	return nil
 }
 
 // ResolveClientConfigNames returns the ordered client config names for an authenticated user.
-func (c *Client) ResolveClientConfigNames(tokens *idtoken.IDToken, openVPNUserCommonName, username string) ([]string, error) {
+func (c *Client) ResolveClientConfigNames(
+	authMode CELAuthMode,
+	session state.State,
+	tokens *idtoken.IDToken,
+	user types.UserInfo,
+) ([]string, error) {
 	if !c.conf.OpenVPN.ClientConfig.Enabled {
 		return nil, nil
 	}
@@ -63,24 +45,20 @@ func (c *Client) ResolveClientConfigNames(tokens *idtoken.IDToken, openVPNUserCo
 		return nil, errors.New("client config expression is not configured")
 	}
 
-	return c.resolveClientConfigNamesCEL(tokens, openVPNUserCommonName, username)
+	return c.resolveClientConfigNamesCEL(authMode, session, tokens, user)
 }
 
-func (c *Client) resolveClientConfigNamesCEL(tokens *idtoken.IDToken, openVPNUserCommonName, username string) ([]string, error) {
+func (c *Client) resolveClientConfigNamesCEL(
+	authMode CELAuthMode,
+	session state.State,
+	tokens *idtoken.IDToken,
+	user types.UserInfo,
+) ([]string, error) {
 	if c.configsCELPrg == nil {
 		return nil, errors.New("client config CEL expression is not initialized")
 	}
 
-	claims := make(map[string]any)
-	if tokens != nil && tokens.IDTokenClaims != nil {
-		claims = tokens.IDTokenClaims.Claims
-	}
-
-	out, _, err := c.configsCELPrg.Eval(map[string]any{
-		"openVPNUserCommonName": openVPNUserCommonName,
-		"oauth2TokenClaims":     claims,
-		"username":              username,
-	})
+	out, _, err := c.configsCELPrg.Eval(newCELActivation(authMode, session, tokens, user))
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate CEL expression for client configs: %w", err)
 	}

--- a/internal/oauth2/client_config_test.go
+++ b/internal/oauth2/client_config_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
+	oauth2types "github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,18 +16,20 @@ func TestResolveClientConfigNamesExpression(t *testing.T) {
 
 	conf := config.Defaults
 	conf.OpenVPN.ClientConfig.Enabled = true
-	conf.OpenVPN.ClientConfig.Expression = `oauth2TokenClaims.groups.filter(g, g in ["base", "admin"]) + [username]`
+	conf.OpenVPN.ClientConfig.Expression = `user.groups.filter(g, g in ["base", "admin"]) + [user.username]`
 
 	client := Client{conf: &conf}
 	require.NoError(t, client.initializeClientConfigResolver())
 
-	names, err := client.ResolveClientConfigNames(&idtoken.IDToken{
-		IDTokenClaims: &idtoken.Claims{
-			Claims: map[string]any{
-				"groups": []any{"base", "ignored", "admin"},
-			},
+	names, err := client.ResolveClientConfigNames(
+		CELAuthModeInteractive,
+		state.State{Client: state.ClientIdentifier{CommonName: "client-cn"}},
+		&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}},
+		oauth2types.UserInfo{
+			Username: "alice",
+			Groups:   []string{"base", "ignored", "admin"},
 		},
-	}, "client-cn", "alice")
+	)
 
 	require.NoError(t, err)
 	require.Equal(t, []string{"base", "admin", "alice"}, names)
@@ -36,15 +40,16 @@ func TestResolveClientConfigNamesExpressionUsesCommonNameAndUsername(t *testing.
 
 	conf := config.Defaults
 	conf.OpenVPN.ClientConfig.Enabled = true
-	conf.OpenVPN.ClientConfig.Expression = `[openVPNUserCommonName, username]`
+	conf.OpenVPN.ClientConfig.Expression = `[openvpn.commonName, user.username]`
 
 	client := Client{conf: &conf}
 	require.NoError(t, client.initializeClientConfigResolver())
 
 	names, err := client.ResolveClientConfigNames(
+		CELAuthModeInteractive,
+		state.State{Client: state.ClientIdentifier{CommonName: "client-cn"}},
 		&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}},
-		"client-cn",
-		"alice",
+		oauth2types.UserInfo{Username: "alice"},
 	)
 
 	require.NoError(t, err)
@@ -61,7 +66,12 @@ func TestResolveClientConfigNamesExpressionRejectsInvalidName(t *testing.T) {
 	client := Client{conf: &conf}
 	require.NoError(t, client.initializeClientConfigResolver())
 
-	_, err := client.ResolveClientConfigNames(&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}}, "client-cn", "alice")
+	_, err := client.ResolveClientConfigNames(
+		CELAuthModeInteractive,
+		state.State{Client: state.ClientIdentifier{CommonName: "client-cn"}},
+		&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}},
+		oauth2types.UserInfo{Username: "alice"},
+	)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid client config path")
@@ -77,7 +87,12 @@ func TestResolveClientConfigNamesExpressionRejectsUnsafeName(t *testing.T) {
 	client := Client{conf: &conf}
 	require.NoError(t, client.initializeClientConfigResolver())
 
-	_, err := client.ResolveClientConfigNames(&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}}, "client-cn", "alice")
+	_, err := client.ResolveClientConfigNames(
+		CELAuthModeInteractive,
+		state.State{Client: state.ClientIdentifier{CommonName: "client-cn"}},
+		&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}},
+		oauth2types.UserInfo{Username: "alice"},
+	)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsafe client config name")
@@ -118,12 +133,17 @@ func TestResolveClientConfigNamesExpressionRejectsMissingClaim(t *testing.T) {
 
 	conf := config.Defaults
 	conf.OpenVPN.ClientConfig.Enabled = true
-	conf.OpenVPN.ClientConfig.Expression = `oauth2TokenClaims.groups`
+	conf.OpenVPN.ClientConfig.Expression = `token.claims.groups`
 
 	client := Client{conf: &conf}
 	require.NoError(t, client.initializeClientConfigResolver())
 
-	_, err := client.ResolveClientConfigNames(&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}}, "client-cn", "alice")
+	_, err := client.ResolveClientConfigNames(
+		CELAuthModeInteractive,
+		state.State{Client: state.ClientIdentifier{CommonName: "client-cn"}},
+		&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}},
+		oauth2types.UserInfo{Username: "alice"},
+	)
 
 	require.Error(t, err)
 }
@@ -136,7 +156,12 @@ func TestResolveClientConfigNamesRequiresExpression(t *testing.T) {
 
 	client := Client{conf: &conf}
 
-	_, err := client.ResolveClientConfigNames(&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}}, "client-cn", "alice")
+	_, err := client.ResolveClientConfigNames(
+		CELAuthModeInteractive,
+		state.State{Client: state.ClientIdentifier{CommonName: "client-cn"}},
+		&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{Claims: map[string]any{}}},
+		oauth2types.UserInfo{Username: "alice"},
+	)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "client config expression is not configured")

--- a/internal/oauth2/errors.go
+++ b/internal/oauth2/errors.go
@@ -12,7 +12,6 @@ var (
 
 	ErrCELValidationFailed = errors.New("cel validation failed")
 	ErrCELNoBooleanResult  = errors.New("cel expression did not evaluate to a boolean value")
-	ErrNoIDTokenAvailable  = errors.New("no ID token claims available for cel validation")
 
 	ErrClientRejected = errors.New("client rejected")
 )

--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -314,7 +314,7 @@ func (c *Client) postCodeExchangeHandler(
 
 		logger = withIDTokenClaimsLogger(ctx, logger, tokens)
 
-		user, err := c.fetchUser(ctx, logger, tokens, userInfo)
+		user, err := c.fetchUser(ctx, logger, session, tokens, userInfo)
 		if err != nil {
 			c.openvpn.DenyClient(ctx, logger, session.Client, err.openvpnReason)
 			c.writeHTTPError(ctx, w, logger, err.httpStatus, err.errorType, err.err.Error())
@@ -336,25 +336,21 @@ func (c *Client) postCodeExchangeHandler(
 
 		logger.LogAttrs(ctx, slog.LevelInfo, "successful authorization via oauth2")
 
-		username := user.Username
-		if username == "" {
-			username = session.Client.CommonName
-		}
-
 		codeExchange := codeExchangeRequest{
 			logger:         logger,
 			encryptedState: encryptedState,
 			session:        session,
 			clientID:       clientID,
 			tokens:         tokens,
-			username:       username,
+			user:           user,
+			username:       user.Username,
 		}
 
 		if c.handleClientConfig(ctx, w, codeExchange) {
 			return
 		}
 
-		c.acceptOAuth2Client(ctx, w, codeExchange, username)
+		c.acceptOAuth2Client(ctx, w, codeExchange, user.Username)
 	}
 }
 
@@ -386,10 +382,11 @@ type userValidationError struct {
 func (c *Client) fetchUser(
 	ctx context.Context,
 	logger *slog.Logger,
+	session state.State,
 	tokens *idtoken.IDToken,
 	userInfo *types.UserInfo,
 ) (types.UserInfo, *userValidationError) {
-	user, err := c.provider.GetUser(ctx, logger, tokens, userInfo)
+	user, err := c.resolveUser(ctx, logger, CELAuthModeInteractive, session, tokens, userInfo)
 	if err != nil {
 		return types.UserInfo{}, &userValidationError{
 			err:           err,
@@ -397,6 +394,28 @@ func (c *Client) fetchUser(
 			errorType:     "fetchUser",
 			openvpnReason: "unable to fetch user data",
 		}
+	}
+
+	return user, nil
+}
+
+// resolveUser normalizes provider data and applies the configured username expression.
+func (c *Client) resolveUser(
+	ctx context.Context,
+	logger *slog.Logger,
+	authMode CELAuthMode,
+	session state.State,
+	tokens *idtoken.IDToken,
+	userInfo *types.UserInfo,
+) (types.UserInfo, error) {
+	user, err := c.provider.GetUser(ctx, logger, tokens, userInfo)
+	if err != nil {
+		return types.UserInfo{}, fmt.Errorf("get user from provider: %w", err)
+	}
+
+	user.Username, err = c.resolveUsername(authMode, session, tokens, user)
+	if err != nil {
+		return types.UserInfo{}, err
 	}
 
 	return user, nil
@@ -413,7 +432,7 @@ func (c *Client) validateInteractiveUser(
 		return failedUserValidation(err)
 	}
 
-	if err := c.CheckTokenCEL(CELAuthModeInteractive, session, tokens); err != nil {
+	if err := c.CheckIdentityCEL(CELAuthModeInteractive, session, tokens, user); err != nil {
 		return failedUserValidation(err)
 	}
 
@@ -433,6 +452,7 @@ func failedUserValidation(err error) *userValidationError {
 type codeExchangeRequest struct {
 	logger         *slog.Logger
 	tokens         *idtoken.IDToken
+	user           types.UserInfo
 	encryptedState state.EncryptedState
 	clientID       string
 	username       string
@@ -445,7 +465,7 @@ func (c *Client) handleClientConfig(ctx context.Context, w http.ResponseWriter, 
 		return false
 	}
 
-	clientConfigProfiles, err := c.ResolveClientConfigNames(req.tokens, req.session.Client.CommonName, req.username)
+	clientConfigProfiles, err := c.ResolveClientConfigNames(CELAuthModeInteractive, req.session, req.tokens, req.user)
 	if err != nil {
 		c.openvpn.DenyClient(ctx, req.logger, req.session.Client, "invalid client config")
 		c.writeHTTPError(ctx, w, req.logger, http.StatusForbidden, "client config", err.Error())

--- a/internal/oauth2/handler_test.go
+++ b/internal/oauth2/handler_test.go
@@ -45,7 +45,8 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
+				conf.OAuth2.Validate.Expression = "user.username == string(token.claims.sub)"
 
 				return conf
 			}(),
@@ -65,7 +66,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -89,7 +90,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -111,7 +112,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.UserInfo = true
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -133,7 +134,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.UserInfo = true
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -155,7 +156,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.UserInfo = true
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -175,7 +176,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -195,7 +196,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -217,7 +218,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -238,7 +239,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -260,7 +261,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -282,7 +283,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -305,7 +306,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Validate.Expression = "false"
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -327,9 +328,9 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.ClientConfig.Enabled = true
-				conf.OpenVPN.ClientConfig.Expression = "[string(oauth2TokenClaims." + testsuite.SubjectClaim + ")]"
+				conf.OpenVPN.ClientConfig.Expression = "[string(token.claims." + testsuite.SubjectClaim + ")]"
 				conf.OpenVPN.ClientConfig.Path = types.FS{
 					FS: fstest.MapFS{
 						"id1.conf": &fstest.MapFile{
@@ -358,9 +359,9 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.ClientConfig.Enabled = true
-				conf.OpenVPN.ClientConfig.Expression = "[string(oauth2TokenClaims." + testsuite.SubjectClaim + ")]"
+				conf.OpenVPN.ClientConfig.Expression = "[string(token.claims." + testsuite.SubjectClaim + ")]"
 				conf.OpenVPN.ClientConfig.Path = types.FS{
 					FS: fstest.MapFS{
 						"id1.conf": &fstest.MapFile{
@@ -391,7 +392,7 @@ func TestHandler(t *testing.T) {
 				conf.OpenVPN.AuthTokenUser = true
 				conf.OAuth2.OpenVPNUsername = ""
 				conf.OpenVPN.ClientConfig.Enabled = true
-				conf.OpenVPN.ClientConfig.Expression = "[openVPNUserCommonName]"
+				conf.OpenVPN.ClientConfig.Expression = "[openvpn.commonName]"
 				conf.OpenVPN.ClientConfig.Path = types.FS{
 					FS: fstest.MapFS{},
 				}
@@ -416,7 +417,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.ClientConfig.Enabled = true
 				conf.OpenVPN.ClientConfig.Strategy = config.OpenVPNConfigStrategyUserSelector
 				conf.OpenVPN.ClientConfig.Expression = `["static"]`
@@ -448,10 +449,10 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.ClientConfig.Enabled = true
 				conf.OpenVPN.ClientConfig.Strategy = config.OpenVPNConfigStrategyUserSelector
-				conf.OpenVPN.ClientConfig.Expression = `["static", string(oauth2TokenClaims.` + testsuite.SubjectClaim + `)]`
+				conf.OpenVPN.ClientConfig.Expression = `["static", string(token.claims.` + testsuite.SubjectClaim + `)]`
 				conf.OpenVPN.ClientConfig.Path = types.FS{
 					FS: fstest.MapFS{
 						"id1.conf": &fstest.MapFile{
@@ -480,10 +481,10 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.ClientConfig.Enabled = true
 				conf.OpenVPN.ClientConfig.Strategy = config.OpenVPNConfigStrategyUserSelector
-				conf.OpenVPN.ClientConfig.Expression = `["aaa"] + oauth2TokenClaims.amr`
+				conf.OpenVPN.ClientConfig.Expression = `["aaa"] + token.claims.amr`
 				conf.OpenVPN.ClientConfig.Path = types.FS{
 					FS: fstest.MapFS{
 						"pwd.conf": &fstest.MapFile{
@@ -512,7 +513,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.ClientConfig.Enabled = true
 				conf.OpenVPN.ClientConfig.Strategy = config.OpenVPNConfigStrategyUserSelector
 				conf.OpenVPN.ClientConfig.Expression = `["static"]`
@@ -576,7 +577,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.ClientConfig.Enabled = true
 				conf.OpenVPN.ClientConfig.Strategy = config.OpenVPNConfigStrategyUserSelector
 				conf.OpenVPN.ClientConfig.Expression = `["group1", "group2"]`
@@ -608,7 +609,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -630,7 +631,7 @@ func TestHandler(t *testing.T) {
 				conf.OAuth2.Scopes = []string{oauth2types.ScopeOpenID, oauth2types.ScopeProfile}
 				conf.OpenVPN.Bypass.CommonNames = make(types.RegexpSlice, 0)
 				conf.OpenVPN.AuthTokenUser = true
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 				return conf
 			}(),
@@ -745,7 +746,7 @@ func TestHandler(t *testing.T) {
 			clientConfigSelectorActive := tc.conf.OpenVPN.ClientConfig.Enabled &&
 				tc.conf.OpenVPN.ClientConfig.Strategy == config.OpenVPNConfigStrategyUserSelector &&
 				(strings.Contains(tc.conf.OpenVPN.ClientConfig.Expression, ",") ||
-					strings.Contains(tc.conf.OpenVPN.ClientConfig.Expression, "+ oauth2TokenClaims"))
+					strings.Contains(tc.conf.OpenVPN.ClientConfig.Expression, "+ token.claims"))
 
 			switch {
 			case !tc.postAllow:
@@ -770,12 +771,7 @@ func TestHandler(t *testing.T) {
 					suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")
 				}
 			default:
-				if tc.conf.OAuth2.UserInfo {
-					suite.ExpectMessage(t, "client-auth 0 1\r\npush \"auth-token-user dGVzdC11c2VyQGxvY2FsaG9zdA==\"\r\nEND")
-				} else {
-					suite.ExpectMessage(t, "client-auth 0 1\r\npush \"auth-token-user aWQx\"\r\nEND")
-				}
-
+				suite.ExpectMessage(t, "client-auth 0 1\r\npush \"auth-token-user aWQx\"\r\nEND")
 				suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")
 			}
 

--- a/internal/oauth2/provider.go
+++ b/internal/oauth2/provider.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/crypto"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
@@ -75,51 +73,11 @@ func New(
 		}
 	}
 
-	err = client.initializeCELValidation()
-	if err != nil {
-		return nil, err
-	}
-
-	err = client.initializeClientConfigResolver()
-	if err != nil {
+	if err = client.initializeCELPrograms(); err != nil {
 		return nil, err
 	}
 
 	return client, nil
-}
-
-// initializeCELValidation compiles the configured CEL expression used for token validation.
-func (c *Client) initializeCELValidation() error {
-	if c.conf.OAuth2.Validate.Expression == "" {
-		return nil
-	}
-
-	env, err := cel.NewEnv(
-		cel.VariableWithDoc("authMode", cel.StringType, "The authentication mode used (e.g., 'interactive', 'non-interactive')"),
-		cel.VariableWithDoc("openVPNSessionState", cel.StringType, "The OpenVPN session state "+
-			"(e.g., '', 'Empty', 'Initial', 'Authenticated', 'Expired', 'Invalid', 'AuthenticatedEmptyUser', 'ExpiredEmptyUser')"),
-		cel.VariableWithDoc("openVPNUserCommonName", cel.StringType, "The common name of the OpenVPN user"),
-		cel.VariableWithDoc("openVPNUserIPAddr", cel.StringType, "The IP address of the OpenVPN user"),
-		cel.VariableWithDoc("oauth2TokenIPAddr", cel.StringType, "The IP address claim of the OAuth2 ID token"),
-		cel.VariableWithDoc("oauth2TokenClaims", cel.MapType(cel.StringType, cel.DynType), "The claims of the OAuth2 ID token"),
-		ext.Strings(ext.StringsVersion(5)),
-		ext.Lists(ext.ListsVersion(3)),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create CEL environment: %w", err)
-	}
-
-	prg, issues := env.Compile(c.conf.OAuth2.Validate.Expression)
-	if issues.Err() != nil {
-		return fmt.Errorf("failed to compile CEL expression: %w", issues.Err())
-	}
-
-	c.celEvalPrg, err = env.Program(prg)
-	if err != nil {
-		return fmt.Errorf("failed to create CEL program: %w", err)
-	}
-
-	return nil
 }
 
 // newOIDCRelyingParty creates a new [rp.NewRelyingPartyOIDC]. This is used for providers that support OIDC.

--- a/internal/oauth2/providers/generic/bench_test.go
+++ b/internal/oauth2/providers/generic/bench_test.go
@@ -28,6 +28,7 @@ func BenchmarkGetUser(b *testing.B) {
 			conf: config.Defaults,
 			token: &idtoken.IDToken{
 				IDTokenClaims: &idtoken.Claims{
+					PreferredUsername: "username",
 					Claims: map[string]any{
 						"preferred_username": "username",
 					},
@@ -45,6 +46,7 @@ func BenchmarkGetUser(b *testing.B) {
 			}(),
 			token: &idtoken.IDToken{
 				IDTokenClaims: &idtoken.Claims{
+					PreferredUsername: "username",
 					Claims: map[string]any{
 						"preferred_username": "username",
 						"groups":             []string{"group1", "group2"},
@@ -63,6 +65,7 @@ func BenchmarkGetUser(b *testing.B) {
 			}(),
 			token: &idtoken.IDToken{
 				IDTokenClaims: &idtoken.Claims{
+					PreferredUsername: "username",
 					Claims: map[string]any{
 						"preferred_username": "username",
 						"groups":             []any{"group1", "group2"},
@@ -72,17 +75,12 @@ func BenchmarkGetUser(b *testing.B) {
 			},
 		},
 		{
-			name: "username-cel",
-			conf: func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "string(oauth2TokenClaims.groups[0])"
-
-				return conf
-			}(),
+			name: "roles-any-slice",
+			conf: config.Defaults,
 			token: &idtoken.IDToken{
 				IDTokenClaims: &idtoken.Claims{
 					Claims: map[string]any{
-						"groups": []any{"group1", "group2"},
+						"roles": []any{"role1", "role2"},
 					},
 					TokenClaims: oidc.TokenClaims{Subject: "subject"},
 				},

--- a/internal/oauth2/providers/generic/main.go
+++ b/internal/oauth2/providers/generic/main.go
@@ -2,68 +2,27 @@ package generic
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 )
 
 const Name = "generic"
 
 type Provider struct {
-	celEvalPrg cel.Program
-	Conf       *config.Config
+	Conf *config.Config
 }
 
 // NewProvider creates a new generic provider from the supplied configuration.
 // The http.Client argument is ignored because the provider uses the global
 // client from the oauth2 package.
 func NewProvider(_ context.Context, conf *config.Config, _ *http.Client) (*Provider, error) {
-	provider := &Provider{
+	return &Provider{
 		Conf: conf,
-	}
-
-	celEvalPrg, err := provider.setupCEL()
-	if err != nil {
-		return nil, err
-	}
-
-	provider.celEvalPrg = celEvalPrg
-
-	return provider, nil
+	}, nil
 }
 
 // GetName returns the identifier of this provider implementation.
 func (p Provider) GetName() string {
 	return Name
-}
-
-// setupCEL compiles the optional CEL expression used to derive the OpenVPN username.
-func (p Provider) setupCEL() (cel.Program, error) {
-	if p.Conf.OAuth2.OpenVPNUsername == "" {
-		return nil, nil //nolint:nilnil // No CEL expression configured, so we don't need to set up a program.
-	}
-
-	env, err := cel.NewEnv(
-		cel.VariableWithDoc("oauth2TokenClaims", cel.MapType(cel.StringType, cel.DynType), "The claims of the OAuth2 ID token"),
-		ext.Strings(ext.StringsVersion(5)),
-		ext.Lists(ext.ListsVersion(3)),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
-	}
-
-	prg, issues := env.Compile(p.Conf.OAuth2.OpenVPNUsername)
-	if issues.Err() != nil {
-		return nil, fmt.Errorf("failed to compile CEL expression: %w", issues.Err())
-	}
-
-	celEvalPrg, err := env.Program(prg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create CEL program: %w", err)
-	}
-
-	return celEvalPrg, nil
 }

--- a/internal/oauth2/providers/generic/user.go
+++ b/internal/oauth2/providers/generic/user.go
@@ -9,108 +9,144 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 )
 
-// GetUser resolves user data from UserInfo when available, otherwise from ID token claims.
+// GetUser normalizes user data from UserInfo and ID token claims.
 func (p Provider) GetUser(ctx context.Context, logger *slog.Logger, tokens *idtoken.IDToken, userinfo *types.UserInfo) (types.UserInfo, error) {
-	if userinfo != nil {
-		return *userinfo, nil
+	user := userFromUserInfo(userinfo)
+
+	if tokens == nil {
+		return user, nil
 	}
 
 	if tokens.IDTokenClaims == nil {
-		if tokens.IDToken == "" {
-			// if tokens.Token.Extra("id_token") != nil {
-			// 	logger.Warn("The provider has returned an 'id_token', however, it was configured as an OAUTH2 provider. " +
-			// 		"As a result, user data validation cannot be performed. If you have defined endpoints in the configuration, please remove them and retry.")
-			// 	logger.Debug("id_token", "id_token", tokens.Token.Extra("id_token"))
-			// } else {
-			logger.LogAttrs(ctx, slog.LevelWarn, "provider did not return a id_token. validation of user data is not possible.")
-		} else {
-			logger.LogAttrs(ctx, slog.LevelWarn, "provider did return a id_token, but it was not parsed correctly. Validation of user data is not possible."+
-				" Enable DEBUG logs to see the raw token and report this to maintainer.")
-			logger.LogAttrs(
-				ctx, slog.LevelDebug, "id_token",
-				slog.String("id_token", tokens.IDToken),
-			)
+		if userinfo == nil {
+			logMissingIDToken(ctx, logger, tokens)
 		}
 
-		return types.UserInfo{}, nil
+		return user, nil
 	}
 
-	var groups []string
+	fillUserFromIDToken(&user, tokens.IDTokenClaims)
 
-	if len(p.Conf.OAuth2.Validate.Groups) != 0 {
-		var err error
-
-		groups, err = p.extractGroups(ctx, logger, tokens)
-		if err != nil {
-			return types.UserInfo{}, err
-		}
-	}
-
-	username, err := p.extractUsernameFromToken(tokens)
-	if err != nil {
+	if err := p.fillUserGroupsAndRoles(ctx, logger, tokens, &user); err != nil {
 		return types.UserInfo{}, err
 	}
 
-	return types.UserInfo{
-		Username: username,
-		Subject:  tokens.IDTokenClaims.Subject,
-		Email:    tokens.IDTokenClaims.EMail,
-		Groups:   groups,
-	}, nil
+	return user, nil
 }
 
-// extractUsernameFromToken resolves the OpenVPN username from a CEL expression.
-func (p Provider) extractUsernameFromToken(tokens *idtoken.IDToken) (string, error) {
-	switch {
-	case p.Conf.OAuth2.OpenVPNUsername != "":
-		out, _, err := p.celEvalPrg.Eval(map[string]any{
-			"oauth2TokenClaims": tokens.IDTokenClaims.Claims,
-		})
+func userFromUserInfo(userinfo *types.UserInfo) types.UserInfo {
+	if userinfo != nil {
+		return *userinfo
+	}
+
+	return types.UserInfo{}
+}
+
+func fillUserFromIDToken(user *types.UserInfo, claims *idtoken.Claims) {
+	if user.Subject == "" {
+		user.Subject = claims.Subject
+	}
+
+	if user.Email == "" {
+		user.Email = claims.EMail
+	}
+
+	if user.Username == "" {
+		user.Username = claims.PreferredUsername
+	}
+}
+
+func (p Provider) fillUserGroupsAndRoles(
+	ctx context.Context,
+	logger *slog.Logger,
+	tokens *idtoken.IDToken,
+	user *types.UserInfo,
+) error {
+	if user.Groups == nil {
+		groups, err := p.extractStringSliceClaim(
+			ctx,
+			logger,
+			tokens,
+			p.Conf.OAuth2.GroupsClaim,
+			len(p.Conf.OAuth2.Validate.Groups) != 0,
+		)
 		if err != nil {
-			return "", fmt.Errorf("failed to evaluate CEL expression for username: %w", err)
+			return err
 		}
 
-		username, ok := out.Value().(string)
-		if !ok {
-			return "", fmt.Errorf("%w: CEL expression for username did not evaluate to a string: %T", types.ErrInvalidClaimType, out.Value())
-		}
-
-		return username, nil
-	default:
-		return "", nil
+		user.Groups = groups
 	}
+
+	if user.Roles == nil {
+		roles, err := p.extractStringSliceClaim(ctx, logger, tokens, "roles", false)
+		if err != nil {
+			return err
+		}
+
+		user.Roles = roles
+	}
+
+	return nil
 }
 
-// extractGroups reads the configured groups claim from the ID token.
-func (p Provider) extractGroups(ctx context.Context, logger *slog.Logger, tokens *idtoken.IDToken) ([]string, error) {
-	groupClaim, ok := tokens.IDTokenClaims.Claims[p.Conf.OAuth2.GroupsClaim]
+func logMissingIDToken(ctx context.Context, logger *slog.Logger, tokens *idtoken.IDToken) {
+	if tokens.IDToken == "" {
+		// if tokens.Token.Extra("id_token") != nil {
+		// 	logger.Warn("The provider has returned an 'id_token', however, it was configured as an OAUTH2 provider. " +
+		// 		"As a result, user data validation cannot be performed. If you have defined endpoints in the configuration, please remove them and retry.")
+		// 	logger.Debug("id_token", "id_token", tokens.Token.Extra("id_token"))
+		// } else {
+		logger.LogAttrs(ctx, slog.LevelWarn, "provider did not return a id_token. validation of user data is not possible.")
+
+		return
+	}
+
+	logger.LogAttrs(ctx, slog.LevelWarn, "provider did return a id_token, but it was not parsed correctly. Validation of user data is not possible."+
+		" Enable DEBUG logs to see the raw token and report this to maintainer.")
+	logger.LogAttrs(
+		ctx, slog.LevelDebug, "id_token",
+		slog.String("id_token", tokens.IDToken),
+	)
+}
+
+// extractStringSliceClaim reads a string-list claim from the ID token.
+func (p Provider) extractStringSliceClaim(
+	ctx context.Context,
+	logger *slog.Logger,
+	tokens *idtoken.IDToken,
+	claimName string,
+	warnIfMissing bool,
+) ([]string, error) {
+	claim, ok := tokens.IDTokenClaims.Claims[claimName]
 	if !ok {
-		logger.LogAttrs(ctx, slog.LevelWarn, "provider did not return a groups claim. validation of groups is not possible.")
+		if warnIfMissing {
+			logger.LogAttrs(ctx, slog.LevelWarn, "provider did not return a groups claim. validation of groups is not possible.")
+		}
 
 		return nil, nil
 	}
 
-	if groupClaim == nil {
+	if claim == nil {
 		return nil, nil
 	}
 
-	switch groups := groupClaim.(type) {
+	switch values := claim.(type) {
 	case []string:
-		return groups, nil
+		return values, nil
 	case []any:
-		var convertedGroups []string
+		convertedValues := make([]string, 0, len(values))
 
-		for _, group := range groups {
-			strGroup, ok := group.(string)
+		for _, value := range values {
+			stringValue, ok := value.(string)
 			if !ok {
-				return nil, fmt.Errorf("%w: groups claim contains non-string element: %T", types.ErrInvalidClaimType, group)
+				return nil, fmt.Errorf("%w: %s claim contains non-string element: %T", types.ErrInvalidClaimType, claimName, value)
 			}
 
-			convertedGroups = append(convertedGroups, strGroup)
+			convertedValues = append(convertedValues, stringValue)
 		}
 
-		return convertedGroups, nil
+		return convertedValues, nil
 	default:
-		return nil, fmt.Errorf("%w: groups claim: %T", types.ErrInvalidClaimType, groupClaim)
+		return nil, fmt.Errorf("%w: %s claim: %T", types.ErrInvalidClaimType, claimName, claim)
 	}
 }

--- a/internal/oauth2/providers/generic/user_test.go
+++ b/internal/oauth2/providers/generic/user_test.go
@@ -1,7 +1,6 @@
 package generic_test
 
 import (
-	"errors"
 	"log/slog"
 	"net/http"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/providers/generic"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testsuite"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
@@ -23,403 +21,141 @@ func TestGetUser(t *testing.T) {
 		conf     config.Config
 		token    *idtoken.IDToken
 		userInfo *types.UserInfo
-		userData types.UserInfo
+		expected types.UserInfo
 		err      error
 	}{
 		{
-			"default token",
-			config.Defaults,
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					Claims: map[string]any{
-						"preferred_username": "username",
-					},
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
+			name: "ID token identity",
+			conf: config.Defaults,
+			token: tokenWithClaims(
+				map[string]any{},
+				idtoken.Claims{
+					TokenClaims:       oidc.TokenClaims{Subject: "subject"},
+					PreferredUsername: "username",
+					EMail:             "user@example.com",
 				},
-			},
-			nil,
-			types.UserInfo{
+			),
+			expected: types.UserInfo{
 				Subject:  "subject",
+				Email:    "user@example.com",
 				Username: "username",
 			},
-			nil,
 		},
 		{
-			"default token with groups claim",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.Validate.Groups = []string{"group"}
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					Claims: map[string]any{
-						"preferred_username": "username",
-						"groups":             []string{"group1", "group2"},
-					},
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
+			name: "groups and roles",
+			conf: config.Defaults,
+			token: tokenWithClaims(
+				map[string]any{
+					"groups": []any{"group1", "group2"},
+					"roles":  []string{"role1", "role2"},
 				},
+				idtoken.Claims{},
+			),
+			expected: types.UserInfo{
+				Groups: []string{"group1", "group2"},
+				Roles:  []string{"role1", "role2"},
 			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: "username",
-				Groups:   []string{"group1", "group2"},
-			},
-			nil,
 		},
 		{
-			"default token with groups claim type any",
-			func() config.Config {
+			name: "custom groups claim",
+			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.Validate.Groups = []string{"group"}
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"preferred_username": "username",
-						"groups":             []any{any("group1"), any("group2")},
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: "username",
-				Groups:   []string{"group1", "group2"},
-			},
-			nil,
-		},
-		{
-			"default token with invalid groups claim type any",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.Validate.Groups = []string{"group"}
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"preferred_username": "username",
-						"groups":             []any{any("group1"), any(0)},
-					},
-				},
-			},
-			nil,
-			types.UserInfo{},
-			types.ErrInvalidClaimType,
-		},
-		{
-			"default token with custom groups claim",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.Validate.Groups = []string{"group"}
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"preferred_username": "username",
-						"groups_direct":      []string{"group1", "group2"},
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: "username",
-			},
-			nil,
-		},
-		{
-			"default token with configured custom groups claim",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.Validate.Groups = []string{"group"}
 				conf.OAuth2.GroupsClaim = "groups_direct"
 
 				return conf
 			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"preferred_username": "username",
-						"groups_direct":      []string{"group1", "group2"},
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: "username",
-				Groups:   []string{"group1", "group2"},
-			},
-			nil,
+			token: tokenWithClaims(
+				map[string]any{"groups_direct": []string{"group1", "group2"}},
+				idtoken.Claims{},
+			),
+			expected: types.UserInfo{Groups: []string{"group1", "group2"}},
 		},
 		{
-			"default token with invalid groups claim",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.Validate.Groups = []string{"group"}
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"groups":             "group1",
-						"preferred_username": "username",
-					},
+			name: "UserInfo takes precedence and token fills missing fields",
+			conf: config.Defaults,
+			token: tokenWithClaims(
+				map[string]any{
+					"groups": []string{"token-group"},
+					"roles":  []string{"token-role"},
 				},
+				idtoken.Claims{
+					TokenClaims:       oidc.TokenClaims{Subject: "token-subject"},
+					PreferredUsername: "token-username",
+					EMail:             "token@example.com",
+				},
+			),
+			userInfo: &types.UserInfo{
+				Subject:  "userinfo-subject",
+				Username: "userinfo-username",
+				Groups:   []string{"userinfo-group"},
 			},
-			nil,
-			types.UserInfo{},
-			types.ErrInvalidClaimType,
+			expected: types.UserInfo{
+				Subject:  "userinfo-subject",
+				Email:    "token@example.com",
+				Username: "userinfo-username",
+				Groups:   []string{"userinfo-group"},
+				Roles:    []string{"token-role"},
+			},
 		},
 		{
-			"default token with nil groups claim",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.Validate.Groups = []string{"group"}
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"groups":             nil,
-						"preferred_username": "username",
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
+			name:  "UserInfo without ID token",
+			conf:  config.Defaults,
+			token: &idtoken.IDToken{},
+			userInfo: &types.UserInfo{
 				Subject:  "subject",
 				Username: "username",
 			},
-			nil,
-		},
-		{
-			"custom username expression",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						testsuite.SubjectClaim: testsuite.SubjectClaim,
-						"preferred_username":   "username",
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: testsuite.SubjectClaim,
-			},
-			nil,
-		},
-		{
-			"custom username expression with missing claim",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims.invalid"
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						testsuite.SubjectClaim: testsuite.SubjectClaim,
-						"preferred_username":   "username",
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: testsuite.SubjectClaim,
-			},
-			errors.New("failed to evaluate CEL expression for username"),
-		},
-		{
-			"custom username expression with invalid claim type",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims.groups"
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"groups":             []any{any("group1"), any("group2")},
-						"preferred_username": "username",
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: testsuite.SubjectClaim,
-			},
-			types.ErrInvalidClaimType,
-		},
-		{
-			"custom username CEL expression",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims.sub"
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						testsuite.SubjectClaim: "username",
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
+			expected: types.UserInfo{
 				Subject:  "subject",
 				Username: "username",
 			},
-			nil,
 		},
 		{
-			"custom username CEL expression with string",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "string(oauth2TokenClaims.groups[0])"
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"groups":             []any{any("group1"), any("group2")},
-						"preferred_username": "username",
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: "group1",
-			},
-			nil,
+			name: "invalid groups element",
+			conf: config.Defaults,
+			token: tokenWithClaims(
+				map[string]any{"groups": []any{"group1", 1}},
+				idtoken.Claims{},
+			),
+			err: types.ErrInvalidClaimType,
 		},
 		{
-			"invalid CEL expression",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "string(oauth2TokenClaims.groups[0]"
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{
-						Subject: "subject",
-					},
-					Claims: map[string]any{
-						"groups":             []any{any("group1"), any("group2")},
-						"preferred_username": "username",
-					},
-				},
-			},
-			nil,
-			types.UserInfo{
-				Subject:  "subject",
-				Username: "group1",
-			},
-			errors.New("failed to compile CEL expression"),
+			name: "invalid roles type",
+			conf: config.Defaults,
+			token: tokenWithClaims(
+				map[string]any{"roles": "role1"},
+				idtoken.Claims{},
+			),
+			err: types.ErrInvalidClaimType,
 		},
 		{
-			"empty username expression",
-			func() config.Config {
-				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = ""
-
-				return conf
-			}(),
-			&oidc.Tokens[*idtoken.Claims]{
-				IDTokenClaims: &idtoken.Claims{
-					TokenClaims: oidc.TokenClaims{},
-					Claims:      nil,
-				},
-			},
-			nil,
-			types.UserInfo{},
-			nil,
+			name:     "missing token",
+			conf:     config.Defaults,
+			token:    nil,
+			expected: types.UserInfo{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			provider, err := generic.NewProvider(t.Context(), &tc.conf, http.DefaultClient)
-			if err != nil && tc.err != nil {
-				require.ErrorContains(t, err, tc.err.Error())
+			require.NoError(t, err)
+
+			userData, err := provider.GetUser(t.Context(), slog.New(slog.DiscardHandler), tc.token, tc.userInfo)
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
 
 				return
 			}
 
 			require.NoError(t, err)
-
-			userData, err := provider.GetUser(t.Context(), slog.New(slog.DiscardHandler), tc.token, tc.userInfo)
-			if tc.err == nil {
-				require.NoError(t, err)
-				require.Equal(t, tc.userData, userData)
-			} else {
-				require.Error(t, err)
-				require.ErrorContains(t, err, tc.err.Error())
-			}
+			require.Equal(t, tc.expected, userData)
 		})
 	}
+}
+
+func tokenWithClaims(rawClaims map[string]any, claims idtoken.Claims) *idtoken.IDToken {
+	claims.Claims = rawClaims
+
+	return &idtoken.IDToken{IDTokenClaims: &claims}
 }

--- a/internal/oauth2/providers/github/check.go
+++ b/internal/oauth2/providers/github/check.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 )
 
 type orgType struct {
@@ -17,41 +15,6 @@ type orgType struct {
 type teamType struct {
 	Org  orgType `json:"organization"`
 	Slug string  `json:"slug"`
-}
-
-// CheckUser implements the [github.com/jkroepke/openvpn-auth-oauth2/internal/oauth2.Provider] interface.
-// It checks if it meets specific GitHub related conditions.
-func (p Provider) CheckUser(
-	ctx context.Context, sessionState state.State, userData types.UserInfo, tokens *idtoken.IDToken,
-) error {
-	if tokens.IDTokenClaims == nil {
-		//nolint:exhaustruct
-		tokens.IDTokenClaims = &idtoken.Claims{}
-	}
-
-	if tokens.IDTokenClaims.Claims == nil {
-		tokens.IDTokenClaims.Claims = make(map[string]any)
-	}
-
-	if len(p.Conf.OAuth2.Validate.Groups) > 0 {
-		organizations, err := p.getOrganizations(ctx, tokens)
-		if err != nil {
-			return fmt.Errorf("error getting GitHub organizations: %w", err)
-		}
-
-		userData.Groups = organizations
-	}
-
-	if p.Conf.OAuth2.Validate.Expression != "" {
-		teams, err := p.getTeams(ctx, tokens)
-		if err != nil {
-			return fmt.Errorf("error getting GitHub teams: %w", err)
-		}
-
-		tokens.IDTokenClaims.Claims["roles"] = teams
-	}
-
-	return p.Provider.CheckUser(ctx, sessionState, userData, tokens) //nolint:wrapcheck
 }
 
 // getTeams fetch the users GitHub teams by accessing the GitHub API.

--- a/internal/oauth2/providers/github/check_test.go
+++ b/internal/oauth2/providers/github/check_test.go
@@ -10,7 +10,6 @@ import (
 	oauth3 "github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/providers/github"
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testsuite"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +50,7 @@ func TestValidateGroups(t *testing.T) {
 			EmptyToken,
 			`ERROR`,
 			[]string{"apple"},
-			"error getting GitHub organizations: access token is empty",
+			"access token is empty",
 		},
 		{
 			"http status error",
@@ -107,13 +106,21 @@ func TestValidateGroups(t *testing.T) {
 			}
 
 			httpClient := &http.Client{
-				Transport: testsuite.NewRoundTripperFunc(nil, func(_ http.RoundTripper, _ *http.Request) (*http.Response, error) {
+				Transport: testsuite.NewRoundTripperFunc(nil, func(_ http.RoundTripper, req *http.Request) (*http.Response, error) {
 					resp := httptest.NewRecorder()
-					if strings.Contains(tc.userOrgs, "error") {
-						resp.WriteHeader(http.StatusInternalServerError)
-					}
 
-					_, _ = resp.WriteString(tc.userOrgs)
+					switch req.URL.Path {
+					case "/user":
+						_, _ = resp.WriteString(`{"login": "login", "email": "ID", "id": 10}`)
+					case "/user/orgs":
+						if strings.Contains(tc.userOrgs, "error") {
+							resp.WriteHeader(http.StatusInternalServerError)
+						}
+
+						_, _ = resp.WriteString(tc.userOrgs)
+					case "/user/teams":
+						_, _ = resp.WriteString(`[]`)
+					}
 
 					return resp.Result(), nil
 				}),
@@ -122,7 +129,10 @@ func TestValidateGroups(t *testing.T) {
 			provider, err := github.NewProvider(t.Context(), &conf, httpClient)
 			require.NoError(t, err)
 
-			err = provider.CheckUser(t.Context(), state.State{}, types.UserInfo{Email: "ID"}, token)
+			user, err := provider.GetUser(t.Context(), nil, token, nil)
+			if err == nil {
+				err = provider.CheckUser(t.Context(), state.State{}, user, token)
+			}
 
 			if tc.err == "" {
 				require.NoError(t, err)
@@ -134,7 +144,7 @@ func TestValidateGroups(t *testing.T) {
 	}
 }
 
-func TestCheckUserLoadsTeamsForCEL(t *testing.T) {
+func TestGetUserEnrichesTeams(t *testing.T) {
 	t.Parallel()
 
 	token := &idtoken.IDToken{
@@ -151,7 +161,7 @@ func TestCheckUserLoadsTeamsForCEL(t *testing.T) {
 	conf := types2.Config{
 		OAuth2: types2.OAuth2{
 			Validate: types2.OAuth2Validate{
-				Expression: "'apple:justice-league' in oauth2TokenClaims.roles",
+				Expression: "'apple:justice-league' in user.roles",
 			},
 		},
 	}
@@ -160,14 +170,19 @@ func TestCheckUserLoadsTeamsForCEL(t *testing.T) {
 
 	httpClient := &http.Client{
 		Transport: testsuite.NewRoundTripperFunc(testsuite.NewMockRoundTripper(nil), func(rt http.RoundTripper, req *http.Request) (*http.Response, error) {
-			if req.URL.Path != "/user/teams" {
+			resp := httptest.NewRecorder()
+
+			switch req.URL.Path {
+			case "/user":
+				_, _ = resp.WriteString(`{"login": "login", "email": "ID", "id": 10}`)
+			case "/user/orgs":
+				_, _ = resp.WriteString(`[]`)
+			case "/user/teams":
+				teamsCalled = true
+				_, _ = resp.WriteString(`[{ "slug": "justice-league", "organization": { "login": "apple" }}]`)
+			default:
 				return rt.RoundTrip(req)
 			}
-
-			teamsCalled = true
-
-			resp := httptest.NewRecorder()
-			_, _ = resp.WriteString(`[{ "slug": "justice-league", "organization": { "login": "apple" }}]`)
 
 			return resp.Result(), nil
 		}),
@@ -176,10 +191,11 @@ func TestCheckUserLoadsTeamsForCEL(t *testing.T) {
 	provider, err := github.NewProvider(t.Context(), &conf, httpClient)
 	require.NoError(t, err)
 
-	err = provider.CheckUser(t.Context(), state.State{}, types.UserInfo{Email: "ID"}, token)
+	user, err := provider.GetUser(t.Context(), nil, token, nil)
 	require.NoError(t, err)
 
 	assert.True(t, teamsCalled)
-	assert.Equal(t, []string{"apple:justice-league"}, token.IDTokenClaims.Claims["roles"])
+	assert.Equal(t, []string{"apple:justice-league"}, user.Roles)
+	assert.NotContains(t, token.IDTokenClaims.Claims, "roles")
 	assert.Equal(t, "test-user", token.IDTokenClaims.Claims["login"])
 }

--- a/internal/oauth2/providers/github/user.go
+++ b/internal/oauth2/providers/github/user.go
@@ -3,8 +3,10 @@ package github
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
@@ -32,9 +34,47 @@ func (p Provider) GetUser(ctx context.Context, _ *slog.Logger, tokens *idtoken.I
 		return types.UserInfo{}, err
 	}
 
-	return types.UserInfo{
+	userInfo := types.UserInfo{
 		Username: user.Login,
 		Email:    user.Email,
 		Subject:  strconv.Itoa(user.ID),
-	}, nil
+	}
+
+	if len(p.Conf.OAuth2.Validate.Groups) > 0 || p.usesUserField("groups") {
+		organizations, err := p.getOrganizations(ctx, tokens)
+		if err != nil {
+			return types.UserInfo{}, fmt.Errorf("error getting GitHub organizations: %w", err)
+		}
+
+		userInfo.Groups = organizations
+	}
+
+	if p.usesUserField("roles") {
+		teams, err := p.getTeams(ctx, tokens)
+		if err != nil {
+			return types.UserInfo{}, fmt.Errorf("error getting GitHub teams: %w", err)
+		}
+
+		userInfo.Roles = teams
+	}
+
+	return userInfo, nil
+}
+
+func (p Provider) usesUserField(field string) bool {
+	expressions := [...]string{
+		p.Conf.OAuth2.OpenVPNUsername,
+		p.Conf.OAuth2.Validate.Expression,
+		p.Conf.OpenVPN.ClientConfig.Expression,
+	}
+
+	for _, expression := range expressions {
+		if strings.Contains(expression, "user."+field) ||
+			strings.Contains(expression, `user["`+field+`"]`) ||
+			strings.Contains(expression, `user['`+field+`']`) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/oauth2/providers/github/user_test.go
+++ b/internal/oauth2/providers/github/user_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	types2 "github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
@@ -33,6 +34,8 @@ func TestGetUser(t *testing.T) {
 				Username: "login",
 				Email:    "email",
 				Subject:  "10",
+				Groups:   []string{"apple"},
+				Roles:    []string{"apple:justice-league"},
 			},
 			"",
 		},
@@ -72,19 +75,28 @@ func TestGetUser(t *testing.T) {
 			conf := types2.Config{
 				OAuth2: types2.OAuth2{
 					Validate: types2.OAuth2Validate{
-						Groups: make([]string, 0),
+						Groups:     make([]string, 0),
+						Expression: "'apple' in user.groups && 'apple:justice-league' in user.roles",
 					},
 				},
 			}
 
 			httpClient := &http.Client{
-				Transport: testsuite.NewRoundTripperFunc(nil, func(_ http.RoundTripper, _ *http.Request) (*http.Response, error) {
+				Transport: testsuite.NewRoundTripperFunc(nil, func(_ http.RoundTripper, req *http.Request) (*http.Response, error) {
 					resp := httptest.NewRecorder()
-					if strings.Contains(tc.user, "error") {
-						resp.WriteHeader(http.StatusInternalServerError)
-					}
 
-					_, _ = resp.WriteString(tc.user)
+					switch req.URL.Path {
+					case "/user":
+						if strings.Contains(tc.user, "error") {
+							resp.WriteHeader(http.StatusInternalServerError)
+						}
+
+						_, _ = resp.WriteString(tc.user)
+					case "/user/orgs":
+						_, _ = resp.WriteString(`[{ "login": "apple" }]`)
+					case "/user/teams":
+						_, _ = resp.WriteString(`[{ "slug": "justice-league", "organization": { "login": "apple" }}]`)
+					}
 
 					return resp.Result(), nil
 				}),
@@ -104,4 +116,38 @@ func TestGetUser(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetUserSkipsUnusedOrganizationAndTeamLookups(t *testing.T) {
+	t.Parallel()
+
+	token := &idtoken.IDToken{
+		Token: &oauth2.Token{AccessToken: "TOKEN"},
+	}
+	conf := types2.Config{
+		OAuth2: types2.OAuth2{OpenVPNUsername: "user.username"},
+	}
+
+	var requests atomic.Int32
+
+	httpClient := &http.Client{
+		Transport: testsuite.NewRoundTripperFunc(nil, func(_ http.RoundTripper, req *http.Request) (*http.Response, error) {
+			requests.Add(1)
+			require.Equal(t, "/user", req.URL.Path)
+
+			resp := httptest.NewRecorder()
+			_, _ = resp.WriteString(`{"login": "login", "email": "email", "id": 10}`)
+
+			return resp.Result(), nil
+		}),
+	}
+
+	provider, err := github.NewProvider(t.Context(), &conf, httpClient)
+	require.NoError(t, err)
+
+	user, err := provider.GetUser(t.Context(), nil, token, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, "login", user.Username)
+	require.EqualValues(t, 1, requests.Load())
 }

--- a/internal/oauth2/providers/google/check.go
+++ b/internal/oauth2/providers/google/check.go
@@ -6,24 +6,7 @@ import (
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 )
-
-// CheckUser resolves Google group membership when configured and then runs generic user validation.
-func (p Provider) CheckUser(
-	ctx context.Context,
-	session state.State,
-	userData types.UserInfo,
-	tokens *idtoken.IDToken,
-) error {
-	if len(p.Conf.OAuth2.Validate.Groups) > 0 {
-		if err := p.resolveGroupMemberships(ctx, &userData, tokens); err != nil {
-			return err
-		}
-	}
-
-	return p.Provider.CheckUser(ctx, session, userData, tokens) //nolint:wrapcheck
-}
 
 // resolveGroupMemberships replaces userData.Groups with the configured required
 // groups that the user is a member of. Do not stop after the first match:

--- a/internal/oauth2/providers/google/check_test.go
+++ b/internal/oauth2/providers/google/check_test.go
@@ -2,6 +2,7 @@ package google_test
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -145,7 +146,15 @@ func TestValidateGroups(t *testing.T) {
 			provider, err := google.NewProvider(t.Context(), &conf, httpClient)
 			require.NoError(t, err)
 
-			err = provider.CheckUser(t.Context(), state.State{}, types.UserInfo{Subject: "123456789101112131415"}, token)
+			user, err := provider.GetUser(
+				t.Context(),
+				slog.New(slog.DiscardHandler),
+				token,
+				&types.UserInfo{Subject: "123456789101112131415"},
+			)
+			if err == nil {
+				err = provider.CheckUser(t.Context(), state.State{}, user, token)
+			}
 
 			if tc.err == "" {
 				require.NoError(t, err)
@@ -225,12 +234,15 @@ func TestValidateGroupsChecksAllConfiguredGroupsAfterFirstMatch(t *testing.T) {
 			provider, err := google.NewProvider(t.Context(), &conf, httpClient)
 			require.NoError(t, err)
 
-			err = provider.CheckUser(
+			user, err := provider.GetUser(
 				t.Context(),
-				state.State{},
-				types.UserInfo{Subject: "123456789101112131415", Email: "user@example.com"},
+				slog.New(slog.DiscardHandler),
 				token,
+				&types.UserInfo{Subject: "123456789101112131415", Email: "user@example.com"},
 			)
+			if err == nil {
+				err = provider.CheckUser(t.Context(), state.State{}, user, token)
+			}
 
 			require.NoError(t, err)
 			assert.EqualValues(t, 2, requests.Load())
@@ -362,12 +374,15 @@ func TestValidateGroupsTransitive(t *testing.T) {
 			provider, err := google.NewProvider(t.Context(), &conf, httpClient)
 			require.NoError(t, err)
 
-			err = provider.CheckUser(
+			user, err := provider.GetUser(
 				t.Context(),
-				state.State{},
-				types.UserInfo{Subject: "123456789101112131415", Email: tc.email},
+				slog.New(slog.DiscardHandler),
 				token,
+				&types.UserInfo{Subject: "123456789101112131415", Email: tc.email},
 			)
+			if err == nil {
+				err = provider.CheckUser(t.Context(), state.State{}, user, token)
+			}
 
 			switch {
 			case tc.errContains != "":

--- a/internal/oauth2/providers/google/user.go
+++ b/internal/oauth2/providers/google/user.go
@@ -8,7 +8,18 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 )
 
-// GetUser delegates user resolution to the embedded generic provider.
+// GetUser normalizes Google user data and resolves configured group memberships.
 func (p Provider) GetUser(ctx context.Context, logger *slog.Logger, tokens *idtoken.IDToken, userInfo *types.UserInfo) (types.UserInfo, error) {
-	return p.Provider.GetUser(ctx, logger, tokens, userInfo) //nolint:wrapcheck
+	user, err := p.Provider.GetUser(ctx, logger, tokens, userInfo)
+	if err != nil {
+		return types.UserInfo{}, err //nolint:wrapcheck
+	}
+
+	if len(p.Conf.OAuth2.Validate.Groups) > 0 {
+		if err = p.resolveGroupMemberships(ctx, &user, tokens); err != nil {
+			return types.UserInfo{}, err
+		}
+	}
+
+	return user, nil
 }

--- a/internal/oauth2/refresh.go
+++ b/internal/oauth2/refresh.go
@@ -238,7 +238,7 @@ func (c *Client) validateRefreshedUser(
 		return types.UserInfo{}, err
 	}
 
-	user, err := c.provider.GetUser(ctx, logger, tokens, userInfo)
+	user, err := c.resolveUser(ctx, logger, CELAuthModeNonInteractive, oAuth2State, tokens, userInfo)
 	if err != nil {
 		return types.UserInfo{}, fmt.Errorf("error fetch user data: %w", err)
 	}
@@ -247,7 +247,7 @@ func (c *Client) validateRefreshedUser(
 		return types.UserInfo{}, fmt.Errorf("error check user data: %w", err)
 	}
 
-	if err = c.CheckTokenCEL(CELAuthModeNonInteractive, oAuth2State, tokens); err != nil {
+	if err = c.CheckIdentityCEL(CELAuthModeNonInteractive, oAuth2State, tokens, user); err != nil {
 		return types.UserInfo{}, fmt.Errorf("error cel validation: %w", err)
 	}
 

--- a/internal/oauth2/refresh_test.go
+++ b/internal/oauth2/refresh_test.go
@@ -107,7 +107,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OAuth2.Refresh.Enabled = true
 				conf.OAuth2.Refresh.ValidateUser = true
 				conf.OAuth2.Refresh.UseSessionID = false
@@ -122,7 +122,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.ReAuthentication = false
 
 				return conf
@@ -151,7 +151,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.AuthTokenUser = true
 				conf.OpenVPN.OverrideUsername = true
 				conf.OAuth2.Refresh.Enabled = true
@@ -168,7 +168,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OAuth2.Refresh.Enabled = true
 				conf.OAuth2.Refresh.ValidateUser = false
 				conf.OAuth2.Refresh.UseSessionID = false
@@ -183,7 +183,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OAuth2.Refresh.Enabled = true
 				conf.OAuth2.Refresh.ValidateUser = false
 				conf.OAuth2.Refresh.UseSessionID = false
@@ -203,7 +203,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OAuth2.Validate.Groups = []string{"group1"}
 				conf.OAuth2.UserInfo = true
 				conf.OAuth2.Refresh.Enabled = true
@@ -218,7 +218,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.AuthTokenUser = false
 				conf.OAuth2.Refresh.Enabled = true
 				conf.OAuth2.Refresh.ValidateUser = false
@@ -234,7 +234,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.AuthTokenUser = false
 				conf.OAuth2.Refresh.Enabled = true
 				conf.OAuth2.Refresh.ValidateUser = true
@@ -250,7 +250,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.AuthTokenUser = false
 				conf.OAuth2.Provider = google.Name
 				conf.OAuth2.Scopes = []string{types.ScopeEmail, types.ScopeProfile, types.ScopeOpenID, types.ScopeOfflineAccess}
@@ -268,7 +268,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "user.username"
 				conf.OpenVPN.AuthTokenUser = false
 				conf.OAuth2.Provider = github.Name
 				conf.OAuth2.Refresh.Enabled = true
@@ -285,7 +285,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: false,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OAuth2.Refresh.Enabled = true
 				conf.OAuth2.Refresh.ValidateUser = true
 				conf.OAuth2.Refresh.UseSessionID = false
@@ -311,7 +311,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: false,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "user.username"
 				conf.OpenVPN.AuthTokenUser = false
 				conf.OAuth2.Provider = generic.Name
 				conf.OAuth2.Refresh.Enabled = true
@@ -349,7 +349,7 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: true,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "user.username"
 				conf.OpenVPN.AuthTokenUser = false
 				conf.OAuth2.Provider = generic.Name
 				conf.OAuth2.Refresh.Enabled = true
@@ -410,13 +410,13 @@ func TestRefreshReAuth(t *testing.T) {
 			nonInteractiveShouldWork: false,
 			conf: func() config.Config {
 				conf := config.Defaults
-				conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+				conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 				conf.OpenVPN.AuthTokenUser = false
 				conf.OAuth2.Provider = generic.Name
 				conf.OAuth2.Refresh.Enabled = true
 				conf.OAuth2.Refresh.ValidateUser = true
 				conf.OAuth2.Refresh.UseSessionID = false
-				conf.OAuth2.Validate.Expression = "authMode == 'interactive'"
+				conf.OAuth2.Validate.Expression = "auth.mode == 'interactive'"
 
 				return conf
 			}(),
@@ -480,7 +480,7 @@ func TestRefreshReAuth(t *testing.T) {
 				case tc.clientCommonName == "":
 					suite.ExpectMessage(t, `override-username "username"`)
 				case tc.conf.OAuth2.UserInfo:
-					suite.ExpectMessage(t, `override-username "test-user@localhost"`)
+					suite.ExpectMessage(t, `override-username "id1"`)
 				default:
 					suite.ExpectMessage(t, `override-username "id1"`)
 				}
@@ -493,7 +493,7 @@ func TestRefreshReAuth(t *testing.T) {
 				case tc.clientCommonName == "":
 					suite.ExpectMessage(t, `push "auth-token-user dXNlcm5hbWU="`)
 				case tc.conf.OAuth2.UserInfo:
-					suite.ExpectMessage(t, `push "auth-token-user dGVzdC11c2VyQGxvY2FsaG9zdA=="`)
+					suite.ExpectMessage(t, `push "auth-token-user aWQx"`)
 				default:
 					suite.ExpectMessage(t, `push "auth-token-user aWQx"`)
 				}
@@ -550,7 +550,7 @@ func TestRefreshReAuth(t *testing.T) {
 				case tc.clientCommonName == "":
 					suite.ExpectMessage(t, `override-username "username"`)
 				case tc.conf.OAuth2.UserInfo:
-					suite.ExpectMessage(t, `override-username "test-user@localhost"`)
+					suite.ExpectMessage(t, `override-username "id1"`)
 				default:
 					suite.ExpectMessage(t, `override-username "id1"`)
 				}
@@ -563,7 +563,7 @@ func TestRefreshReAuth(t *testing.T) {
 				case tc.clientCommonName == "":
 					suite.ExpectMessage(t, `push "auth-token-user dXNlcm5hbWU="`)
 				case tc.conf.OAuth2.UserInfo:
-					suite.ExpectMessage(t, `push "auth-token-user dGVzdC11c2VyQGxvY2FsaG9zdA=="`)
+					suite.ExpectMessage(t, `push "auth-token-user aWQx"`)
 				default:
 					suite.ExpectMessage(t, `push "auth-token-user aWQx"`)
 				}
@@ -594,7 +594,7 @@ func TestRefreshReAuth(t *testing.T) {
 				case tc.clientCommonName == "":
 					suite.ExpectMessage(t, `override-username "username"`)
 				case tc.conf.OAuth2.UserInfo:
-					suite.ExpectMessage(t, `override-username "test-user@localhost"`)
+					suite.ExpectMessage(t, `override-username "id1"`)
 				default:
 					suite.ExpectMessage(t, `override-username "id1"`)
 				}
@@ -607,7 +607,7 @@ func TestRefreshReAuth(t *testing.T) {
 				case tc.clientCommonName == "":
 					suite.ExpectMessage(t, `push "auth-token-user dXNlcm5hbWU="`)
 				case tc.conf.OAuth2.UserInfo:
-					suite.ExpectMessage(t, `push "auth-token-user dGVzdC11c2VyQGxvY2FsaG9zdA=="`)
+					suite.ExpectMessage(t, `push "auth-token-user aWQx"`)
 				default:
 					suite.ExpectMessage(t, `push "auth-token-user aWQx"`)
 				}
@@ -636,7 +636,7 @@ func TestRefreshReAuth(t *testing.T) {
 					case tc.clientCommonName == "":
 						suite.ExpectMessage(t, `push "auth-token-user dXNlcm5hbWU="`)
 					case tc.conf.OAuth2.UserInfo:
-						suite.ExpectMessage(t, `push "auth-token-user dGVzdC11c2VyQGxvY2FsaG9zdA=="`)
+						suite.ExpectMessage(t, `push "auth-token-user aWQx"`)
 					default:
 						suite.ExpectMessage(t, `push "auth-token-user aWQx"`)
 					}

--- a/internal/oauth2/types.go
+++ b/internal/oauth2/types.go
@@ -15,16 +15,17 @@ import (
 )
 
 type Client struct {
-	relyingParty    rp.RelyingParty
-	openvpn         openvpnManagementClient
-	storage         tokenstorage.Storage
-	provider        Provider
-	celEvalPrg      cel.Program
-	configsCELPrg   cel.Program
-	logger          *slog.Logger
-	stateCrypto     *crypto.Cipher
-	conf            *types2.Config
-	authorizeParams []rp.URLParamOpt
+	relyingParty     rp.RelyingParty
+	openvpn          openvpnManagementClient
+	storage          tokenstorage.Storage
+	provider         Provider
+	validationCELPrg cel.Program
+	usernameCELPrg   cel.Program
+	configsCELPrg    cel.Program
+	logger           *slog.Logger
+	stateCrypto      *crypto.Cipher
+	conf             *types2.Config
+	authorizeParams  []rp.URLParamOpt
 }
 
 type Provider interface {

--- a/internal/oauth2/types/authmode.go
+++ b/internal/oauth2/types/authmode.go
@@ -1,0 +1,11 @@
+package types
+
+// AuthMode identifies the stage that evaluates a CEL expression.
+type AuthMode string
+
+const (
+	// AuthModeInteractive identifies the initial browser-based authentication.
+	AuthModeInteractive AuthMode = "interactive"
+	// AuthModeNonInteractive identifies refresh-token authentication.
+	AuthModeNonInteractive AuthMode = "non-interactive"
+)

--- a/internal/oauth2/types/userdata.go
+++ b/internal/oauth2/types/userdata.go
@@ -9,6 +9,7 @@ type UserInfo struct {
 	Email    string   `json:"email"`
 	Username string   `json:"preferred_username"` //nolint:tagliatelle // preferred_username is the standard claim for the username.
 	Groups   []string `json:"groups"`
+	Roles    []string `json:"roles"`
 }
 
 // GetSubject returns the subject identifier from the UserInfo response.

--- a/internal/oauth2/username_test.go
+++ b/internal/oauth2/username_test.go
@@ -1,0 +1,152 @@
+//nolint:testpackage
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveUsername(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		expression string
+		authMode   CELAuthMode
+		token      *idtoken.IDToken
+		user       types.UserInfo
+		expected   string
+		err        string
+	}{
+		{
+			name:       "normalized provider username",
+			expression: "user.username",
+			authMode:   CELAuthModeInteractive,
+			user:       types.UserInfo{Username: "provider-user"},
+			expected:   "provider-user",
+		},
+		{
+			name:       "UserInfo email",
+			expression: `user.email.split("@")[0]`,
+			authMode:   CELAuthModeInteractive,
+			user:       types.UserInfo{Email: "alice@example.com"},
+			expected:   "alice",
+		},
+		{
+			name:       "token claim",
+			expression: "string(token.claims.sub)",
+			authMode:   CELAuthModeInteractive,
+			token: &idtoken.IDToken{
+				IDTokenClaims: &idtoken.Claims{Claims: map[string]any{"sub": "token-user"}},
+			},
+			expected: "token-user",
+		},
+		{
+			name:       "shared authentication and OpenVPN context",
+			expression: `auth.mode + "-" + openvpn.commonName`,
+			authMode:   CELAuthModeNonInteractive,
+			expected:   "non-interactive-client-cn",
+		},
+		{
+			name:       "normalized provider role",
+			expression: "user.roles[0]",
+			authMode:   CELAuthModeInteractive,
+			user:       types.UserInfo{Roles: []string{"provider-role"}},
+			expected:   "provider-role",
+		},
+		{
+			name:       "empty result falls back to common name",
+			expression: `""`,
+			authMode:   CELAuthModeInteractive,
+			expected:   "client-cn",
+		},
+		{
+			name:       "invalid result type",
+			expression: "user.groups",
+			authMode:   CELAuthModeInteractive,
+			user:       types.UserInfo{Groups: []string{"group"}},
+			err:        "did not evaluate to a string",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			conf := config.Defaults
+			conf.OAuth2.OpenVPNUsername = tc.expression
+			client := Client{conf: &conf}
+
+			require.NoError(t, client.initializeUsernameResolver())
+
+			username, err := client.resolveUsername(
+				tc.authMode,
+				state.State{Client: state.ClientIdentifier{CommonName: "client-cn"}},
+				tc.token,
+				tc.user,
+			)
+			if tc.err != "" {
+				require.ErrorContains(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, username)
+		})
+	}
+}
+
+func TestResolveUsernameWithoutExpressionUsesCommonName(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Defaults
+	conf.OAuth2.OpenVPNUsername = ""
+	client := Client{conf: &conf}
+
+	require.NoError(t, client.initializeUsernameResolver())
+
+	username, err := client.resolveUsername(
+		CELAuthModeInteractive,
+		state.State{Client: state.ClientIdentifier{CommonName: "client-cn"}},
+		nil,
+		types.UserInfo{Username: "provider-user"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "client-cn", username)
+}
+
+func TestInitializeUsernameResolverRejectsInvalidExpressions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		expression string
+		err        string
+	}{
+		{
+			name:       "invalid syntax",
+			expression: "string(token.claims.sub",
+			err:        "failed to compile CEL expression",
+		},
+		{
+			name:       "boolean result",
+			expression: "true",
+			err:        "cel expression must evaluate to string, got bool",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			conf := config.Defaults
+			conf.OAuth2.OpenVPNUsername = tc.expression
+			client := Client{conf: &conf}
+
+			require.ErrorContains(t, client.initializeUsernameResolver(), tc.err)
+		})
+	}
+}

--- a/internal/openvpn/client.go
+++ b/internal/openvpn/client.go
@@ -126,7 +126,17 @@ func (c *Client) acceptSilentlyReAuthenticatedClient(
 	if tokens != nil && len(clientConfigNames) == 0 {
 		var err error
 
-		clientConfigNames, err = c.oauth2.ResolveClientConfigNames(tokens, client.CommonName, user.Username)
+		clientConfigNames, err = c.oauth2.ResolveClientConfigNames(
+			types.AuthModeNonInteractive,
+			state.State{
+				Client:       stateClientIdentifier(client),
+				IPAddr:       client.IPAddr,
+				IPPort:       client.IPPort,
+				SessionState: client.SessionState,
+			},
+			tokens,
+			user,
+		)
 		if err != nil {
 			logger.LogAttrs(ctx, slog.LevelWarn, "failed to resolve client config", slog.Any("err", err))
 			c.DenyClient(ctx, logger, stateClientIdentifier(client), "invalid client config")

--- a/internal/openvpn/client_refresh_test.go
+++ b/internal/openvpn/client_refresh_test.go
@@ -277,8 +277,10 @@ func (c *blockingRefreshOAuth2Client) RefreshClientAuth(
 }
 
 func (c *blockingRefreshOAuth2Client) ResolveClientConfigNames(
+	_ oauth2types.AuthMode,
+	_ state.State,
 	_ *idtoken.IDToken,
-	_, _ string,
+	_ oauth2types.UserInfo,
 ) ([]string, error) {
 	return nil, nil
 }
@@ -311,8 +313,10 @@ func (c *storedProfileOAuth2Client) RefreshClientAuth(
 }
 
 func (c *storedProfileOAuth2Client) ResolveClientConfigNames(
+	_ oauth2types.AuthMode,
+	_ state.State,
 	_ *idtoken.IDToken,
-	_, _ string,
+	_ oauth2types.UserInfo,
 ) ([]string, error) {
 	c.resolveCalls.Add(1)
 

--- a/internal/openvpn/types.go
+++ b/internal/openvpn/types.go
@@ -42,7 +42,12 @@ type Client struct {
 
 type oauth2Client interface {
 	RefreshClientAuth(ctx context.Context, logger *slog.Logger, client connection.Client) (types.UserInfo, *idtoken.IDToken, []string, bool, error)
-	ResolveClientConfigNames(tokens *idtoken.IDToken, openVPNUserCommonName, username string) ([]string, error)
+	ResolveClientConfigNames(
+		authMode types.AuthMode,
+		session state.State,
+		tokens *idtoken.IDToken,
+		user types.UserInfo,
+	) ([]string, error)
 	ClientDisconnect(ctx context.Context, logger *slog.Logger, client connection.Client)
 	EncryptState(oidcState state.State) (state.EncryptedState, error)
 }

--- a/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go
+++ b/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go
@@ -126,7 +126,7 @@ func TestPlugin(t *testing.T) {
 
 			tc.conf.OpenVPN.Addr = types.URL{URL: &url.URL{Scheme: "unix", Path: unixSocket}}
 			tc.conf.OpenVPN.Password = "password"
-			tc.conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+			tc.conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 			suite := testsuite.New(&tc.conf)
 			suite.SetupOIDCServer(t, clientListener, nil)
@@ -336,7 +336,7 @@ func TestPluginDenyNonWebAuthClient(t *testing.T) {
 	conf := config.Defaults
 	conf.OpenVPN.Addr = types.URL{URL: &url.URL{Scheme: "unix", Path: unixSocket}}
 	conf.OpenVPN.Password = "password"
-	conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+	conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 
 	suite := testsuite.New(&conf)
 	suite.SetupOIDCServer(t, clientListener, nil)

--- a/lib/openvpn-auth-oauth2/plugin_it_test.go
+++ b/lib/openvpn-auth-oauth2/plugin_it_test.go
@@ -241,7 +241,7 @@ func TestIT(t *testing.T) {
 	require.NoError(t, err)
 
 	conf := config.Defaults
-	conf.OAuth2.OpenVPNUsername = "oauth2TokenClaims." + testsuite.SubjectClaim
+	conf.OAuth2.OpenVPNUsername = "token.claims." + testsuite.SubjectClaim
 	conf.OpenVPN.Addr = types.URL{URL: &url.URL{Scheme: "tcp", Host: strings.TrimPrefix(pluginManagementEndpoint, "tcp://")}}
 	conf.OpenVPN.Password = testsuite.Password
 

--- a/packaging/etc/openvpn-auth-oauth2/config.yaml
+++ b/packaging/etc/openvpn-auth-oauth2/config.yaml
@@ -39,7 +39,7 @@
 #    groups: []
 #    #  - "test"
 #    #  - "test2"
-#    expression: "openVPNUserCommonName == oauth2TokenClaims.preferred_username"  # CEL expression for custom validation
+#    expression: "openvpn.commonName == user.username"  # CEL expression for custom validation
 #  nonce: true
 #  refresh-nonce: "auto"  # Options: auto (try with nonce, retry without on error), empty (always use empty nonce for refresh), equal (use same nonce as initial auth)
 #  pkce: true


### PR DESCRIPTION
## Summary

- define one shared, namespaced CEL context for username resolution, identity validation, and client config resolution: `auth`, `openvpn`, `token`, and normalized `user` ([implementation](https://github.com/jkroepke/openvpn-auth-oauth2/blob/agent/normalize-cel-identity/internal/oauth2/cel.go#L21-L217))
- normalize provider and UserInfo data before resolving the final username, then use that same identity for provider checks, CEL validation, client config, interactive login, and refresh ([flow](https://github.com/jkroepke/openvpn-auth-oauth2/blob/agent/normalize-cel-identity/internal/oauth2/handler.go#L381-L468))
- merge generic OIDC/UserInfo fields and normalize groups and roles; expose GitHub organizations/teams and Google group memberships through the same user model ([generic normalization](https://github.com/jkroepke/openvpn-auth-oauth2/blob/agent/normalize-cel-identity/internal/oauth2/providers/generic/user.go#L12-L90))
- update defaults, packaged examples, tests, and end-user documentation for the shared contract ([CEL reference](https://github.com/jkroepke/openvpn-auth-oauth2/blob/agent/normalize-cel-identity/docs/CEL%20Language%20Features.md#L23-L58))

## Why

Username CEL was owned by the generic provider. GitHub did not apply it, UserInfo could bypass it, and refresh behavior could differ from interactive authentication. Validation and client config also exposed different variables and ran at different stages. Centralizing normalization and CEL evaluation gives every provider and authentication path the same identity contract.

## Breaking changes

CEL fields are namespaced: `authMode` → `auth.mode`, `openVPNSessionState` → `openvpn.sessionState`, `openVPNUserCommonName` → `openvpn.commonName`, `openVPNUserIPAddr` → `openvpn.ip`, `oauth2TokenIPAddr` → `token.ip`, `oauth2TokenClaims` → `token.claims`, and client-config `username` → `user.username`.

The default `oauth2.openvpn-username` expression is now `user.username`. GitHub organizations are exposed as `user.groups`, and teams as `user.roles`, instead of mutating raw token claims. The complete migration guide and examples are in [Upgrade V2](https://github.com/jkroepke/openvpn-auth-oauth2/blob/agent/normalize-cel-identity/docs/Upgrade%20V2.md#L72-L139).

## Testing

- `make fmt`
- `make lint`
- `make test`
- `textlint --rule terminology` on all changed end-user Markdown files
