### PR TITLE
docs: document the CEL validation migration for v2

### DIFF
--- a/docs/Upgrade V2.md
+++ b/docs/Upgrade V2.md
@@ -422,6 +422,16 @@ openvpn:
 
 ## Token validation
 
+Version 2 renames the general CEL validation option and its environment
+variable:
+
+| Version 1 | Version 2 |
+| --- | --- |
+| `oauth2.validate.cel` | `oauth2.validate.expression` |
+| `CONFIG_OAUTH2_VALIDATE_CEL` | `OPENVPN_AUTH_OAUTH2_OAUTH2_VALIDATE_EXPRESSION` |
+
+Update the fields used by the expression as described in [CEL context](#cel-context).
+
 Version 2 removes the following dedicated validation options:
 
 | Version 1 option | Version 2 replacement |


### PR DESCRIPTION
#### What this PR does / why we need it

Documents the version 1 to version 2 migration from `oauth2.validate.cel` to `oauth2.validate.expression`, including the corresponding environment-variable rename.

Without this entry, users following the upgrade guide can retain a key that strict version 2 configuration parsing rejects, or an environment variable that no longer configures CEL validation.

#### Which issue this PR fixes

Not applicable.

#### Special notes for your reviewer

Documentation-only change.

#### Particularly user-facing changes

- The version 2 upgrade guide now lists the old and new CEL validation keys.
- The guide now lists `CONFIG_OAUTH2_VALIDATE_CEL` and its version 2 replacement.
- The migration points readers to the renamed CEL context fields.

#### Testing

- `npx --yes --package textlint --package textlint-rule-terminology textlint --rule terminology 'docs/Upgrade V2.md'`
- `make fmt`
- `make lint`
- `make test`

All checks passed.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR