### PR TITLE
feat!: replace the generic `CONFIG_` environment prefix with `OPENVPN_AUTH_OAUTH2_`

### DIFF
--- a/docs/Article - How OIDC SSO Authentication works with OpenVPN Community Server.md
+++ b/docs/Article - How OIDC SSO Authentication works with OpenVPN Community Server.md
@@ -57,7 +57,7 @@ You need to configure the `openvpn-auth-oauth2` plugin to validate group claims.
 In your `openvpn-auth-oauth2` configuration file, add the following lines:
 
 ```ini
-CONFIG_OAUTH2_VALIDATE_GROUPS=group1,group2
+OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_GROUPS=group1,group2
 ```
 
 Replace `group1,group2` with a comma-separated list of the groups that should have access to the VPN.
@@ -71,7 +71,7 @@ In the context of `openvpn-auth-oauth2`, the `acr` claim can be used to enforce 
 To configure `acr` validation, set a CEL validation expression in your `openvpn-auth-oauth2` configuration file. Here's an example:
 
 ```ini
-CONFIG_OAUTH2_VALIDATE_EXPRESSION="token.claims.acr == 'phr'"
+OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_EXPRESSION="token.claims.acr == 'phr'"
 ```
 
 In this example, `phr` is the `acr` value that represents a specific authentication method. `phr` stands for Phishing Resistant. It's a term used in the context of multi-factor authentication (MFA). Phishing-resistant mechanisms are designed to resist phishing and other fraudulent attempts to steal user credentials. This could be a hardware device that requires a user to physically interact with it, or a biometric authentication method. When used in the `acr` (Authentication Context Class Reference) in OpenID Connect, it indicates that the authentication process should involve a phishing-resistant method.

--- a/docs/Client token validation.md
+++ b/docs/Client token validation.md
@@ -28,7 +28,7 @@ oauth2:
 ### Environment Variable
 
 ```bash
-CONFIG_OAUTH2_VALIDATE_EXPRESSION='openvpn.commonName == user.username'
+OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_EXPRESSION='openvpn.commonName == user.username'
 ```
 
 > [!IMPORTANT]

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -8,7 +8,9 @@ Take a look at the [FAQ](./FAQ) section, for common questions, issues and soluti
 
 ## Configuration file
 
-openvpn-auth-oauth2 supports configuration via a YAML file. The file can be passed via the `--config` flag.
+openvpn-auth-oauth2 supports configuration via a YAML file. Pass the file with
+the `--config` flag or the `OPENVPN_AUTH_OAUTH2_CONFIG_FILE` environment
+variable.
 
 See the [example configuration file](https://github.com/jkroepke/openvpn-auth-oauth2/blob/main/packaging/etc/openvpn-auth-oauth2/config.yaml).
 
@@ -21,135 +23,135 @@ Documentation available at https://github.com/jkroepke/openvpn-auth-oauth2/wiki
 Usage of openvpn-auth-oauth2:
 
   --config string
-    	path to one .yaml config file (env: CONFIG_CONFIG)
+        path to one .yaml config file (env: OPENVPN_AUTH_OAUTH2_CONFIG_FILE)
   --debug.listen string
-    	listen address for go profiling endpoint (env: CONFIG_DEBUG_LISTEN) (default "127.0.0.1:9001")
+        listen address for go profiling endpoint (env: OPENVPN_AUTH_OAUTH2_DEBUG_LISTEN) (default "127.0.0.1:9001")
   --debug.pprof
-    	Enables go profiling endpoint. This should be never exposed. (env: CONFIG_DEBUG_PPROF)
+        Enables go profiling endpoint. This should be never exposed. (env: OPENVPN_AUTH_OAUTH2_DEBUG_PPROF)
   --http.assets-path value
-    	Custom path to the assets directory. Files in this directory will be served under /assets/ and having an higher priority than the embedded assets. (env: CONFIG_HTTP_ASSETS__PATH)
+        Custom path to the assets directory. Files in this directory will be served under /assets/ and having an higher priority than the embedded assets. (env: OPENVPN_AUTH_OAUTH2_HTTP_ASSETS__PATH)
   --http.baseurl value
-    	listen addr for client listener (env: CONFIG_HTTP_BASEURL) (default http://localhost:9000)
+        listen addr for client listener (env: OPENVPN_AUTH_OAUTH2_HTTP_BASEURL) (default http://localhost:9000)
   --http.cert string
-    	Path to tls server certificate used for TLS listener. (env: CONFIG_HTTP_CERT)
+        Path to tls server certificate used for TLS listener. (env: OPENVPN_AUTH_OAUTH2_HTTP_CERT)
   --http.check.ipaddr
-    	Check if client IP in http and VPN is equal (env: CONFIG_HTTP_CHECK_IPADDR)
+        Check if client IP in http and VPN is equal (env: OPENVPN_AUTH_OAUTH2_HTTP_CHECK_IPADDR)
   --http.enable-proxy-headers
-    	Use X-Forwarded-For http header for client ips (env: CONFIG_HTTP_ENABLE__PROXY__HEADERS)
+        Use X-Forwarded-For http header for client ips (env: OPENVPN_AUTH_OAUTH2_HTTP_ENABLE__PROXY__HEADERS)
   --http.trusted-proxies value
-    	Trusted reverse proxy CIDRs allowed to set X-Forwarded-For. Multiple values can be provided as a comma-separated list. (env: CONFIG_HTTP_TRUSTED__PROXIES)
+        Trusted reverse proxy CIDRs allowed to set X-Forwarded-For. Multiple values can be provided as a comma-separated list. (env: OPENVPN_AUTH_OAUTH2_HTTP_TRUSTED__PROXIES)
   --http.key string
-    	Path to tls server key used for TLS listener. (env: CONFIG_HTTP_KEY)
+        Path to tls server key used for TLS listener. (env: OPENVPN_AUTH_OAUTH2_HTTP_KEY)
   --http.listen string
-    	listen addr for client listener (env: CONFIG_HTTP_LISTEN) (default ":9000")
+        listen addr for client listener (env: OPENVPN_AUTH_OAUTH2_HTTP_LISTEN) (default ":9000")
   --http.secret value
-    	Random generated secret for cookie encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file. (env: CONFIG_HTTP_SECRET)
+        Random generated secret for cookie encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file. (env: OPENVPN_AUTH_OAUTH2_HTTP_SECRET)
   --http.short-url
-    	Enable short URL. The URL which is used for initial authentication will be reduced to /?s=... instead of /oauth2/start?state=... (env: CONFIG_HTTP_SHORT__URL)
+        Enable short URL. The URL which is used for initial authentication will be reduced to /?s=... instead of /oauth2/start?state=... (env: OPENVPN_AUTH_OAUTH2_HTTP_SHORT__URL)
   --http.template value
-    	Path to a HTML file which is displayed at the end of the screen. See https://github.com/jkroepke/openvpn-auth-oauth2/wiki/Layout-Customization for more information. (env: CONFIG_HTTP_TEMPLATE)
+        Path to a HTML file which is displayed at the end of the screen. See https://github.com/jkroepke/openvpn-auth-oauth2/wiki/Layout-Customization for more information. (env: OPENVPN_AUTH_OAUTH2_HTTP_TEMPLATE)
   --http.tls
-    	enable TLS listener (env: CONFIG_HTTP_TLS)
+        enable TLS listener (env: OPENVPN_AUTH_OAUTH2_HTTP_TLS)
   --log.format string
-    	log format. json or console (env: CONFIG_LOG_FORMAT) (default "console")
+        log format. json or console (env: OPENVPN_AUTH_OAUTH2_LOG_FORMAT) (default "console")
   --log.level value
-    	log level. Can be one of: debug, info, warn, error (env: CONFIG_LOG_LEVEL) (default INFO)
+        log level. Can be one of: debug, info, warn, error (env: OPENVPN_AUTH_OAUTH2_LOG_LEVEL) (default INFO)
   --log.vpn-client-ip
-    	log IP of VPN client. Useful to have an identifier between OpenVPN and openvpn-auth-oauth2. (env: CONFIG_LOG_VPN__CLIENT__IP) (default true)
+        log IP of VPN client. Useful to have an identifier between OpenVPN and openvpn-auth-oauth2. (env: OPENVPN_AUTH_OAUTH2_LOG_VPN__CLIENT__IP) (default true)
   --oauth2.auth-style value
-    	Auth style represents how requests for tokens are authenticated to the server. Possible values: AuthStyleAutoDetect, AuthStyleInParams, AuthStyleInHeader. See https://pkg.go.dev/golang.org/x/oauth2#AuthStyle (env: CONFIG_OAUTH2_AUTH__STYLE) (default AuthStyleInParams)
+        Auth style represents how requests for tokens are authenticated to the server. Possible values: AuthStyleAutoDetect, AuthStyleInParams, AuthStyleInHeader. See https://pkg.go.dev/golang.org/x/oauth2#AuthStyle (env: OPENVPN_AUTH_OAUTH2_OAUTH2_AUTH__STYLE) (default AuthStyleInParams)
   --oauth2.authorize-params string
-    	additional url query parameter to authorize endpoint (env: CONFIG_OAUTH2_AUTHORIZE__PARAMS)
+        additional url query parameter to authorize endpoint (env: OPENVPN_AUTH_OAUTH2_OAUTH2_AUTHORIZE__PARAMS)
   --oauth2.client.id string
-    	oauth2 client id (env: CONFIG_OAUTH2_CLIENT_ID)
+        oauth2 client id (env: OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID)
   --oauth2.client.private-key value
-    	oauth2 client private key. Secure alternative to oauth2.client.secret. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OAUTH2_CLIENT_PRIVATE__KEY)
+        oauth2 client private key. Secure alternative to oauth2.client.secret. If argument starts with file:// it reads the secret from a file. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_PRIVATE__KEY)
   --oauth2.client.private-key-id string
-    	oauth2 client private key id. If specified, JWT assertions will be generated with the specific kid header. (env: CONFIG_OAUTH2_CLIENT_PRIVATE__KEY__ID)
+        oauth2 client private key id. If specified, JWT assertions will be generated with the specific kid header. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_PRIVATE__KEY__ID)
   --oauth2.client.secret value
-    	oauth2 client secret. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OAUTH2_CLIENT_SECRET)
+        oauth2 client secret. If argument starts with file:// it reads the secret from a file. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET)
   --oauth2.endpoint.auth value
-    	The flag is used to specify a custom OAuth2 authorization endpoint. (env: CONFIG_OAUTH2_ENDPOINT_AUTH)
+        The flag is used to specify a custom OAuth2 authorization endpoint. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_ENDPOINT_AUTH)
   --oauth2.endpoint.discovery value
-    	The flag is used to set a custom OAuth2 discovery URL. This URL retrieves the provider's configuration details. (env: CONFIG_OAUTH2_ENDPOINT_DISCOVERY)
+        The flag is used to set a custom OAuth2 discovery URL. This URL retrieves the provider's configuration details. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_ENDPOINT_DISCOVERY)
   --oauth2.endpoint.token value
-    	The flag is used to specify a custom OAuth2 token endpoint. (env: CONFIG_OAUTH2_ENDPOINT_TOKEN)
+        The flag is used to specify a custom OAuth2 token endpoint. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_ENDPOINT_TOKEN)
   --oauth2.groups-claim string
-    	Defines the claim name in the ID Token which contains the user groups. (env: CONFIG_OAUTH2_GROUPS__CLAIM) (default "groups")
+        Defines the claim name in the ID Token which contains the user groups. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_GROUPS__CLAIM) (default "groups")
   --oauth2.issuer value
-    	oauth2 issuer (env: CONFIG_OAUTH2_ISSUER)
+        oauth2 issuer (env: OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER)
   --oauth2.nonce
-    	If true, a nonce will be defined on the auth URL which is expected inside the token. (env: CONFIG_OAUTH2_NONCE) (default true)
+        If true, a nonce will be defined on the auth URL which is expected inside the token. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_NONCE) (default true)
   --oauth2.openvpn-username string
-        CEL expression to resolve the username from the normalized identity. The expression must evaluate to a string value. Example: string(token.claims.sub). If empty, the common name is used. (env: CONFIG_OAUTH2_OPENVPN__USERNAME) (default "user.username")
+        CEL expression to resolve the username from the normalized identity. The expression must evaluate to a string value. Example: string(token.claims.sub). If empty, the common name is used. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_OPENVPN__USERNAME) (default "user.username")
   --oauth2.pkce
-    	If true, Proof Key for Code Exchange (PKCE) RFC 7636 is used for token exchange. (env: CONFIG_OAUTH2_PKCE) (default true)
+        If true, Proof Key for Code Exchange (PKCE) RFC 7636 is used for token exchange. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_PKCE) (default true)
   --oauth2.provider string
-    	oauth2 provider (env: CONFIG_OAUTH2_PROVIDER) (default "generic")
+        oauth2 provider (env: OPENVPN_AUTH_OAUTH2_OAUTH2_PROVIDER) (default "generic")
   --oauth2.refresh-nonce value
-    	Controls nonce behavior on refresh token requests. Options: auto (try with nonce, retry without on error), empty (always use empty nonce), equal (use same nonce as initial auth). (env: CONFIG_OAUTH2_REFRESH__NONCE) (default auto)
+        Controls nonce behavior on refresh token requests. Options: auto (try with nonce, retry without on error), empty (always use empty nonce), equal (use same nonce as initial auth). (env: OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH__NONCE) (default auto)
   --oauth2.refresh.enabled
-    	If true, openvpn-auth-oauth2 stores refresh tokens and will use it do an non-interaction reauth. (env: CONFIG_OAUTH2_REFRESH_ENABLED)
+        If true, openvpn-auth-oauth2 stores refresh tokens and will use it do an non-interaction reauth. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_ENABLED)
   --oauth2.refresh.expires duration
-    	TTL of stored oauth2 token. (env: CONFIG_OAUTH2_REFRESH_EXPIRES) (default 8h0m0s)
+        TTL of stored oauth2 token. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_EXPIRES) (default 8h0m0s)
   --oauth2.refresh.secret value
-    	Required, if oauth2.refresh.enabled=true. Random generated secret for token encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OAUTH2_REFRESH_SECRET)
+        Required, if oauth2.refresh.enabled=true. Random generated secret for token encryption. Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_SECRET)
   --oauth2.refresh.use-session-id
-    	If true, openvpn-auth-oauth2 will use the session_id to refresh sessions on initial auth. Requires 'auth-token-gen [lifetime] external-auth' on OpenVPN server. (env: CONFIG_OAUTH2_REFRESH_USE__SESSION__ID)
+        If true, openvpn-auth-oauth2 will use the session_id to refresh sessions on initial auth. Requires 'auth-token-gen [lifetime] external-auth' on OpenVPN server. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_USE__SESSION__ID)
   --oauth2.refresh.validate-user
-    	If true, openvpn-auth-oauth2 will validate the user against the OIDC provider on each refresh. Usefully, if API limits are exceeded or OIDC provider can't deliver an refresh token. (env: CONFIG_OAUTH2_REFRESH_VALIDATE__USER) (default true)
+        If true, openvpn-auth-oauth2 will validate the user against the OIDC provider on each refresh. Usefully, if API limits are exceeded or OIDC provider can't deliver an refresh token. (env: OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_VALIDATE__USER) (default true)
   --oauth2.scopes value
-    	oauth2 token scopes. Defaults depends on oauth2.provider. Comma separated list. Example: openid,profile,email (env: CONFIG_OAUTH2_SCOPES)
+        oauth2 token scopes. Defaults depends on oauth2.provider. Comma separated list. Example: openid,profile,email (env: OPENVPN_AUTH_OAUTH2_OAUTH2_SCOPES)
   --oauth2.user-info
-    	If true, openvpn-auth-oauth2 uses the OIDC UserInfo endpoint to fetch additional information about the user (e.g. groups). (env: CONFIG_OAUTH2_USER__INFO)
+        If true, openvpn-auth-oauth2 uses the OIDC UserInfo endpoint to fetch additional information about the user (e.g. groups). (env: OPENVPN_AUTH_OAUTH2_OAUTH2_USER__INFO)
   --oauth2.validate.expression string
-        CEL expression for custom identity validation. The expression must evaluate to a boolean value. Example: openvpn.commonName == user.username (env: CONFIG_OAUTH2_VALIDATE_EXPRESSION)
+        CEL expression for custom identity validation. The expression must evaluate to a boolean value. Example: openvpn.commonName == user.username (env: OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_EXPRESSION)
   --oauth2.validate.groups value
-    	oauth2 required user groups. If multiple groups are configured, the user needs to be least in one group. Comma separated list. Example: group1,group2,group3 (env: CONFIG_OAUTH2_VALIDATE_GROUPS)
+        oauth2 required user groups. If multiple groups are configured, the user needs to be least in one group. Comma separated list. Example: group1,group2,group3 (env: OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_GROUPS)
   --openvpn.addr value
-    	openvpn management interface addr. Must start with unix:// or tcp:// (env: CONFIG_OPENVPN_ADDR) (default unix:/run/openvpn/server.sock)
+        openvpn management interface addr. Must start with unix:// or tcp:// (env: OPENVPN_AUTH_OAUTH2_OPENVPN_ADDR) (default unix:/run/openvpn/server.sock)
   --openvpn.auth-pending-timeout duration
-    	How long OpenVPN server wait until user is authenticated (env: CONFIG_OPENVPN_AUTH__PENDING__TIMEOUT) (default 3m0s)
+        How long OpenVPN server wait until user is authenticated (env: OPENVPN_AUTH_OAUTH2_OPENVPN_AUTH__PENDING__TIMEOUT) (default 3m0s)
   --openvpn.auth-token-user
-    	Override the username of a session with the username from the token by using auth-token-user, if the client username is empty (env: CONFIG_OPENVPN_AUTH__TOKEN__USER) (default true)
+        Override the username of a session with the username from the token by using auth-token-user, if the client username is empty (env: OPENVPN_AUTH_OAUTH2_OPENVPN_AUTH__TOKEN__USER) (default true)
   --openvpn.bypass.common-names value
-    	Skip OAuth authentication for client certificate common names (CNs) matching any of the given regular expressions. Multiple expressions can be provided as a comma-separated list. Regular expressions are automatically anchored (^…$) by default, so "client" matches only "client". To allow partial matches, specify explicitly (e.g. "client.*"). (env: CONFIG_OPENVPN_BYPASS_COMMON__NAMES)
+        Skip OAuth authentication for client certificate common names (CNs) matching any of the given regular expressions. Multiple expressions can be provided as a comma-separated list. Regular expressions are automatically anchored (^…$) by default, so "client" matches only "client". To allow partial matches, specify explicitly (e.g. "client.*"). (env: OPENVPN_AUTH_OAUTH2_OPENVPN_BYPASS_COMMON__NAMES)
   --openvpn.client-config.enabled
-    	If true, openvpn-auth-oauth2 will read the CCD directory for additional configuration. This function mimic the client-config-dir directive in OpenVPN. (env: CONFIG_OPENVPN_CLIENT__CONFIG_ENABLED)
+        If true, openvpn-auth-oauth2 will read the CCD directory for additional configuration. This function mimic the client-config-dir directive in OpenVPN. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_CLIENT__CONFIG_ENABLED)
   --openvpn.client-config.path value
-    	Path to the CCD directory. openvpn-auth-oauth2 will look for an file with an .conf suffix and returns the content back. (env: CONFIG_OPENVPN_CLIENT__CONFIG_PATH)
+        Path to the CCD directory. openvpn-auth-oauth2 will look for an file with an .conf suffix and returns the content back. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_CLIENT__CONFIG_PATH)
   --openvpn.client-config.ignore-not-found
-    	Ignore missing client configuration files. (env: CONFIG_OPENVPN_CLIENT__CONFIG_IGNORE__NOT__FOUND) (default true)
+        Ignore missing client configuration files. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_CLIENT__CONFIG_IGNORE__NOT__FOUND) (default true)
   --openvpn.client-config.expression string
-    	CEL expression that returns an ordered list of client configuration names. (env: CONFIG_OPENVPN_CLIENT__CONFIG_EXPRESSION)
+        CEL expression that returns an ordered list of client configuration names. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_CLIENT__CONFIG_EXPRESSION)
   --openvpn.client-config.strategy value
-    	Client config selection strategy. Values: [merge,user-selector]. (env: CONFIG_OPENVPN_CLIENT__CONFIG_STRATEGY) (default merge)
+        Client config selection strategy. Values: [merge,user-selector]. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_CLIENT__CONFIG_STRATEGY) (default merge)
   --openvpn.common-name.environment-variable-name string
-    	Name of the environment variable in the OpenVPN management interface which contains the common name. If username-as-common-name is enabled, this should be set to 'username' to use the username as common name. Other values like 'X509_0_emailAddress' are supported. See https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/#environmental-variables for more information. (env: CONFIG_OPENVPN_COMMON__NAME_ENVIRONMENT__VARIABLE__NAME) (default "common_name")
+        Name of the environment variable in the OpenVPN management interface which contains the common name. If username-as-common-name is enabled, this should be set to 'username' to use the username as common name. Other values like 'X509_0_emailAddress' are supported. See https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/#environmental-variables for more information. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_COMMON__NAME_ENVIRONMENT__VARIABLE__NAME) (default "common_name")
   --openvpn.common-name.mode value
-    	If common names are too long, use md5/sha1 to hash them or omit to skip them. Values: [plain,omit] (env: CONFIG_OPENVPN_COMMON__NAME_MODE) (default plain)
+        If common names are too long, use md5/sha1 to hash them or omit to skip them. Values: [plain,omit] (env: OPENVPN_AUTH_OAUTH2_OPENVPN_COMMON__NAME_MODE) (default plain)
   --openvpn.enforce-unique-user
-        Requires OpenVPN Server 2.7 and openvpn.override-username=true. If true, openvpn-auth-oauth2 enforces one active OpenVPN session per username. (env: CONFIG_OPENVPN_ENFORCE__UNIQUE__USER)
+        Requires OpenVPN Server 2.7 and openvpn.override-username=true. If true, openvpn-auth-oauth2 enforces one active OpenVPN session per username. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_ENFORCE__UNIQUE__USER)
   --openvpn.override-username
-    	Requires OpenVPN Server 2.7! If true, openvpn-auth-oauth2 use the override-username command to set the username in OpenVPN connection. This is useful to use real usernames in OpenVPN statistics. The username will be set after client configs are read. Read OpenVPN man page for limitations of the override-username. (env: CONFIG_OPENVPN_OVERRIDE__USERNAME)
+        Requires OpenVPN Server 2.7! If true, openvpn-auth-oauth2 use the override-username command to set the username in OpenVPN connection. This is useful to use real usernames in OpenVPN statistics. The username will be set after client configs are read. Read OpenVPN man page for limitations of the override-username. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_OVERRIDE__USERNAME)
   --openvpn.pass-through.address value
-    	The address of the pass-through socket. Must start with unix:// or tcp:// (env: CONFIG_OPENVPN_PASS__THROUGH_ADDRESS) (default unix:/run/openvpn-auth-oauth2/server.sock)
+        The address of the pass-through socket. Must start with unix:// or tcp:// (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_ADDRESS) (default unix:/run/openvpn-auth-oauth2/server.sock)
   --openvpn.pass-through.enabled
-    	If true, openvpn-auth-oauth2 will setup a pass-through socket for the OpenVPN management interface. (env: CONFIG_OPENVPN_PASS__THROUGH_ENABLED)
+        If true, openvpn-auth-oauth2 will setup a pass-through socket for the OpenVPN management interface. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_ENABLED)
   --openvpn.pass-through.password value
-    	The password for the pass-through socket. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OPENVPN_PASS__THROUGH_PASSWORD)
+        The password for the pass-through socket. If argument starts with file:// it reads the secret from a file. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_PASSWORD)
   --openvpn.pass-through.socket-group string
-    	The group for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix:// If empty, the group of the process is used. (env: CONFIG_OPENVPN_PASS__THROUGH_SOCKET__GROUP)
+        The group for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix:// If empty, the group of the process is used. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_SOCKET__GROUP)
   --openvpn.pass-through.socket-mode uint
-    	The unix file permission mode for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix:// (env: CONFIG_OPENVPN_PASS__THROUGH_SOCKET__MODE) (default 660)
+        The unix file permission mode for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix:// (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_SOCKET__MODE) (default 660)
   --openvpn.password value
-    	openvpn management interface password. If argument starts with file:// it reads the secret from a file. (env: CONFIG_OPENVPN_PASSWORD)
+        openvpn management interface password. If argument starts with file:// it reads the secret from a file. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASSWORD)
   --openvpn.reauthentication
-    	If set to false, openvpn-auth-oauth2 rejects all re-authentication requests. (env: CONFIG_OPENVPN_REAUTHENTICATION) (default true)
+        If set to false, openvpn-auth-oauth2 rejects all re-authentication requests. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_REAUTHENTICATION) (default true)
   --provider.google.validate.groups-transitive
-    	If true, required group membership for the Google provider is matched transitively: nested sub-groups of a configured group in oauth2.validate.groups are accepted. Requires the cloud-identity.groups.readonly scope and a Google Workspace/Cloud Identity plan that supports the Cloud Identity checkTransitiveMembership API. (env: CONFIG_PROVIDER_GOOGLE_VALIDATE_GROUPS__TRANSITIVE)
+        If true, required group membership for the Google provider is matched transitively: nested sub-groups of a configured group in oauth2.validate.groups are accepted. Requires the cloud-identity.groups.readonly scope and a Google Workspace/Cloud Identity plan that supports the Cloud Identity checkTransitiveMembership API. (env: OPENVPN_AUTH_OAUTH2_PROVIDER_GOOGLE_VALIDATE_GROUPS__TRANSITIVE)
   --version
-    	show version
+        show version
 ```
 <!-- END USAGE -->
 
@@ -170,7 +172,7 @@ openvpn-auth-oauth2 starts an HTTP listener that the OpenVPN client must access 
 By default, the HTTP listener operates on `:9000`.
 
 It is highly recommended to place openvpn-auth-oauth2 behind a reverse proxy terminates the TLS connections.
-Configuring `CONFIG_HTTP_BASEURL` remains crucial because openvpn-auth-oauth2 needs to know the redirect URL.
+Configuring `OPENVPN_AUTH_OAUTH2_HTTP_BASEURL` remains crucial because openvpn-auth-oauth2 needs to know the redirect URL.
 
 Example:
 
@@ -180,8 +182,8 @@ Example:
 
 ```ini
 # openvpn-auth-oauth2 config file
-CONFIG_HTTP_LISTEN=:9000
-CONFIG_HTTP_BASEURL=https://login.example.com
+OPENVPN_AUTH_OAUTH2_HTTP_LISTEN=:9000
+OPENVPN_AUTH_OAUTH2_HTTP_BASEURL=https://login.example.com
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -233,9 +235,9 @@ auth-gen-token 28800 external-auth
 
 ```ini
 # openvpn-auth-oauth2 config file
-CONFIG_OPENVPN_ADDR=unix:///run/openvpn/server.sock
-CONFIG_OPENVPN_PASSWORD=<password>
-CONFIG_OPENVPN_OVERRIDE__USERNAME=true # For OpenVPN 2.7+ servers
+OPENVPN_AUTH_OAUTH2_OPENVPN_ADDR=unix:///run/openvpn/server.sock
+OPENVPN_AUTH_OAUTH2_OPENVPN_PASSWORD=<password>
+OPENVPN_AUTH_OAUTH2_OPENVPN_OVERRIDE__USERNAME=true # For OpenVPN 2.7+ servers
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>

--- a/docs/Debugging Errors.md
+++ b/docs/Debugging Errors.md
@@ -69,9 +69,9 @@ you may want to make sure you add these lines to your oauth configuration file
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_REFRESH_ENABLED=true
-CONFIG_OAUTH2_REFRESH_EXPIRES=24h
-CONFIG_OAUTH2_REFRESH_SECRET=... # 16 or 24 characters
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_ENABLED=true
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_EXPIRES=24h
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_SECRET=... # 16 or 24 characters
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -107,10 +107,10 @@ auth-token-gen [lifetime] external-auth
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_REFRESH_ENABLED=true
-CONFIG_OAUTH2_REFRESH_EXPIRES=8h
-CONFIG_OAUTH2_REFRESH_SECRET=... # a static secret to encrypt token. Must be 16, 24 or 32
-CONFIG_OAUTH2_REFRESH_USE__SESSION__ID=true
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_ENABLED=true
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_EXPIRES=8h
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_SECRET=... # a static secret to encrypt token. Must be 16, 24 or 32
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_USE__SESSION__ID=true
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>

--- a/docs/HTTPS Listener.md
+++ b/docs/HTTPS Listener.md
@@ -1,7 +1,7 @@
 # HTTPS Listener
 
 > [!IMPORTANT]
-> Remember to set `CONFIG_HTTP_BASEURL` correctly. It should start with `https://` following your public domain name plus port.
+> Remember to set `OPENVPN_AUTH_OAUTH2_HTTP_BASEURL` correctly. It should start with `https://` following your public domain name plus port.
 
 Some SSO Provider like Entra ID requires `https://` based redirect URL.
 In the default configuration, openvpn-auth-oauth2 listen on `http://`.
@@ -25,9 +25,9 @@ the owner `root` and the group `openvpn-auth-oauth2`. See [Filesystem Permission
 <tbody><tr><td>
 
 ```ini
-CONFIG_HTTP_TLS=true
-CONFIG_HTTP_KEY=/etc/openvpn-auth-oauth2/server.key
-CONFIG_HTTP_CERT=/etc/openvpn-auth-oauth2/server.crt
+OPENVPN_AUTH_OAUTH2_HTTP_TLS=true
+OPENVPN_AUTH_OAUTH2_HTTP_KEY=/etc/openvpn-auth-oauth2/server.key
+OPENVPN_AUTH_OAUTH2_HTTP_CERT=/etc/openvpn-auth-oauth2/server.crt
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>

--- a/docs/Management Interface pass-through.md
+++ b/docs/Management Interface pass-through.md
@@ -27,11 +27,11 @@ openvpn-auth-oauth2 \
 <tbody><tr><td>
 
 ```ini
-CONFIG_OPENVPN_PASS__THROUGH_ENABLED=true
-CONFIG_OPENVPN_PASS__THROUGH_ADDRESS=unix:///run/openvpn/pass-through.sock
-# CONFIG_OPENVPN_PASS__THROUGH_PASSWORD=secret # optional
-# CONFIG_OPENVPN_PASS__THROUGH_SOCKET__GROUP=openvpn-auth-oauth2 # optional
-# CONFIG_OPENVPN_PASS__THROUGH_SOCKET__MODE=0660 # optional
+OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_ENABLED=true
+OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_ADDRESS=unix:///run/openvpn/pass-through.sock
+# OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_PASSWORD=secret # optional
+# OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_SOCKET__GROUP=openvpn-auth-oauth2 # optional
+# OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_SOCKET__MODE=0660 # optional
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>

--- a/docs/Non-interactive session refresh.md
+++ b/docs/Non-interactive session refresh.md
@@ -145,11 +145,11 @@ For providers like Authentik that return empty nonces on refresh (per OIDC spec)
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_REFRESH_ENABLED=true
-CONFIG_OAUTH2_REFRESH_EXPIRES=8h
-CONFIG_OAUTH2_REFRESH_SECRET= # a static secret to encrypt token. Must be 16, 24 or 32
-CONFIG_OAUTH2_REFRESH_USE__SESSION__ID=true
-CONFIG_OPENVPN_AUTH__TOKEN__USER=true
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_ENABLED=true
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_EXPIRES=8h
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_SECRET= # a static secret to encrypt token. Must be 16, 24 or 32
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_USE__SESSION__ID=true
+OPENVPN_AUTH_OAUTH2_OPENVPN_AUTH__TOKEN__USER=true
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>

--- a/docs/OpenVPN Plugin.md
+++ b/docs/OpenVPN Plugin.md
@@ -66,13 +66,13 @@ Configure openvpn-auth-oauth2 to connect to the plugin's management socket inste
 <tbody><tr><td>
 
 ```ini
-CONFIG_OPENVPN_ADDR=unix:///var/run/openvpn-oauth2.sock
-CONFIG_OPENVPN_PASSWORD=file:///etc/openvpn-auth-oauth2/oauth2-plugin-password.txt
-CONFIG_OAUTH2_REFRESH_ENABLED=true
-CONFIG_OAUTH2_REFRESH_EXPIRES=8h
-CONFIG_OAUTH2_REFRESH_SECRET= # a static secret to encrypt token. Must be 16, 24 or 32
-CONFIG_OAUTH2_REFRESH_USE__SESSION__ID=true
-CONFIG_OPENVPN_AUTH__TOKEN__USER=true
+OPENVPN_AUTH_OAUTH2_OPENVPN_ADDR=unix:///var/run/openvpn-oauth2.sock
+OPENVPN_AUTH_OAUTH2_OPENVPN_PASSWORD=file:///etc/openvpn-auth-oauth2/oauth2-plugin-password.txt
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_ENABLED=true
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_EXPIRES=8h
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_SECRET= # a static secret to encrypt token. Must be 16, 24 or 32
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_USE__SESSION__ID=true
+OPENVPN_AUTH_OAUTH2_OPENVPN_AUTH__TOKEN__USER=true
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>

--- a/docs/OpenVPN Username.md
+++ b/docs/OpenVPN Username.md
@@ -46,7 +46,7 @@ When setting up `username-as-common-name` on the OpenVPN server, you **must** al
 Or via environment variable:
 
 ```dotenv
-CONFIG_OPENVPN_COMMON__NAME_ENVIRONMENT__VARIABLE__NAME=username
+OPENVPN_AUTH_OAUTH2_OPENVPN_COMMON__NAME_ENVIRONMENT__VARIABLE__NAME=username
 ```
 
 ### Why This Configuration Is Required
@@ -86,7 +86,7 @@ Enable this feature using:
 Or via environment variable:
 
 ```bash
-CONFIG_OPENVPN_OVERRIDE__USERNAME=true
+OPENVPN_AUTH_OAUTH2_OPENVPN_OVERRIDE__USERNAME=true
 ```
 
 #### Username source

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -37,12 +37,12 @@ References:
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_ISSUER=https://login.microsoftonline.com/$TENANT_ID/v2.0
-CONFIG_OAUTH2_CLIENT_ID=<client_id>
-CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
+OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://login.microsoftonline.com/$TENANT_ID/v2.0
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=<client_id>
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=<client_secret>
 # The scopes openid profile are required, but configured by default.
 # offline_access is required for non-interactive session refresh.
-# CONFIG_OAUTH2_SCOPES=openid profile offline_access
+# OPENVPN_AUTH_OAUTH2_OAUTH2_SCOPES=openid profile offline_access
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -74,7 +74,7 @@ Users get the notice from Azure that they aren’t part of the group, and the lo
 
 Reference: https://learn.microsoft.com/en-us/entra/identity-platform/howto-restrict-your-app-to-a-set-of-users#assign-the-app-to-users-and-groups-to-restrict-access
 
-To require multiple groups, define `CONFIG_OAUTH2_VALIDATE_GROUPS`.
+To require multiple groups, define `OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_GROUPS`.
 
 </details>
 
@@ -110,7 +110,7 @@ To require multiple groups, define `CONFIG_OAUTH2_VALIDATE_GROUPS`.
 1. Navigate to the [Google Cloud Identity API](https://console.cloud.google.com/apis/api/cloudidentity.googleapis.com/) page and click on the "Enable API" button.
 2. Access the [Google Admin Portal](https://admin.google.com/ac/groups) and locate the group that is required for the `openvpn-auth-oauth2` authorization.
 3. The URL of the group page should follow this pattern: `https://admin.google.com/ac/groups/<ID>`. Replace `<ID>` with the ID of the group. Make sure to copy this ID for future use. If there are multiple groups, repeat this step for each one.
-4. Insert the copied IDs into the `CONFIG_OAUTH2_VALIDATE_GROUPS` configuration setting in your `openvpn-auth-oauth2` setup.
+4. Insert the copied IDs into the `OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_GROUPS` configuration setting in your `openvpn-auth-oauth2` setup.
 5. **Optional**: If oauth2 scopes are set in the configuration, the `https://www.googleapis.com/auth/cloud-identity.groups.readonly` scope is required for group validation.
 
 ### Configuration
@@ -122,17 +122,17 @@ Set the following variables in your openvpn-auth-oauth2 configuration file:
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_PROVIDER=google
-CONFIG_OAUTH2_ISSUER=https://accounts.google.com
-CONFIG_OAUTH2_CLIENT_ID=162738495-xxxxx.apps.googleusercontent.com
-CONFIG_OAUTH2_CLIENT_SECRET=GOCSPX-xxxxxxxx
-CONFIG_OAUTH2_OPENVPN__USERNAME=user.email
+OPENVPN_AUTH_OAUTH2_OAUTH2_PROVIDER=google
+OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://accounts.google.com
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=162738495-xxxxx.apps.googleusercontent.com
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=GOCSPX-xxxxxxxx
+OPENVPN_AUTH_OAUTH2_OAUTH2_OPENVPN__USERNAME=user.email
 
 # The scopes openid profile email are required, but configured by default.
 # https://www.googleapis.com/auth/cloud-identity.groups.readonly is mandatory for group validation.
 # Enabled by default, if scopes aren't set in the config.
-#CONFIG_OAUTH2_SCOPES=openid profile email https://www.googleapis.com/auth/cloud-identity.groups.readonly
-#CONFIG_OAUTH2_VALIDATE_GROUPS=03x8tuzt3hqdv5v
+#OPENVPN_AUTH_OAUTH2_OAUTH2_SCOPES=openid profile email https://www.googleapis.com/auth/cloud-identity.groups.readonly
+#OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_GROUPS=03x8tuzt3hqdv5v
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -173,7 +173,7 @@ of nested sub-groups are accepted as well:
 <tbody><tr><td>
 
 ```ini
-CONFIG_PROVIDER_GOOGLE_VALIDATE_GROUPS__TRANSITIVE=true
+OPENVPN_AUTH_OAUTH2_PROVIDER_GOOGLE_VALIDATE_GROUPS__TRANSITIVE=true
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -238,12 +238,12 @@ Set the following variables in your `openvpn-auth-oauth2` configuration file:
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_ISSUER=https://<keycloak-domain>/auth/realms/<realm-name>
-CONFIG_OAUTH2_CLIENT_ID=<client_id>
-CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
+OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://<keycloak-domain>/auth/realms/<realm-name>
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=<client_id>
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=<client_secret>
 # The scopes openid profile are required, but configured by default.
 # offline_access is required for non-interactive session refresh.
-# CONFIG_OAUTH2_SCOPES=openid profile offline_access
+# OPENVPN_AUTH_OAUTH2_OAUTH2_SCOPES=openid profile offline_access
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -318,11 +318,11 @@ After registering the app, you will receive an OAuth2 client ID and secret. Thes
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_PROVIDER=github
-CONFIG_OAUTH2_ISSUER=https://github.com
-CONFIG_OAUTH2_CLIENT_ID=<client_id>
-CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
-CONFIG_OAUTH2_VALIDATE_GROUPS=your_github_org_name
+OPENVPN_AUTH_OAUTH2_OAUTH2_PROVIDER=github
+OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://github.com
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=<client_id>
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=<client_secret>
+OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_GROUPS=your_github_org_name
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -370,11 +370,11 @@ If you are using Self-Managed GitLab, your instance must have enabled HTTPS.
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_ISSUER=https://gitlab.com/
-CONFIG_OAUTH2_SCOPES=openid profile email
-CONFIG_OAUTH2_USER__INFO=true
-CONFIG_OAUTH2_CLIENT_ID=<client_id>
-CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
+OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://gitlab.com/
+OPENVPN_AUTH_OAUTH2_OAUTH2_SCOPES=openid profile email
+OPENVPN_AUTH_OAUTH2_OAUTH2_USER__INFO=true
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=<client_id>
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=<client_secret>
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -417,12 +417,12 @@ and only used between the application and the DigitalOcean authorization server 
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_ISSUER=https://cloud.digitalocean.com/
-CONFIG_OAUTH2_SCOPES=read
-CONFIG_OAUTH2_CLIENT_ID=<client_id>
-CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
-CONFIG_OAUTH2_ENDPOINT_TOKEN=https://cloud.digitalocean.com/v1/oauth/token
-CONFIG_OAUTH2_ENDPOINT_AUTH=https://cloud.digitalocean.com/v1/oauth/authorize
+OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://cloud.digitalocean.com/
+OPENVPN_AUTH_OAUTH2_OAUTH2_SCOPES=read
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=<client_id>
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=<client_secret>
+OPENVPN_AUTH_OAUTH2_OAUTH2_ENDPOINT_TOKEN=https://cloud.digitalocean.com/v1/oauth/token
+OPENVPN_AUTH_OAUTH2_OAUTH2_ENDPOINT_AUTH=https://cloud.digitalocean.com/v1/oauth/authorize
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -468,12 +468,12 @@ After creating application, on page URLs you can find all links that you need.
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_ISSUER=https://company.zitadel.cloud
-CONFIG_OAUTH2_CLIENT_ID=<client_id>
-CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
+OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://company.zitadel.cloud
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=<client_id>
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=<client_secret>
 # The scopes openid profile email are required, but configured by default.
 # offline_access is required for non-interactive session refresh.
-#CONFIG_OAUTH2_SCOPES=openid profile email offline_access
+#OPENVPN_AUTH_OAUTH2_OAUTH2_SCOPES=openid profile email offline_access
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>
@@ -532,10 +532,10 @@ oauth2:
 <tbody><tr><td>
 
 ```ini
-CONFIG_OAUTH2_ISSUER=https://auth.example.com/application/o/openvpn-oauth2/
-CONFIG_OAUTH2_CLIENT_ID=<client_id>
-CONFIG_OAUTH2_CLIENT_SECRET=<client_secret>
-CONFIG_OAUTH2_REFRESH__NONCE=empty
+OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://auth.example.com/application/o/openvpn-oauth2/
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=<client_id>
+OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=<client_secret>
+OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH__NONCE=empty
 ```
 </td></tr></tbody>
 <thead><tr><td>yaml configuration</td></tr></thead>

--- a/docs/Upgrade V2.md
+++ b/docs/Upgrade V2.md
@@ -3,6 +3,22 @@
 Version 2 includes configuration changes for username resolution, client-specific
 configuration, token validation, and security hardening.
 
+## Environment variable prefix
+
+Version 2 uses the project-specific `OPENVPN_AUTH_OAUTH2_` prefix for
+environment variables. The previous `CONFIG_` prefix is no longer supported.
+Rename every environment variable before upgrading:
+
+| Version 1 | Version 2 |
+| --- | --- |
+| `CONFIG_FILE` | `OPENVPN_AUTH_OAUTH2_CONFIG_FILE` |
+| `CONFIG_HTTP_LISTEN` | `OPENVPN_AUTH_OAUTH2_HTTP_LISTEN` |
+| `CONFIG_OAUTH2_CLIENT_ID` | `OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID` |
+| `CONFIG_OPENVPN_PASS__THROUGH_ENABLED` | `OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_ENABLED` |
+
+The suffix conversion is unchanged: dots become single underscores and dashes
+become double underscores.
+
 ## Security hardening
 
 Review the rest of this page even if these hardening items do not apply to your
@@ -29,8 +45,8 @@ http:
 Environment variable configuration:
 
 ```ini
-CONFIG_HTTP_ENABLE__PROXY__HEADERS=true
-CONFIG_HTTP_TRUSTED__PROXIES=127.0.0.1/32,10.0.0.0/24
+OPENVPN_AUTH_OAUTH2_HTTP_ENABLE__PROXY__HEADERS=true
+OPENVPN_AUTH_OAUTH2_HTTP_TRUSTED__PROXIES=127.0.0.1/32,10.0.0.0/24
 ```
 
 If openvpn-auth-oauth2 is not behind a reverse proxy, keep
@@ -133,7 +149,8 @@ oauth2:
   openvpn-username: 'user.email.split("@")[0]'
 ```
 
-The environment variable for the new option is `CONFIG_OAUTH2_OPENVPN__USERNAME`.
+The environment variable for the new option is
+`OPENVPN_AUTH_OAUTH2_OAUTH2_OPENVPN__USERNAME`.
 Unlike version 1's provider-specific paths, the expression is applied
 consistently when identity comes from an ID token, UserInfo, or the GitHub API,
 and during validated refresh authentication.

--- a/docs/demo/docker-compose.yaml
+++ b/docs/demo/docker-compose.yaml
@@ -137,17 +137,17 @@ services:
         aliases:
           - openvpn-auth-oauth2
     environment:
-      CONFIG_HTTP_LISTEN: ":9000"
-      CONFIG_HTTP_BASEURL: "http://localhost:9000/"
-      CONFIG_HTTP_SECRET: "1jd93h5b6s82lf03jh5b2hf9"
-      CONFIG_OPENVPN_ADDR: "tcp://openvpn:8081"
-      CONFIG_OPENVPN_PASSWORD: "password"
-      CONFIG_OAUTH2_ISSUER: "http://localhost:8080/realms/openvpn-auth-oauth2"
-      CONFIG_OAUTH2_ENDPOINT_DISCOVERY: "http://keycloak:8080/realms/openvpn-auth-oauth2/.well-known/openid-configuration"
-      CONFIG_OAUTH2_REFRESH_ENABLED: "true"
-      CONFIG_OAUTH2_REFRESH_SECRET: "1jd93h5b6s82lf03jh5b2hf9"
-      CONFIG_OAUTH2_CLIENT_ID: "openvpn-auth-oauth2"
-      CONFIG_OAUTH2_CLIENT_SECRET: "zSkHo6iq8AEZ9W725JqomqkZGhfOG8jL"
+      OPENVPN_AUTH_OAUTH2_HTTP_LISTEN: ":9000"
+      OPENVPN_AUTH_OAUTH2_HTTP_BASEURL: "http://localhost:9000/"
+      OPENVPN_AUTH_OAUTH2_HTTP_SECRET: "1jd93h5b6s82lf03jh5b2hf9"
+      OPENVPN_AUTH_OAUTH2_OPENVPN_ADDR: "tcp://openvpn:8081"
+      OPENVPN_AUTH_OAUTH2_OPENVPN_PASSWORD: "password"
+      OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER: "http://localhost:8080/realms/openvpn-auth-oauth2"
+      OPENVPN_AUTH_OAUTH2_OAUTH2_ENDPOINT_DISCOVERY: "http://keycloak:8080/realms/openvpn-auth-oauth2/.well-known/openid-configuration"
+      OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_ENABLED: "true"
+      OPENVPN_AUTH_OAUTH2_OAUTH2_REFRESH_SECRET: "1jd93h5b6s82lf03jh5b2hf9"
+      OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID: "openvpn-auth-oauth2"
+      OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET: "zSkHo6iq8AEZ9W725JqomqkZGhfOG8jL"
     ports:
       - "9000:9000/tcp"
       - "9092:9092/tcp"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,11 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+const (
+	configArgument            = "--config"
+	environmentVariablePrefix = "OPENVPN_AUTH_OAUTH2_"
+)
+
 var ErrVersion = errors.New("flag: version requested")
 
 // New loads the configuration from configuration files, command line arguments and environment variables in that order.
@@ -116,30 +121,25 @@ func (c *Config) ReadFromFlagAndEnvironment(args []string, writer io.Writer) err
 }
 
 func lookupConfigArgument(args []string) string {
-	var (
-		configFile string
-		ok         bool
-	)
+	readConfigPath := false
 
-	for i, arg := range args {
-		if !strings.HasPrefix(arg, "--config") {
-			continue
+	for _, arg := range args {
+		if readConfigPath {
+			return arg
 		}
 
-		configFile, ok = strings.CutPrefix(arg, "--config=")
-		if ok {
-			break
+		if configFile, ok := strings.CutPrefix(arg, configArgument+"="); ok {
+			return configFile
 		}
 
-		// check if the argument is --config without value and look for the next argument
-		if len(args) > i+1 {
-			configFile = args[i+1]
-
-			break
-		}
+		readConfigPath = arg == configArgument
 	}
 
-	return configFile
+	if readConfigPath {
+		return ""
+	}
+
+	return lookupEnvOrDefault("config", "")
 }
 
 // lookupEnvOrDefault looks up the environment variable by the flag name and returns the value.
@@ -232,5 +232,10 @@ func lookupEnvOrDefault[T any](key string, defaultValue T) T {
 // It replaces all dots with underscores and all dashes with double underscores.
 // It also converts the flag name to uppercase.
 func getEnvironmentVariableByFlagName(flagName string) string {
-	return "CONFIG_" + strings.ReplaceAll(strings.ReplaceAll(strings.ToUpper(flagName), ".", "_"), "-", "__")
+	if flagName == "config" {
+		return environmentVariablePrefix + "CONFIG_FILE"
+	}
+
+	return environmentVariablePrefix +
+		strings.ReplaceAll(strings.ReplaceAll(strings.ToUpper(flagName), ".", "_"), "-", "__")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -299,6 +299,27 @@ func TestConfigHelpFlag(t *testing.T) {
 	_, err := config.New([]string{"openvpn-auth-oauth2", "--help"}, &buf)
 
 	require.ErrorIs(t, err, flag.ErrHelp)
+	assert.Contains(t, buf.String(), "--config string")
+	assert.Contains(t, buf.String(), "(env: OPENVPN_AUTH_OAUTH2_CONFIG_FILE)")
+	assert.Contains(t, buf.String(), "(env: OPENVPN_AUTH_OAUTH2_HTTP_LISTEN)")
+	assert.NotContains(t, buf.String(), "(env: CONFIG_HTTP_LISTEN)")
+}
+
+func TestConfigFileEnvironmentVariable(t *testing.T) {
+	var buf bytes.Buffer
+
+	configFile, err := os.CreateTemp(t.TempDir(), "openvpn-auth-oauth2-*")
+	require.NoError(t, err)
+
+	_, err = configFile.WriteString("http:\n  listen: \":9100\"\n")
+	require.NoError(t, err)
+	require.NoError(t, configFile.Close())
+
+	t.Setenv("OPENVPN_AUTH_OAUTH2_CONFIG_FILE", configFile.Name())
+
+	conf, err := config.New([]string{"openvpn-auth-oauth2"}, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, ":9100", conf.HTTP.Listen)
 }
 
 func TestConfigVersionFlag(t *testing.T) {

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -116,11 +116,11 @@ func TestLookupEnvOrDefault(t *testing.T) {
 			testFn := func() {
 				require.Equal(t, tc.defaultValue, lookupEnvOrDefault("unset", tc.defaultValue))
 
-				t.Setenv("CONFIG_SET", tc.input)
+				t.Setenv("OPENVPN_AUTH_OAUTH2_SET", tc.input)
 				require.Equal(t, tc.expected, lookupEnvOrDefault("set", tc.defaultValue))
 
 				if tc.badInput != "" {
-					t.Setenv("CONFIG_BAD", tc.badInput)
+					t.Setenv("OPENVPN_AUTH_OAUTH2_BAD", tc.badInput)
 					require.Equal(t, tc.defaultValue, lookupEnvOrDefault("bad", tc.defaultValue))
 				}
 			}
@@ -132,4 +132,28 @@ func TestLookupEnvOrDefault(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetEnvironmentVariableByFlagName(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "OPENVPN_AUTH_OAUTH2_CONFIG_FILE", getEnvironmentVariableByFlagName("config"))
+	require.Equal(t,
+		"OPENVPN_AUTH_OAUTH2_OPENVPN_PASS__THROUGH_SOCKET__MODE",
+		getEnvironmentVariableByFlagName("openvpn.pass-through.socket-mode"))
+}
+
+func TestLookupEnvOrDefaultIgnoresLegacyPrefix(t *testing.T) {
+	t.Setenv("CONFIG_LEGACY__PREFIX__TEST", "legacy")
+
+	require.Equal(t, "default", lookupEnvOrDefault("legacy-prefix-test", "default"))
+}
+
+func TestLookupConfigArgument(t *testing.T) {
+	t.Setenv("OPENVPN_AUTH_OAUTH2_CONFIG_FILE", "environment.yaml")
+
+	require.Equal(t, "environment.yaml", lookupConfigArgument([]string{"openvpn-auth-oauth2"}))
+	require.Equal(t, "flag.yaml", lookupConfigArgument([]string{"openvpn-auth-oauth2", "--config", "flag.yaml"}))
+	require.Equal(t, "flag.yaml", lookupConfigArgument([]string{"openvpn-auth-oauth2", "--config=flag.yaml"}))
+	require.Empty(t, lookupConfigArgument([]string{"openvpn-auth-oauth2", "--config"}))
 }

--- a/packaging/etc/sysconfig/openvpn-auth-oauth2
+++ b/packaging/etc/sysconfig/openvpn-auth-oauth2
@@ -22,19 +22,19 @@
 # Environment Variables
 # ------------------------------------------------------------------------------
 
-## CONFIG_FILE is the path to the configuration file. Defaults to /etc/openvpn-auth-oauth2/config.yaml
-#CONFIG_FILE=/etc/openvpn-auth-oauth2/config.yaml
+## OPENVPN_AUTH_OAUTH2_CONFIG_FILE is the path to the configuration file. Defaults to /etc/openvpn-auth-oauth2/config.yaml
+#OPENVPN_AUTH_OAUTH2_CONFIG_FILE=/etc/openvpn-auth-oauth2/config.yaml
 
-CONFIG_OPENVPN_ADDR=unix:///run/openvpn/server.sock
+OPENVPN_AUTH_OAUTH2_OPENVPN_ADDR=unix:///run/openvpn/server.sock
 
 ## Define OIDC related settings
-#CONFIG_OAUTH2_ISSUER=https://login.microsoftonline.com/<tenant-id>/v2.0
-#CONFIG_OAUTH2_CLIENT_ID=
-#CONFIG_OAUTH2_CLIENT_SECRET=
-#CONFIG_HTTP_LISTEN=:9000
+#OPENVPN_AUTH_OAUTH2_OAUTH2_ISSUER=https://login.microsoftonline.com/<tenant-id>/v2.0
+#OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID=
+#OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET=
+#OPENVPN_AUTH_OAUTH2_HTTP_LISTEN=:9000
 
 ## Define a random value with 16 or 24 characters
-#CONFIG_HTTP_SECRET=
+#OPENVPN_AUTH_OAUTH2_HTTP_SECRET=
 
 ## Define the public http endpoint here.
-#CONFIG_HTTP_BASEURL=http://localhost:9000
+#OPENVPN_AUTH_OAUTH2_HTTP_BASEURL=http://localhost:9000

--- a/packaging/usr/lib/systemd/system/openvpn-auth-oauth2.service
+++ b/packaging/usr/lib/systemd/system/openvpn-auth-oauth2.service
@@ -17,11 +17,11 @@ User=openvpn-auth-oauth2-dynamic
 Group=openvpn-auth-oauth2-dynamic
 SupplementaryGroups=openvpn-auth-oauth2
 
-ExecStart=/usr/bin/openvpn-auth-oauth2 --config ${CONFIG_FILE}
+ExecStart=/usr/bin/openvpn-auth-oauth2 --config ${OPENVPN_AUTH_OAUTH2_CONFIG_FILE}
 NoExecPaths=/
 ExecPaths=/usr/bin/openvpn-auth-oauth2 /usr/bin/env /usr/bin/kill
 ExecReload=/usr/bin/env kill -USR1 $MAINPID
-Environment=CONFIG_FILE=/etc/openvpn-auth-oauth2/config.yaml
+Environment=OPENVPN_AUTH_OAUTH2_CONFIG_FILE=/etc/openvpn-auth-oauth2/config.yaml
 EnvironmentFile=-/etc/sysconfig/openvpn-auth-oauth2
 #LoadCredential=openvpn-auth-oauth2:/etc/openvpn-auth-oauth2/
 #ConfigurationDirectory=openvpn-auth-oauth2


### PR DESCRIPTION
## Summary

- replace the generic `CONFIG_` environment prefix with `OPENVPN_AUTH_OAUTH2_`
- stop reading legacy `CONFIG_` variables without a compatibility fallback
- expose and read `OPENVPN_AUTH_OAUTH2_CONFIG_FILE`, while keeping `--config` at higher precedence
- update CLI help, packaging, the systemd unit, the demo Compose file, and all configuration documentation
- add v2 migration guidance and regression coverage

## Why

The generic `CONFIG_` namespace can collide with unrelated environment variables. Version 2 is the appropriate breaking-change boundary for a project-specific namespace. The config-file flag also derived the misleading `CONFIG_CONFIG` help entry while packaged installations used `CONFIG_FILE`; the runtime and help now agree on `OPENVPN_AUTH_OAUTH2_CONFIG_FILE`.

## Implementation

- [Environment-name generation and config-file precedence](https://github.com/jkroepke/openvpn-auth-oauth2/blob/991a470d52cf91ded6da95abd01721fc46c32e18/internal/config/config.go#L18-L20)
- [CLI help and config-file environment integration coverage](https://github.com/jkroepke/openvpn-auth-oauth2/blob/991a470d52cf91ded6da95abd01721fc46c32e18/internal/config/config_test.go#L292-L323)
- [Legacy-prefix rejection and mapping coverage](https://github.com/jkroepke/openvpn-auth-oauth2/blob/991a470d52cf91ded6da95abd01721fc46c32e18/internal/config/env_test.go#L137-L158)
- [Version 2 migration table](https://github.com/jkroepke/openvpn-auth-oauth2/blob/991a470d52cf91ded6da95abd01721fc46c32e18/docs/Upgrade%20V2.md#L6-L20)

## Breaking change

Deployments must rename `CONFIG_*` variables before upgrading. For example:

- `CONFIG_HTTP_LISTEN` becomes `OPENVPN_AUTH_OAUTH2_HTTP_LISTEN`
- `CONFIG_OAUTH2_CLIENT_ID` becomes `OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_ID`
- `CONFIG_FILE` becomes `OPENVPN_AUTH_OAUTH2_CONFIG_FILE`

## Testing

- `make fmt`
- `make lint`
- `make test`
- `git diff --check`