### PR TITLE
fix: route Zitadel OIDC logs through the configured logger

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -219,5 +219,3 @@ linters:
         text: "missing cases in switch of type management.ClientAuth:"
       - path: lib/
         text: 'directive `//nolint:revive // HttpClient is required by the upstream rp.RelyingParty interface.` is unused for linter "revive"'
-      - path: internal/
-        text: 'SA1019: "github.com/zitadel/logging" is deprecated'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,25 @@ dependency risk.
 
 Summarize your changes and cite relevant lines in the repository. Mention the output of the programmatic checks.
 
+Pull request titles and changelog labels are published in user-facing release
+notes. Write each title as a concise description of the user-visible change and
+start it with `feat:`, `fix:`, `docs:`, or `chore:` as required by CI. Use the
+`!` form, such as `feat!:`, when the title describes a breaking change.
+
+Before merging, apply at least one changelog label defined in
+[`.github/release.yml`](.github/release.yml):
+
+- `💥 breaking-change` for breaking changes
+- `✨ enhancement` for new functionality
+- `🐞 bug` for fixes
+- `🛠️ dependencies` for dependency updates
+- `📖 docs` for documentation
+- `chore` only for changes that should be excluded from the user-facing
+  changelog
+
+Add `💥 breaking-change` whenever a change is breaking, even if another label
+also applies.
+
 ## Documentation
 
 If you write documentation, please respect the [textlint-rule-terminology](https://github.com/sapegin/textlint-rule-terminology) rule.

--- a/cmd/openvpn-auth-oauth2/root.go
+++ b/cmd/openvpn-auth-oauth2/root.go
@@ -179,6 +179,9 @@ func initializeConfigAndLogger(args []string, stdout io.Writer) (*config.Config,
 		return nil, nil, ReturnCodeError
 	}
 
+	// Use the configured logger for dependencies that log through package-level slog functions.
+	slog.SetDefault(logger)
+
 	return conf, logger, ReturnCodeNoError
 }
 

--- a/cmd/openvpn-auth-oauth2/root_test.go
+++ b/cmd/openvpn-auth-oauth2/root_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 
@@ -123,4 +124,37 @@ func TestExecuteConfigInvalid(t *testing.T) {
 			assert.Contains(t, output, tc.err)
 		})
 	}
+}
+
+//nolint:paralleltest // slog.SetDefault changes process-wide state.
+func TestInitializeConfigAndLoggerSetsDefault(t *testing.T) {
+	previousLogger := slog.Default()
+
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	args := []string{
+		"openvpn-auth-oauth2",
+		"--config=../../config.example.yaml",
+		"--log.format=json",
+		"--log.level=debug",
+		"--http.secret=" + testsuite.Secret,
+		"--http.listen=127.0.0.1:0",
+	}
+
+	firstOutput := testlogger.New()
+	_, firstLogger, returnCode := initializeConfigAndLogger(args, firstOutput)
+	require.Equal(t, ReturnCodeNoError, returnCode, firstOutput.String())
+	require.Same(t, firstLogger, slog.Default())
+
+	secondOutput := testlogger.New()
+	_, secondLogger, returnCode := initializeConfigAndLogger(args, secondOutput)
+	require.Equal(t, ReturnCodeNoError, returnCode, secondOutput.String())
+	require.Same(t, secondLogger, slog.Default())
+
+	slog.Debug("default logger reconfigured") //nolint:sloglint // Verify package-level logging uses the reconfigured default.
+
+	assert.NotContains(t, firstOutput.String(), "default logger reconfigured")
+	assert.Contains(t, secondOutput.String(), "default logger reconfigured")
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/moby/moby/client v0.5.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.43.0
-	github.com/zitadel/logging v0.7.0
 	github.com/zitadel/oidc/v3 v3.48.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/tklauser/numcpus v0.12.0 h1:NR85qdvHA9pFse3x3weVZ0r0ST8R6l5RHbZrlRaqo
 github.com/tklauser/numcpus v0.12.0/go.mod h1:ABHeXzJnr/qqwguhClkZKT1/8VABcYrsyUiUGobwWJg=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zitadel/logging v0.7.0 h1:eugftwMM95Wgqwftsvj81isL0JK/hoScVqp/7iA2adQ=
-github.com/zitadel/logging v0.7.0/go.mod h1:9A6h9feBF/3u0IhA4uffdzSDY7mBaf7RE78H5sFMINQ=
 github.com/zitadel/oidc/v3 v3.48.0 h1:bJmwMyBXeeC5y+i/tx1k7Lq+eLMYrPrVCNsB5fbujtA=
 github.com/zitadel/oidc/v3 v3.48.0/go.mod h1:HwoguOGo0eem0RK5Gb+P6Q4aQLVinJ9LhomlVEA57ck=
 github.com/zitadel/schema v1.3.2 h1:gfJvt7dOMfTmxzhscZ9KkapKo3Nei3B6cAxjav+lyjI=
@@ -177,8 +175,6 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=

--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
-	"github.com/zitadel/logging"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 )
 
@@ -113,8 +112,6 @@ func (c *Client) OAuth2Callback() http.Handler {
 		}
 
 		logger := c.createSessionLoggerWithState(oAuth2State)
-
-		ctx = logging.ToContext(ctx, logger)
 
 		clientID := c.getClientID(oAuth2State)
 

--- a/internal/oauth2/provider.go
+++ b/internal/oauth2/provider.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/crypto"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/tokenstorage"
-	"github.com/zitadel/logging"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"golang.org/x/oauth2"
@@ -99,7 +98,7 @@ func newOIDCRelyingParty(
 	}
 
 	replyingParty, err := rp.NewRelyingPartyOIDC(
-		logging.ToContext(ctx, logger),
+		ctx,
 		conf.OAuth2.Issuer.String(),
 		conf.OAuth2.Client.ID,
 		conf.OAuth2.Client.Secret.String(),
@@ -174,12 +173,11 @@ func (c *Client) getRelyingPartyOptions(httpClient *http.Client) []rp.Option {
 		}))
 	}
 
-	options := make([]rp.Option, 0, 10)
+	options := make([]rp.Option, 0, 9)
 	options = append(
 		options,
 		rp.WithAuthStyle(c.conf.OAuth2.AuthStyle.AuthStyle()),
 		rp.WithSigningAlgsFromDiscovery(),
-		rp.WithLogger(c.logger),
 		rp.WithCookieHandler(cookieHandler),
 		rp.WithVerifierOpts(verifierOpts...),
 		rp.WithHTTPClient(httpClient),

--- a/internal/oauth2/providers/generic/oidc.go
+++ b/internal/oauth2/providers/generic/oidc.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
-	"github.com/zitadel/logging"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
@@ -30,9 +28,7 @@ func (p Provider) GetRefreshToken(tokens *idtoken.IDToken) (string, error) {
 }
 
 // Refresh initiates a non-interactive authentication against the sso provider.
-func (p Provider) Refresh(ctx context.Context, logger *slog.Logger, relyingParty rp.RelyingParty, refreshToken string) (*idtoken.IDToken, error) {
-	ctx = logging.ToContext(ctx, logger)
-
+func (p Provider) Refresh(ctx context.Context, relyingParty rp.RelyingParty, refreshToken string) (*idtoken.IDToken, error) {
 	// Apply refresh nonce control based on configuration
 	if p.Conf.OAuth2.RefreshNonce == config.OAuth2RefreshNonceEmpty {
 		ctx = context.WithValue(ctx, types.CtxNonce{}, "")
@@ -60,9 +56,7 @@ func (p Provider) Refresh(ctx context.Context, logger *slog.Logger, relyingParty
 }
 
 // RevokeRefreshToken revokes a refresh token when the relying party supports token revocation.
-func (p Provider) RevokeRefreshToken(ctx context.Context, logger *slog.Logger, relyingParty rp.RelyingParty, refreshToken string) error {
-	ctx = logging.ToContext(ctx, logger)
-
+func (p Provider) RevokeRefreshToken(ctx context.Context, relyingParty rp.RelyingParty, refreshToken string) error {
 	err := rp.RevokeToken(ctx, revokeHTTPClientRelyingParty{RelyingParty: relyingParty}, refreshToken, "refresh_token")
 	if err != nil && !errors.Is(err, rp.ErrRelyingPartyNotSupportRevokeCaller) {
 		return fmt.Errorf("error revoke refresh token: %w", err)

--- a/internal/oauth2/providers/github/oidc.go
+++ b/internal/oauth2/providers/github/oidc.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
@@ -22,7 +21,7 @@ func (p Provider) GetRefreshToken(tokens *idtoken.IDToken) (string, error) {
 
 // Refresh use the [oauth2.Token.AccessToken] from initial authentication and call the REST API if the user is still present
 // inside the required groups.
-func (p Provider) Refresh(_ context.Context, _ *slog.Logger, _ rp.RelyingParty, refreshToken string) (*idtoken.IDToken, error) {
+func (p Provider) Refresh(_ context.Context, _ rp.RelyingParty, refreshToken string) (*idtoken.IDToken, error) {
 	return &idtoken.IDToken{
 		Token:         &gooauth2.Token{AccessToken: refreshToken},
 		IDTokenClaims: &idtoken.Claims{},
@@ -30,7 +29,7 @@ func (p Provider) Refresh(_ context.Context, _ *slog.Logger, _ rp.RelyingParty, 
 }
 
 // RevokeRefreshToken is a no-op because GitHub OAuth apps do not support token revocation here.
-func (p Provider) RevokeRefreshToken(_ context.Context, _ *slog.Logger, _ rp.RelyingParty, _ string) error {
+func (p Provider) RevokeRefreshToken(_ context.Context, _ rp.RelyingParty, _ string) error {
 	// GitHub doesn't support revoke token
 	return nil
 }

--- a/internal/oauth2/providers/github/oidc_test.go
+++ b/internal/oauth2/providers/github/oidc_test.go
@@ -1,7 +1,6 @@
 package github_test
 
 import (
-	"log/slog"
 	"testing"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2"
@@ -65,7 +64,7 @@ func TestRefresh(t *testing.T) {
 
 	var provider github.Provider
 
-	tokens, err := provider.Refresh(t.Context(), slog.New(slog.DiscardHandler), nil, "github-access-token")
+	tokens, err := provider.Refresh(t.Context(), nil, "github-access-token")
 
 	require.NoError(t, err)
 	require.Equal(t, "github-access-token", tokens.AccessToken)
@@ -77,5 +76,5 @@ func TestRevokeRefreshToken(t *testing.T) {
 
 	var provider github.Provider
 
-	require.NoError(t, provider.RevokeRefreshToken(t.Context(), slog.New(slog.DiscardHandler), nil, "github-access-token"))
+	require.NoError(t, provider.RevokeRefreshToken(t.Context(), nil, "github-access-token"))
 }

--- a/internal/oauth2/providers/google/oidc.go
+++ b/internal/oauth2/providers/google/oidc.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
@@ -14,11 +13,11 @@ func (p Provider) GetRefreshToken(tokens *idtoken.IDToken) (string, error) {
 }
 
 // Refresh delegates refresh-token authentication to the embedded generic provider.
-func (p Provider) Refresh(ctx context.Context, logger *slog.Logger, relyingParty rp.RelyingParty, refreshToken string) (*idtoken.IDToken, error) {
-	return p.Provider.Refresh(ctx, logger, relyingParty, refreshToken) //nolint:wrapcheck
+func (p Provider) Refresh(ctx context.Context, relyingParty rp.RelyingParty, refreshToken string) (*idtoken.IDToken, error) {
+	return p.Provider.Refresh(ctx, relyingParty, refreshToken) //nolint:wrapcheck
 }
 
 // RevokeRefreshToken delegates refresh token revocation to the embedded generic provider.
-func (p Provider) RevokeRefreshToken(ctx context.Context, logger *slog.Logger, relyingParty rp.RelyingParty, refreshToken string) error {
-	return p.Provider.RevokeRefreshToken(ctx, logger, relyingParty, refreshToken) //nolint:wrapcheck
+func (p Provider) RevokeRefreshToken(ctx context.Context, relyingParty rp.RelyingParty, refreshToken string) error {
+	return p.Provider.RevokeRefreshToken(ctx, relyingParty, refreshToken) //nolint:wrapcheck
 }

--- a/internal/oauth2/refresh.go
+++ b/internal/oauth2/refresh.go
@@ -203,7 +203,7 @@ func (c *Client) withRefreshNonce(ctx context.Context, clientID string) context.
 func (c *Client) refreshTokens(ctx context.Context, logger *slog.Logger, refreshToken string) (*idtoken.IDToken, error) {
 	logger.LogAttrs(ctx, slog.LevelInfo, "initiate non-interactive authentication via refresh token")
 
-	tokens, err := c.provider.Refresh(ctx, logger, c.relyingParty, refreshToken)
+	tokens, err := c.provider.Refresh(ctx, c.relyingParty, refreshToken)
 	if err != nil {
 		return nil, fmt.Errorf("error from non-interactive authentication via refresh token: %w", err)
 	}
@@ -358,7 +358,7 @@ func (c *Client) ClientDisconnect(ctx context.Context, logger *slog.Logger, clie
 
 	logger.LogAttrs(ctx, slog.LevelDebug, "revoke refresh token")
 
-	if err = c.provider.RevokeRefreshToken(ctx, logger, c.relyingParty, refreshToken); err != nil {
+	if err = c.provider.RevokeRefreshToken(ctx, c.relyingParty, refreshToken); err != nil {
 		logger.LogAttrs(ctx, slog.LevelWarn, err.Error())
 	}
 }

--- a/internal/oauth2/types.go
+++ b/internal/oauth2/types.go
@@ -36,8 +36,8 @@ type Provider interface {
 	GetUser(ctx context.Context, logger *slog.Logger, tokens *idtoken.IDToken, userinfo *types.UserInfo) (types.UserInfo, error)
 
 	// Refresh initiates a non-interactive authentication against the sso provider.
-	Refresh(ctx context.Context, logger *slog.Logger, relyingParty rp.RelyingParty, refreshToken string) (*idtoken.IDToken, error)
-	RevokeRefreshToken(ctx context.Context, logger *slog.Logger, relyingParty rp.RelyingParty, refreshToken string) error
+	Refresh(ctx context.Context, relyingParty rp.RelyingParty, refreshToken string) (*idtoken.IDToken, error)
+	RevokeRefreshToken(ctx context.Context, relyingParty rp.RelyingParty, refreshToken string) error
 }
 
 // clientConfigToken is used to store additional information on the client side.

--- a/internal/test/testsuite/testsuite.go
+++ b/internal/test/testsuite/testsuite.go
@@ -153,11 +153,7 @@ func (s *Suite) SetupOIDCServer(tb testing.TB, clientListener net.Listener, opCo
 		}
 	}
 
-	opOpts := make([]op.Option, 0, 2)
-	opOpts = append(opOpts, op.WithAllowInsecure())
-	opOpts = append(opOpts, op.WithLogger(s.logger.Logger()))
-
-	opProvider, err := op.NewProvider(opConfig, opStorage, op.IssuerFromHost(""), opOpts...)
+	opProvider, err := op.NewProvider(opConfig, opStorage, op.IssuerFromHost(""), op.WithAllowInsecure())
 	require.NoError(tb, err, s.Logs())
 
 	httpHandler := http.NewServeMux()


### PR DESCRIPTION
#### What this PR does / why we need it

Routes package-level `slog` records from Zitadel OIDC through the application's configured logger. Zitadel OIDC v3.48.0 switched to the process-wide `slog` default, so the previous context logger and `WithLogger` options no longer controlled library logging.

The configured logger is installed after successful startup configuration and replaced after every successful configuration reload. Obsolete logger options and context bridges are removed together with the direct `github.com/zitadel/logging` dependency. Internal refresh-provider methods no longer carry unused logger parameters.

The contributor instructions now also state that pull request titles and changelog labels are user-facing release-note inputs.

#### Which issue this PR fixes

Not applicable.

#### Special notes for your reviewer

The default-logger test is intentionally nonparallel because `slog.SetDefault` changes process-wide state.

#### Particularly user-facing changes

- Zitadel OIDC logs now follow the configured log format, level, and output.
- Contributor guidance documents the pull request title and label requirements used by generated changelogs.

#### Testing

- `make fmt`
- `make lint`
- `make test`
- `npx --yes --package textlint --package textlint-rule-terminology textlint --rule terminology AGENTS.md`

All checks passed.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
