### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Contributions are welcome through GitHub pull requests.
+
+## Before You Start
+
+Small fixes and documentation improvements can go directly to a pull request.
+Before starting a large feature, breaking change, or substantial refactoring,
+[open an issue](https://github.com/jkroepke/openvpn-auth-oauth2/issues/new/choose)
+to discuss the proposal with the maintainer.
+
+Read the [developer guide](DEVELOPER.md) for an overview of the project and its
+requirements.
+
+## Submit a Pull Request
+
+1. Fork the repository and create a branch for your change.
+2. Keep the change focused, and update tests and documentation when needed.
+3. Run the required checks:
+
+   ```shell
+   make fmt
+   make lint
+   make test
+   ```
+
+4. Sign off each commit with `git commit -s` to certify the
+   [Developer Certificate of Origin](https://developercertificate.org/).
+5. Open a pull request and explain the change, its reason, and how you tested it.
+
+The pull request title becomes an entry in the changelog. Write it as a concise,
+user-facing description of the change.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ For information on the OpenVPN version requirements, please refer to the [OpenVP
 - [openvpn-oidc](https://github.com/vitaliy-sn/openvpn-oidc)
 - [openvpn-auth-azure-ad](https://github.com/jkroepke/openvpn-auth-azure-ad)
 
+## Contributing
+
+See the [contributing guide](CONTRIBUTING.md) to propose and submit changes.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE.txt).


### PR DESCRIPTION
#### What this PR does / why we need it

Adds a concise, human-facing contribution guide and links it from the README. The guide asks contributors to use pull requests, discuss substantial changes in an issue first, run the required checks, sign off commits, and write pull request titles for changelog readers.

#### Which issue this PR fixes

Not applicable.

#### Special notes for your reviewer

The guide is intentionally short and points contributors to `DEVELOPER.md` for the technical project overview.

#### Particularly user-facing changes

- Documents how to propose, validate, and submit contributions.
- Clarifies that pull request titles become changelog entries.

#### Testing

- `npx --yes --package textlint --package textlint-rule-terminology textlint --rule terminology CONTRIBUTING.md README.md`
- `make fmt`
- `make lint`
- `make test`

#### Checklist

- [x] [DCO](https://developercertificate.org/) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR