### PR TITLE
fix!: require octal notation for pass-through socket mode

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -164,8 +164,8 @@ Usage of openvpn-auth-oauth2:
         The password for the pass-through socket. If argument starts with file:// it reads the secret from a file. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS_THROUGH_PASSWORD)
   --openvpn.pass-through.socket-group string
         The group for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix:// If empty, the group of the process is used. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS_THROUGH_SOCKET_GROUP)
-  --openvpn.pass-through.socket-mode uint
-        The unix file permission mode for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix:// (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS_THROUGH_SOCKET_MODE) (default 660)
+  --openvpn.pass-through.socket-mode value
+        The explicit four-digit octal unix file permission mode for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix:// (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASS_THROUGH_SOCKET_MODE) (default 0660)
   --openvpn.password value
         openvpn management interface password. If argument starts with file:// it reads the secret from a file. (env: OPENVPN_AUTH_OAUTH2_OPENVPN_PASSWORD)
   --openvpn.reauthentication

--- a/docs/Management Interface pass-through.md
+++ b/docs/Management Interface pass-through.md
@@ -44,7 +44,7 @@ openvpn:
     address: "unix:///run/openvpn/pass-through.sock"
     #password: "secret" # optional
     #socket-group: "openvpn-auth-oauth2" # optional
-    #socket-mode: 660 # optional
+    #socket-mode: "0660" # optional
 ```
 </td></tr></tbody>
 </table>

--- a/docs/Upgrade V2.md
+++ b/docs/Upgrade V2.md
@@ -86,6 +86,32 @@ for an OpenVPN management command response. Its default is `10s`. It can be
 configured through YAML, the `--openvpn.command-timeout` flag, or
 `OPENVPN_AUTH_OAUTH2_OPENVPN_COMMAND_TIMEOUT`.
 
+### Pass-through socket permissions
+
+`openvpn.pass-through.socket-mode` now requires explicit octal notation and
+accepts only permission values from `0000` through `0777`. Use either a leading
+zero, such as `0660`, or the `0o660` form. Unprefixed and decimal values are no
+longer accepted.
+
+For YAML configuration, quote the value so other YAML tools also preserve its
+octal notation:
+
+```yaml
+openvpn:
+  pass-through:
+    socket-mode: "0660"
+```
+
+For command-line or environment configuration, use `0660`:
+
+```shell
+--openvpn.pass-through.socket-mode=0660
+OPENVPN_AUTH_OAUTH2_OPENVPN_PASS_THROUGH_SOCKET_MODE=0660
+```
+
+If you previously used decimal `432` to obtain permissions `0660`, replace it
+with the explicit octal value `0660`.
+
 ## Security hardening
 
 Review the rest of this page even if these hardening items do not apply to your

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -128,7 +128,7 @@ openvpn:
         enabled: true
         password: "password"
         socket-group: "group"
-        socket-mode: 0666
+        socket-mode: "0666"
     reauthentication: false
 http:
     listen: ":9001"
@@ -213,7 +213,7 @@ http:
 							OmitHost: false,
 						}},
 						SocketGroup: "group",
-						SocketMode:  0o666,
+						SocketMode:  types.FileMode(0o666),
 						Password:    "password",
 					},
 					CommandTimeout:   15 * time.Second,
@@ -305,6 +305,8 @@ func TestConfigHelpFlag(t *testing.T) {
 	assert.Contains(t, buf.String(), "(env: OPENVPN_AUTH_OAUTH2_HTTP_LISTEN)")
 	assert.Contains(t, buf.String(), "--openvpn.command-timeout duration")
 	assert.Contains(t, buf.String(), "(env: OPENVPN_AUTH_OAUTH2_OPENVPN_COMMAND_TIMEOUT)")
+	assert.Contains(t, buf.String(), "--openvpn.pass-through.socket-mode value")
+	assert.Contains(t, buf.String(), "(default 0660)")
 	assert.NotContains(t, buf.String(), "(env: CONFIG_HTTP_LISTEN)")
 }
 
@@ -366,6 +368,47 @@ func TestConfigRejectsRemovedTopLevelConfigProperty(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "field config not found")
+}
+
+func TestConfigRejectsAmbiguousSocketMode(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		configFile string
+		args       []string
+	}{
+		{
+			name:       "yaml",
+			configFile: "openvpn:\n  pass-through:\n    socket-mode: 660\n",
+		},
+		{
+			name: "command line",
+			args: []string{"--openvpn.pass-through.socket-mode=660"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			args := slices.Concat([]string{"openvpn-auth-oauth2"}, tc.args)
+			if tc.configFile != "" {
+				configFile, err := os.CreateTemp(t.TempDir(), "openvpn-auth-oauth2-*")
+				require.NoError(t, err)
+
+				_, err = configFile.WriteString(tc.configFile)
+				require.NoError(t, err)
+				require.NoError(t, configFile.Close())
+
+				args = append(args, "--config", configFile.Name())
+			}
+
+			_, err := config.New(args, &buf)
+
+			require.ErrorContains(t, err, "invalid file mode")
+		})
+	}
 }
 
 func TestConfigVersionFlag(t *testing.T) {
@@ -448,6 +491,16 @@ func TestConfigFlagSet(t *testing.T) {
 			func() config.Config {
 				conf := config.Defaults
 				conf.OpenVPN.CommandTimeout = 42 * time.Second
+
+				return conf
+			}(),
+		},
+		{
+			"--openvpn.pass-through.socket-mode",
+			[]string{"--openvpn.pass-through.socket-mode=0640"},
+			func() config.Config {
+				conf := config.Defaults
+				conf.OpenVPN.Passthrough.SocketMode = 0o640
 
 				return conf
 			}(),

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -73,7 +73,7 @@ var Defaults = Config{
 				Path:     "/run/openvpn-auth-oauth2/server.sock",
 				OmitHost: true,
 			}},
-			SocketMode:  660,
+			SocketMode:  0o660,
 			SocketGroup: "",
 		},
 		CommandTimeout:   10 * time.Second,

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +23,7 @@ func TestReadFromFlagAndEnvironment(t *testing.T) {
 	assert.True(t, conf.HTTP.TLS)
 	assert.False(t, conf.OAuth2.Nonce)
 	assert.Equal(t, 17*time.Second, conf.OpenVPN.CommandTimeout)
-	assert.Equal(t, uint(0o660), conf.OpenVPN.Passthrough.SocketMode)
+	assert.Equal(t, types.FileMode(0o660), conf.OpenVPN.Passthrough.SocketMode)
 }
 
 func TestReadFromFlagAndEnvironmentRejectsNonBooleanEnvironmentValues(t *testing.T) {
@@ -59,9 +60,9 @@ func TestReadFromFlagAndEnvironmentRejectsInvalidEnvironmentValues(t *testing.T)
 			value:               "verbose",
 		},
 		{
-			name:                "unsigned integer",
+			name:                "file mode",
 			environmentVariable: "OPENVPN_AUTH_OAUTH2_OPENVPN_PASS_THROUGH_SOCKET_MODE",
-			value:               "owner-read-write",
+			value:               "660",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -247,11 +247,12 @@ func (c *Config) flagSetOpenVPN(flagSet *flag.FlagSet) {
 		"The group for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix:// "+
 			"If empty, the group of the process is used.",
 	)
-	flagSet.UintVar(
+	flagSet.TextVar(
 		&c.OpenVPN.Passthrough.SocketMode,
 		"openvpn.pass-through.socket-mode",
 		c.OpenVPN.Passthrough.SocketMode,
-		"The unix file permission mode for the pass-through socket. Used only, if openvpn.pass-through.address starts with unix://",
+		"The explicit four-digit octal unix file permission mode for the pass-through socket. "+
+			"Used only, if openvpn.pass-through.address starts with unix://",
 	)
 	flagSet.BoolVar(
 		&c.OpenVPN.ReAuthentication,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -143,11 +143,11 @@ type OAuth2Refresh struct {
 }
 
 type OpenVPNPassthrough struct {
-	Address     types.URL    `json:"address"      yaml:"address"`
-	Password    types.Secret `json:"password"     yaml:"password"`
-	SocketGroup string       `json:"socket-group" yaml:"socket-group"`
-	SocketMode  uint         `json:"socket-mode"  yaml:"socket-mode"`
-	Enabled     bool         `json:"enabled"      yaml:"enabled"`
+	Address     types.URL      `json:"address"      yaml:"address"`
+	Password    types.Secret   `json:"password"     yaml:"password"`
+	SocketGroup string         `json:"socket-group" yaml:"socket-group"`
+	SocketMode  types.FileMode `json:"socket-mode"  yaml:"socket-mode"`
+	Enabled     bool           `json:"enabled"      yaml:"enabled"`
 }
 
 type Debug struct {

--- a/internal/config/types/filemode.go
+++ b/internal/config/types/filemode.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"encoding"
+	"fmt"
+	"io/fs"
+	"strconv"
+	"strings"
+)
+
+var (
+	_ encoding.TextMarshaler   = FileMode(0)
+	_ encoding.TextUnmarshaler = (*FileMode)(nil)
+)
+
+// FileMode is a Unix permission mode represented in configuration using explicit octal notation.
+type FileMode fs.FileMode
+
+// MarshalText implements the [encoding.TextMarshaler] interface.
+func (m FileMode) MarshalText() ([]byte, error) {
+	if m > FileMode(fs.ModePerm) {
+		return nil, fmt.Errorf("invalid file mode %04o: only permission bits up to 0777 are allowed", m)
+	}
+
+	return fmt.Appendf(nil, "%04o", m), nil
+}
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (m *FileMode) UnmarshalText(text []byte) error {
+	value := string(text)
+
+	var digits string
+
+	switch {
+	case len(value) == 4 && strings.HasPrefix(value, "0"):
+		digits = value[1:]
+	case len(value) == 5 && strings.HasPrefix(value, "0o"):
+		digits = value[2:]
+	default:
+		return fmt.Errorf("invalid file mode %q: use explicit octal notation such as 0660", value)
+	}
+
+	parsed, err := strconv.ParseUint(digits, 8, 9)
+	if err != nil {
+		return fmt.Errorf("invalid file mode %q: use explicit octal notation such as 0660: %w", value, err)
+	}
+
+	*m = FileMode(parsed)
+
+	return nil
+}

--- a/internal/config/types/filemode_test.go
+++ b/internal/config/types/filemode_test.go
@@ -1,0 +1,124 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileModeMarshalText(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		mode     types.FileMode
+		expected string
+		err      bool
+	}{
+		{
+			name:     "zero permissions",
+			mode:     0,
+			expected: "0000",
+		},
+		{
+			name:     "owner and group permissions",
+			mode:     0o660,
+			expected: "0660",
+		},
+		{
+			name:     "all permissions",
+			mode:     0o777,
+			expected: "0777",
+		},
+		{
+			name: "non-permission bits",
+			mode: 0o1000,
+			err:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			text, err := tc.mode.MarshalText()
+			if tc.err {
+				require.ErrorContains(t, err, "only permission bits")
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(text))
+		})
+	}
+}
+
+func TestFileModeUnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected types.FileMode
+		err      bool
+	}{
+		{
+			name:     "leading zero",
+			input:    "0660",
+			expected: 0o660,
+		},
+		{
+			name:     "octal prefix",
+			input:    "0o640",
+			expected: 0o640,
+		},
+		{
+			name:     "zero permissions",
+			input:    "0000",
+			expected: 0,
+		},
+		{
+			name:  "missing prefix",
+			input: "660",
+			err:   true,
+		},
+		{
+			name:  "decimal equivalent",
+			input: "432",
+			err:   true,
+		},
+		{
+			name:  "invalid octal digit",
+			input: "0668",
+			err:   true,
+		},
+		{
+			name:  "non-permission bits",
+			input: "01000",
+			err:   true,
+		},
+		{
+			name:  "empty",
+			input: "",
+			err:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := types.FileMode(0o600)
+
+			err := actual.UnmarshalText([]byte(tc.input))
+			if tc.err {
+				require.ErrorContains(t, err, "invalid file mode")
+				assert.Equal(t, types.FileMode(0o600), actual)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/internal/oauth2/providers/generic/oidc_internal_test.go
+++ b/internal/oauth2/providers/generic/oidc_internal_test.go
@@ -41,7 +41,6 @@ type testRevokeRelyingParty struct {
 	httpClient *http.Client
 }
 
-//nolint:revive // HttpClient is required by the upstream rp.RelyingParty interface.
-func (r testRevokeRelyingParty) HttpClient() *http.Client {
+func (r testRevokeRelyingParty) HttpClient() *http.Client { //nolint:revive // Required by rp.RelyingParty.
 	return r.httpClient
 }

--- a/internal/openvpn/passthrough.go
+++ b/internal/openvpn/passthrough.go
@@ -296,7 +296,6 @@ func (c *Client) setupUNIXSocketPermissions() error {
 		}
 	}
 
-	//nolint:gosec
 	if err := os.Chmod(c.conf.OpenVPN.Passthrough.Address.Path, os.FileMode(c.conf.OpenVPN.Passthrough.SocketMode)); err != nil {
 		return fmt.Errorf("error chmod: %w", err)
 	}

--- a/internal/openvpn/passthrough_test.go
+++ b/internal/openvpn/passthrough_test.go
@@ -123,7 +123,6 @@ func TestPassThroughFull(t *testing.T) {
 			scheme: openvpn.SchemeUnix,
 			conf: func() config.Config {
 				conf := newPassThroughTestConfig(testsuite.Secret)
-				conf.OpenVPN.Passthrough.SocketMode = 0o0600
 				conf.OpenVPN.Passthrough.SocketGroup = strconv.Itoa(os.Getgid())
 
 				return conf
@@ -218,8 +217,7 @@ func TestPassThroughFull(t *testing.T) {
 				permission, err := testsuite.GetPermissionsOfFile(tc.conf.OpenVPN.Passthrough.Address.Path)
 				require.NoError(t, err)
 
-				//nolint:gosec
-				assert.Equal(t, os.FileMode(tc.conf.OpenVPN.Passthrough.SocketMode).String(), permission)
+				assert.Equal(t, os.FileMode(0o660).String(), permission)
 			} else {
 				passThroughConn.SendMessagef(t, " quit ")
 				require.NoError(t, passThroughNetConn.Close())

--- a/packaging/etc/openvpn-auth-oauth2/config.yaml
+++ b/packaging/etc/openvpn-auth-oauth2/config.yaml
@@ -78,5 +78,5 @@
 #    enabled: false
 #    password: ""
 #    socket-group: ""
-#    socket-mode: 660
+#    socket-mode: "0660"
 #  reauthentication: true


### PR DESCRIPTION
#### What this PR does / why we need it

Replaces the raw `uint` pass-through socket mode with a dedicated configuration type that accepts explicit octal permissions only. The previous default was written as decimal `660`; when converted to `os.FileMode`, its effective permission bits were `0224` rather than the documented `0660`.

The new type:

- accepts `0NNN` and `0oNNN` notation
- limits values to permission bits from `0000` through `0777`
- renders the canonical value as `0NNN`
- preserves the previous value when parsing fails

The packaged YAML, CLI help, pass-through guide, and v2 upgrade guide now use the same representation.

#### Which issue this PR fixes

Not applicable.

#### Special notes for your reviewer

This is intentionally a breaking configuration validation change for v2. Unprefixed values such as `660` and decimal equivalents such as `432` are rejected; use `0660` instead.

The PR also moves one existing `revive` suppression inline because the current linter otherwise treats the preceding suppression as unused. This has no runtime effect.

#### Particularly user-facing changes

- `openvpn.pass-through.socket-mode` now requires explicit octal notation.
- The default socket permissions are correctly applied as `0660`.
- YAML configuration should quote the value, for example `socket-mode: "0660"`.
- The v2 upgrade guide documents the required migration.

#### Testing

- `npx --yes --package textlint --package textlint-rule-terminology textlint --rule terminology docs/Configuration.md 'docs/Management Interface pass-through.md' 'docs/Upgrade V2.md' packaging/etc/openvpn-auth-oauth2/config.yaml`
- `go test -race ./internal/config/types ./internal/config ./internal/openvpn`
- `make fmt`
- `make lint`
- `make test`

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR