### PR TITLE
fix: publish client config before auth success

### DIFF
--- a/lib/openvpn-auth-oauth2/internal/openvpn/handle.go
+++ b/lib/openvpn-auth-oauth2/internal/openvpn/handle.go
@@ -178,6 +178,11 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 
 			switch resp.ClientAuth {
 			case management.ClientAuthAccept:
+				// Publish the client config before signaling authentication success.
+				// OpenVPN may invoke CLIENT_CONNECT_V2 as soon as it observes the
+				// auth control file change.
+				perClientContext.setClientConfig(resp.ClientConfig)
+
 				if err := openVPNClient.WriteToAuthFile("1"); err != nil {
 					logger.ErrorContext(
 						p.ctx, "write to auth file",
@@ -188,8 +193,6 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 				}
 
 				logger.InfoContext(p.ctx, "authentication accepted")
-
-				perClientContext.setClientConfig(resp.ClientConfig)
 			case management.ClientAuthDeny:
 				handleAuthDenied(p.ctx, logger, openVPNClient, resp)
 


### PR DESCRIPTION
## Summary

- publish deferred-auth client configuration before writing the successful auth-control result
- make the auth-control file update the completion barrier for `CLIENT_CONNECT_V2`
- document why the ordering is required

## Root cause

The deferred-auth goroutine previously wrote success value `1` to `auth_control_file` before storing `resp.ClientConfig`. OpenVPN can invoke `CLIENT_CONNECT_V2` as soon as it observes that file change. In the narrow interval between those operations, the callback saw an empty client configuration and returned success without a return list, causing the rare `TestPlugin/with_refresh` failure.

The client configuration is now published under the existing `ClientContext` mutex before authentication success is exposed externally: [ordering fix](https://github.com/jkroepke/openvpn-auth-oauth2/blob/82434718ed241a5293a0527e4d253e6ad4a49f43/lib/openvpn-auth-oauth2/internal/openvpn/handle.go#L179-L195).

## Impact

This removes the scheduler-dependent window in tests and production. When OpenVPN observes successful deferred authentication, the associated client configuration is already available.

## Testing

- reported shuffle seed, 100 iterations:
  `go test ./lib/openvpn-auth-oauth2/internal/openvpn -run TestPlugin/with_refresh -shuffle=1784929366849778810 -count=100 -failfast`
- reported shuffle seed under the race detector, 20 iterations:
  `go test -race ./lib/openvpn-auth-oauth2/internal/openvpn -run TestPlugin/with_refresh -shuffle=1784929366849778810 -count=20 -failfast`
- `make fmt`
- `make lint`
- `make test`
- `git diff --check`