### PR TITLE
feat!: validate CEL context fields at startup

### DIFF
--- a/docs/CEL Language Features.md
+++ b/docs/CEL Language Features.md
@@ -51,10 +51,9 @@ optional claim.
 
 Provider data is normalized before CEL runs. For a generic OIDC provider,
 `user.groups` comes from `oauth2.groups-claim` and `user.roles` comes from the
-`roles` claim. For GitHub, organizations populate `user.groups` when that field
-is used, and teams always populate `user.roles` in `org:slug` format. Google
-group validation populates `user.groups` with the configured groups that match
-the user.
+`roles` claim. For GitHub, organizations always populate `user.groups`, and
+teams always populate `user.roles` in `org:slug` format. Google group validation
+populates `user.groups` with the configured groups that match the user.
 
 During `oauth2.openvpn-username`, `user.username` is the provider's username
 candidate, such as `preferred_username` from an ID token or UserInfo response,

--- a/docs/CEL Language Features.md
+++ b/docs/CEL Language Features.md
@@ -39,6 +39,16 @@ The same namespaced context is available to `oauth2.openvpn-username`,
 | `user.groups` | `list<string>` | Provider-independent list of groups |
 | `user.roles` | `list<string>` | Provider-independent list of roles |
 
+`auth`, `openvpn`, `token`, and `user` are typed objects. Use the field names
+listed above with dot notation. openvpn-auth-oauth2 validates these names and
+their types when it loads the configuration, so an unknown field prevents
+startup instead of failing during authentication. Every listed field is
+present; unavailable strings and lists use empty values.
+
+`token.claims` remains a `map<string, dynamic>` because OAuth2 providers can
+return arbitrary claims. Use `has(token.claims.department)` before reading an
+optional claim.
+
 Provider data is normalized before CEL runs. For a generic OIDC provider,
 `user.groups` comes from `oauth2.groups-claim` and `user.roles` comes from the
 `roles` claim. For GitHub, organizations populate `user.groups` and teams
@@ -213,7 +223,8 @@ expression: 'has(token.claims.department) && token.claims.department == "enginee
 
 ### Invalid Expressions
 
-If your CEL expression has syntax errors, openvpn-auth-oauth2 will fail to start and log an error message indicating the compilation failure.
+If a CEL expression has syntax errors, unknown context fields, or incompatible
+types, openvpn-auth-oauth2 fails to start and logs the compilation error.
 
 ### Non-Boolean Results
 
@@ -229,7 +240,7 @@ expression: 'openvpn.commonName != ""'
 
 ## Best Practices
 
-1. **Always use `has()` to check for optional claims** before accessing them to avoid validation failures
+1. **Always use `has()` to check for optional token claims** before accessing them to avoid validation failures
 2. **Keep expressions simple and readable** - complex logic can be hard to debug
 3. **Test your CEL expressions** with different token scenarios during development
 4. **Log validation failures** to help troubleshoot issues

--- a/docs/CEL Language Features.md
+++ b/docs/CEL Language Features.md
@@ -51,8 +51,8 @@ optional claim.
 
 Provider data is normalized before CEL runs. For a generic OIDC provider,
 `user.groups` comes from `oauth2.groups-claim` and `user.roles` comes from the
-`roles` claim. For GitHub, organizations populate `user.groups` and teams
-populate `user.roles` in `org:slug` format when those fields are used. Google
+`roles` claim. For GitHub, organizations populate `user.groups` when that field
+is used, and teams always populate `user.roles` in `org:slug` format. Google
 group validation populates `user.groups` with the configured groups that match
 the user.
 

--- a/docs/Client token validation.md
+++ b/docs/Client token validation.md
@@ -52,6 +52,11 @@ The following variables are available in your CEL expressions:
 | `user.groups` | `list<string>` | The normalized groups |
 | `user.roles` | `list<string>` | The normalized roles |
 
+The `auth`, `openvpn`, `token`, and `user` variables are typed objects. Unknown
+fields and incompatible operations are rejected when the configuration loads.
+Only `token.claims` remains a dynamic map because its keys depend on the OAuth2
+provider.
+
 Prefer `user.*` for rules that should work with generic OIDC, UserInfo, GitHub,
 and refresh authentication. Use `token.claims.*` for provider-specific claims.
 See [CEL Language Features](CEL%20Language%20Features.md) for the normalization

--- a/docs/Upgrade V2.md
+++ b/docs/Upgrade V2.md
@@ -542,8 +542,9 @@ oauth2:
 ```
 
 For GitHub provider configurations, team validation is also migrated to CEL.
-The GitHub provider fetches teams from the `/user/teams` API and exposes them
-through `user.roles` in the same `org:slug` format used by version 1:
+The GitHub provider always fetches organizations from `/user/orgs` and teams
+from `/user/teams`. It exposes organizations through `user.groups`. Teams are
+available through `user.roles` in the same `org:slug` format used by version 1:
 
 ```yaml
 # Version 1

--- a/docs/Upgrade V2.md
+++ b/docs/Upgrade V2.md
@@ -193,6 +193,12 @@ client config resolution. Update every CEL expression to use the new names:
 | `oauth2TokenClaims` | `token.claims` |
 | `username` | `user.username` |
 
+The four context namespaces are typed objects in version 2. Field names and
+types are checked when the configuration loads. Unknown fixed fields now
+prevent startup instead of producing an evaluation error during
+authentication. `token.claims` remains a dynamic map, so use
+`has(token.claims.department)` for optional claims.
+
 Version 2 also exposes normalized `user.subject`, `user.email`, `user.groups`,
 and `user.roles` fields. Prefer these fields when an expression should work
 across generic OIDC, UserInfo, GitHub, and refresh authentication. Raw

--- a/internal/oauth2/cel.go
+++ b/internal/oauth2/cel.go
@@ -21,10 +21,11 @@ const (
 // newCELEnvironment returns the common CEL environment used by all configurable expressions.
 func newCELEnvironment() (*cel.Env, error) {
 	env, err := cel.NewEnv(
-		cel.VariableWithDoc("auth", cel.MapType(cel.StringType, cel.StringType), "Authentication context"),
-		cel.VariableWithDoc("openvpn", cel.MapType(cel.StringType, cel.StringType), "OpenVPN session context"),
-		cel.VariableWithDoc("token", cel.MapType(cel.StringType, cel.DynType), "OAuth2 token context"),
-		cel.VariableWithDoc("user", cel.MapType(cel.StringType, cel.DynType), "Normalized user context"),
+		celContextTypes(),
+		cel.VariableWithDoc("auth", cel.ObjectType(celAuthContextTypeName), "Authentication context"),
+		cel.VariableWithDoc("openvpn", cel.ObjectType(celOpenVPNContextTypeName), "OpenVPN session context"),
+		cel.VariableWithDoc("token", cel.ObjectType(celTokenContextTypeName), "OAuth2 token context"),
+		cel.VariableWithDoc("user", cel.ObjectType(celUserContextTypeName), "Normalized user context"),
 		ext.Strings(ext.StringsVersion(5)),
 		ext.Lists(ext.ListsVersion(4)),
 	)
@@ -172,7 +173,8 @@ func newCELActivation(
 	tokens *idtoken.IDToken,
 	userInfo types.UserInfo,
 ) map[string]any {
-	claims := make(map[string]any)
+	var claims map[string]any
+
 	tokenIP := ""
 
 	if tokens != nil && tokens.IDTokenClaims != nil {
@@ -194,24 +196,24 @@ func newCELActivation(
 	}
 
 	return map[string]any{
-		"auth": map[string]string{
-			"mode": string(authMode),
+		"auth": celAuthContext{
+			mode: string(authMode),
 		},
-		"openvpn": map[string]string{
-			"commonName":   session.Client.CommonName,
-			"ip":           session.IPAddr,
-			"sessionState": session.SessionState,
+		"openvpn": celOpenVPNContext{
+			commonName:   session.Client.CommonName,
+			ip:           session.IPAddr,
+			sessionState: session.SessionState,
 		},
-		"token": map[string]any{
-			"claims": claims,
-			"ip":     tokenIP,
+		"token": celTokenContext{
+			claims: claims,
+			ip:     tokenIP,
 		},
-		"user": map[string]any{
-			"email":    userInfo.Email,
-			"groups":   groups,
-			"roles":    roles,
-			"subject":  userInfo.Subject,
-			"username": userInfo.Username,
+		"user": celUserContext{
+			email:    userInfo.Email,
+			groups:   groups,
+			roles:    roles,
+			subject:  userInfo.Subject,
+			username: userInfo.Username,
 		},
 	}
 }

--- a/internal/oauth2/cel_context.go
+++ b/internal/oauth2/cel_context.go
@@ -1,0 +1,233 @@
+package oauth2
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/google/cel-go/cel"
+	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+const (
+	celAuthContextTypeName    = "openvpn_auth_oauth2.AuthContext"
+	celOpenVPNContextTypeName = "openvpn_auth_oauth2.OpenVPNContext"
+	celTokenContextTypeName   = "openvpn_auth_oauth2.TokenContext"
+	celUserContextTypeName    = "openvpn_auth_oauth2.UserContext"
+)
+
+type celContextSchema struct {
+	fields     map[string]*celtypes.FieldType
+	fieldNames []string
+}
+
+type celContextField struct {
+	fieldType *celtypes.FieldType
+	name      string
+}
+
+type celAuthContext struct {
+	mode string
+}
+
+type celOpenVPNContext struct {
+	commonName   string
+	ip           string
+	sessionState string
+}
+
+type celTokenContext struct {
+	claims map[string]any
+	ip     string
+}
+
+type celUserContext struct {
+	email    string
+	subject  string
+	username string
+	groups   []string
+	roles    []string
+}
+
+func newCELContextSchemas() map[string]celContextSchema {
+	return map[string]celContextSchema{
+		celAuthContextTypeName: newCELContextSchema(
+			newCELContextField("mode", cel.StringType, func(context celAuthContext) string {
+				return context.mode
+			}),
+		),
+		celOpenVPNContextTypeName: newCELContextSchema(
+			newCELContextField("commonName", cel.StringType, func(context celOpenVPNContext) string {
+				return context.commonName
+			}),
+			newCELContextField("ip", cel.StringType, func(context celOpenVPNContext) string {
+				return context.ip
+			}),
+			newCELContextField("sessionState", cel.StringType, func(context celOpenVPNContext) string {
+				return context.sessionState
+			}),
+		),
+		celTokenContextTypeName: newCELContextSchema(
+			newCELContextField("claims", cel.MapType(cel.StringType, cel.DynType), func(context celTokenContext) map[string]any {
+				return context.claims
+			}),
+			newCELContextField("ip", cel.StringType, func(context celTokenContext) string {
+				return context.ip
+			}),
+		),
+		celUserContextTypeName: newCELContextSchema(
+			newCELContextField("email", cel.StringType, func(context celUserContext) string {
+				return context.email
+			}),
+			newCELContextField("groups", cel.ListType(cel.StringType), func(context celUserContext) []string {
+				return context.groups
+			}),
+			newCELContextField("roles", cel.ListType(cel.StringType), func(context celUserContext) []string {
+				return context.roles
+			}),
+			newCELContextField("subject", cel.StringType, func(context celUserContext) string {
+				return context.subject
+			}),
+			newCELContextField("username", cel.StringType, func(context celUserContext) string {
+				return context.username
+			}),
+		),
+	}
+}
+
+// celContextTypes registers the fixed fields exposed by the CEL activation.
+// Explicit field getters avoid reflection and report every stable field as present,
+// matching the previous map-key presence semantics for has().
+func celContextTypes() cel.EnvOption {
+	return func(env *cel.Env) (*cel.Env, error) {
+		contextAdapter := &celContextTypeAdapter{Adapter: env.CELTypeAdapter()}
+		contextProvider := &celContextTypeProvider{
+			Provider: env.CELTypeProvider(),
+			schemas:  newCELContextSchemas(),
+		}
+
+		env, err := cel.CustomTypeAdapter(contextAdapter)(env)
+		if err != nil {
+			return nil, fmt.Errorf("register cel context type adapter: %w", err)
+		}
+
+		env, err = cel.CustomTypeProvider(contextProvider)(env)
+		if err != nil {
+			return nil, fmt.Errorf("register cel context type provider: %w", err)
+		}
+
+		return env, nil
+	}
+}
+
+type celContextTypeAdapter struct {
+	celtypes.Adapter
+}
+
+func (a *celContextTypeAdapter) NativeToValue(value any) ref.Val {
+	switch context := value.(type) {
+	case celAuthContext:
+		return celtypes.NewStringStringMap(a.Adapter, map[string]string{
+			"mode": context.mode,
+		})
+	case celOpenVPNContext:
+		return celtypes.NewStringStringMap(a.Adapter, map[string]string{
+			"commonName":   context.commonName,
+			"ip":           context.ip,
+			"sessionState": context.sessionState,
+		})
+	case celTokenContext:
+		return celtypes.NewStringInterfaceMap(a.Adapter, map[string]any{
+			"claims": context.claims,
+			"ip":     context.ip,
+		})
+	case celUserContext:
+		return celtypes.NewStringInterfaceMap(a.Adapter, map[string]any{
+			"email":    context.email,
+			"groups":   context.groups,
+			"roles":    context.roles,
+			"subject":  context.subject,
+			"username": context.username,
+		})
+	default:
+		return a.Adapter.NativeToValue(value)
+	}
+}
+
+type celContextTypeProvider struct {
+	celtypes.Provider
+
+	schemas map[string]celContextSchema
+}
+
+func (p *celContextTypeProvider) FindStructType(structType string) (*celtypes.Type, bool) {
+	if _, ok := p.schemas[structType]; ok {
+		return celtypes.NewTypeTypeWithParam(celtypes.NewObjectType(structType)), true
+	}
+
+	return p.Provider.FindStructType(structType)
+}
+
+func (p *celContextTypeProvider) FindStructFieldNames(structType string) ([]string, bool) {
+	schema, ok := p.schemas[structType]
+	if ok {
+		return slices.Clone(schema.fieldNames), true
+	}
+
+	return p.Provider.FindStructFieldNames(structType)
+}
+
+func (p *celContextTypeProvider) FindStructFieldType(structType, fieldName string) (*celtypes.FieldType, bool) {
+	schema, ok := p.schemas[structType]
+	if ok {
+		fieldType, found := schema.fields[fieldName]
+
+		return fieldType, found
+	}
+
+	return p.Provider.FindStructFieldType(structType, fieldName)
+}
+
+func (p *celContextTypeProvider) NewValue(structType string, fields map[string]ref.Val) ref.Val {
+	if _, ok := p.schemas[structType]; ok {
+		return celtypes.NewErr("%s is a read-only context type", structType)
+	}
+
+	return p.Provider.NewValue(structType, fields)
+}
+
+func newCELContextSchema(fields ...celContextField) celContextSchema {
+	schema := celContextSchema{
+		fields:     make(map[string]*celtypes.FieldType, len(fields)),
+		fieldNames: make([]string, 0, len(fields)),
+	}
+
+	for _, field := range fields {
+		schema.fields[field.name] = field.fieldType
+		schema.fieldNames = append(schema.fieldNames, field.name)
+	}
+
+	return schema
+}
+
+func newCELContextField[Context, Value any](fieldName string, fieldType *cel.Type, getValue func(Context) Value) celContextField {
+	return celContextField{
+		name: fieldName,
+		fieldType: &celtypes.FieldType{
+			Type: fieldType,
+			IsSet: func(target any) bool {
+				_, ok := target.(Context)
+
+				return ok
+			},
+			GetFrom: func(target any) (any, error) {
+				context, ok := target.(Context)
+				if !ok {
+					return nil, fmt.Errorf("invalid cel context for field %q: %T", fieldName, target)
+				}
+
+				return getValue(context), nil
+			},
+		},
+	}
+}

--- a/internal/oauth2/cel_context.go
+++ b/internal/oauth2/cel_context.go
@@ -2,11 +2,13 @@ package oauth2
 
 import (
 	"fmt"
+	"reflect"
 	"slices"
 
 	"github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
 )
 
 const (
@@ -17,7 +19,9 @@ const (
 )
 
 type celContextSchema struct {
+	construct  func(map[string]ref.Val) (any, error)
 	fields     map[string]*celtypes.FieldType
+	objectType *celtypes.Type
 	fieldNames []string
 }
 
@@ -49,14 +53,18 @@ type celUserContext struct {
 	roles    []string
 }
 
-func newCELContextSchemas() map[string]celContextSchema {
-	return map[string]celContextSchema{
+func newCELContextSchemas() map[string]*celContextSchema {
+	return map[string]*celContextSchema{
 		celAuthContextTypeName: newCELContextSchema(
+			celAuthContextTypeName,
+			newCELAuthContext,
 			newCELContextField("mode", cel.StringType, func(context celAuthContext) string {
 				return context.mode
 			}),
 		),
 		celOpenVPNContextTypeName: newCELContextSchema(
+			celOpenVPNContextTypeName,
+			newCELOpenVPNContext,
 			newCELContextField("commonName", cel.StringType, func(context celOpenVPNContext) string {
 				return context.commonName
 			}),
@@ -68,6 +76,8 @@ func newCELContextSchemas() map[string]celContextSchema {
 			}),
 		),
 		celTokenContextTypeName: newCELContextSchema(
+			celTokenContextTypeName,
+			newCELTokenContext,
 			newCELContextField("claims", cel.MapType(cel.StringType, cel.DynType), func(context celTokenContext) map[string]any {
 				return context.claims
 			}),
@@ -76,6 +86,8 @@ func newCELContextSchemas() map[string]celContextSchema {
 			}),
 		),
 		celUserContextTypeName: newCELContextSchema(
+			celUserContextTypeName,
+			newCELUserContext,
 			newCELContextField("email", cel.StringType, func(context celUserContext) string {
 				return context.email
 			}),
@@ -100,10 +112,15 @@ func newCELContextSchemas() map[string]celContextSchema {
 // matching the previous map-key presence semantics for has().
 func celContextTypes() cel.EnvOption {
 	return func(env *cel.Env) (*cel.Env, error) {
-		contextAdapter := &celContextTypeAdapter{Adapter: env.CELTypeAdapter()}
+		schemas := newCELContextSchemas()
+		contextAdapter := &celContextTypeAdapter{
+			Adapter: env.CELTypeAdapter(),
+			schemas: schemas,
+		}
 		contextProvider := &celContextTypeProvider{
 			Provider: env.CELTypeProvider(),
-			schemas:  newCELContextSchemas(),
+			adapter:  contextAdapter,
+			schemas:  schemas,
 		}
 
 		env, err := cel.CustomTypeAdapter(contextAdapter)(env)
@@ -122,47 +139,151 @@ func celContextTypes() cel.EnvOption {
 
 type celContextTypeAdapter struct {
 	celtypes.Adapter
+
+	schemas map[string]*celContextSchema
 }
 
 func (a *celContextTypeAdapter) NativeToValue(value any) ref.Val {
-	switch context := value.(type) {
+	switch value.(type) {
 	case celAuthContext:
-		return celtypes.NewStringStringMap(a.Adapter, map[string]string{
-			"mode": context.mode,
-		})
+		return a.newContextValue(celAuthContextTypeName, value)
 	case celOpenVPNContext:
-		return celtypes.NewStringStringMap(a.Adapter, map[string]string{
-			"commonName":   context.commonName,
-			"ip":           context.ip,
-			"sessionState": context.sessionState,
-		})
+		return a.newContextValue(celOpenVPNContextTypeName, value)
 	case celTokenContext:
-		return celtypes.NewStringInterfaceMap(a.Adapter, map[string]any{
-			"claims": context.claims,
-			"ip":     context.ip,
-		})
+		return a.newContextValue(celTokenContextTypeName, value)
 	case celUserContext:
-		return celtypes.NewStringInterfaceMap(a.Adapter, map[string]any{
-			"email":    context.email,
-			"groups":   context.groups,
-			"roles":    context.roles,
-			"subject":  context.subject,
-			"username": context.username,
-		})
+		return a.newContextValue(celUserContextTypeName, value)
 	default:
 		return a.Adapter.NativeToValue(value)
 	}
 }
 
+func (a *celContextTypeAdapter) newContextValue(typeName string, value any) ref.Val {
+	schema, ok := a.schemas[typeName]
+	if !ok {
+		return celtypes.NewErr("unknown cel context type: %s", typeName)
+	}
+
+	return &celContextValue{
+		adapter: a,
+		schema:  schema,
+		value:   value,
+	}
+}
+
+type celContextValue struct {
+	adapter celtypes.Adapter
+	schema  *celContextSchema
+	value   any
+}
+
+var (
+	_ ref.Val            = (*celContextValue)(nil)
+	_ traits.FieldTester = (*celContextValue)(nil)
+	_ traits.Indexer     = (*celContextValue)(nil)
+)
+
+func (v *celContextValue) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	valueType := reflect.TypeOf(v.value)
+	if valueType.AssignableTo(typeDesc) {
+		return v.value, nil
+	}
+
+	if typeDesc.Kind() == reflect.Pointer && valueType.AssignableTo(typeDesc.Elem()) {
+		valuePtr := reflect.New(typeDesc.Elem())
+		valuePtr.Elem().Set(reflect.ValueOf(v.value))
+
+		return valuePtr.Interface(), nil
+	}
+
+	return nil, fmt.Errorf("type conversion error from %q to %q", v.Type(), typeDesc)
+}
+
+func (v *celContextValue) ConvertToType(typeValue ref.Type) ref.Val {
+	if typeValue == celtypes.TypeType {
+		return v.schema.objectType
+	}
+
+	if typeValue.TypeName() == v.schema.objectType.TypeName() {
+		return v
+	}
+
+	return celtypes.NewErr("type conversion error from %q to %q", v.Type(), typeValue)
+}
+
+func (v *celContextValue) Equal(other ref.Val) ref.Val {
+	otherContext, ok := other.(*celContextValue)
+	if !ok || v.schema.objectType.TypeName() != otherContext.schema.objectType.TypeName() {
+		return celtypes.False
+	}
+
+	return celtypes.Bool(reflect.DeepEqual(v.value, otherContext.value))
+}
+
+func (v *celContextValue) Get(field ref.Val) ref.Val {
+	fieldType, errValue := v.findField(field)
+	if errValue != nil {
+		return errValue
+	}
+
+	value, err := fieldType.GetFrom(v.value)
+	if err != nil {
+		return celtypes.NewErrFromString(err.Error())
+	}
+
+	return v.adapter.NativeToValue(value)
+}
+
+func (v *celContextValue) IsSet(field ref.Val) ref.Val {
+	fieldType, errValue := v.findField(field)
+	if errValue != nil {
+		return errValue
+	}
+
+	return celtypes.Bool(fieldType.IsSet(v.value))
+}
+
+func (v *celContextValue) Type() ref.Type {
+	return v.schema.objectType
+}
+
+func (v *celContextValue) Value() any {
+	return v.value
+}
+
+func (v *celContextValue) findField(field ref.Val) (*celtypes.FieldType, ref.Val) {
+	fieldName, ok := field.(celtypes.String)
+	if !ok {
+		return nil, celtypes.MaybeNoSuchOverloadErr(field)
+	}
+
+	fieldType, ok := v.schema.fields[string(fieldName)]
+	if !ok {
+		return nil, celtypes.NewErr("no such field: %s", fieldName)
+	}
+
+	return fieldType, nil
+}
+
 type celContextTypeProvider struct {
 	celtypes.Provider
 
-	schemas map[string]celContextSchema
+	adapter *celContextTypeAdapter
+	schemas map[string]*celContextSchema
+}
+
+func (p *celContextTypeProvider) FindIdent(identName string) (ref.Val, bool) {
+	schema, ok := p.schemas[identName]
+	if ok {
+		return schema.objectType, true
+	}
+
+	return p.Provider.FindIdent(identName)
 }
 
 func (p *celContextTypeProvider) FindStructType(structType string) (*celtypes.Type, bool) {
-	if _, ok := p.schemas[structType]; ok {
-		return celtypes.NewTypeTypeWithParam(celtypes.NewObjectType(structType)), true
+	if schema, ok := p.schemas[structType]; ok {
+		return celtypes.NewTypeTypeWithParam(schema.objectType), true
 	}
 
 	return p.Provider.FindStructType(structType)
@@ -189,17 +310,29 @@ func (p *celContextTypeProvider) FindStructFieldType(structType, fieldName strin
 }
 
 func (p *celContextTypeProvider) NewValue(structType string, fields map[string]ref.Val) ref.Val {
-	if _, ok := p.schemas[structType]; ok {
-		return celtypes.NewErr("%s is a read-only context type", structType)
+	schema, ok := p.schemas[structType]
+	if !ok {
+		return p.Provider.NewValue(structType, fields)
 	}
 
-	return p.Provider.NewValue(structType, fields)
+	value, err := schema.construct(fields)
+	if err != nil {
+		return celtypes.NewErr("construct %s: %v", structType, err)
+	}
+
+	return p.adapter.NativeToValue(value)
 }
 
-func newCELContextSchema(fields ...celContextField) celContextSchema {
-	schema := celContextSchema{
+func newCELContextSchema(
+	typeName string,
+	construct func(map[string]ref.Val) (any, error),
+	fields ...celContextField,
+) *celContextSchema {
+	schema := &celContextSchema{
+		construct:  construct,
 		fields:     make(map[string]*celtypes.FieldType, len(fields)),
 		fieldNames: make([]string, 0, len(fields)),
+		objectType: celtypes.NewObjectType(typeName),
 	}
 
 	for _, field := range fields {
@@ -208,6 +341,98 @@ func newCELContextSchema(fields ...celContextField) celContextSchema {
 	}
 
 	return schema
+}
+
+func newCELAuthContext(fields map[string]ref.Val) (any, error) {
+	context := celAuthContext{}
+
+	if err := setCELContextField(fields, "mode", &context.mode); err != nil {
+		return nil, err
+	}
+
+	return context, nil
+}
+
+func newCELOpenVPNContext(fields map[string]ref.Val) (any, error) {
+	context := celOpenVPNContext{}
+
+	if err := setCELContextField(fields, "commonName", &context.commonName); err != nil {
+		return nil, err
+	}
+
+	if err := setCELContextField(fields, "ip", &context.ip); err != nil {
+		return nil, err
+	}
+
+	if err := setCELContextField(fields, "sessionState", &context.sessionState); err != nil {
+		return nil, err
+	}
+
+	return context, nil
+}
+
+func newCELTokenContext(fields map[string]ref.Val) (any, error) {
+	context := celTokenContext{}
+
+	if err := setCELContextField(fields, "claims", &context.claims); err != nil {
+		return nil, err
+	}
+
+	if err := setCELContextField(fields, "ip", &context.ip); err != nil {
+		return nil, err
+	}
+
+	return context, nil
+}
+
+func newCELUserContext(fields map[string]ref.Val) (any, error) {
+	context := celUserContext{
+		groups: make([]string, 0),
+		roles:  make([]string, 0),
+	}
+
+	if err := setCELContextField(fields, "email", &context.email); err != nil {
+		return nil, err
+	}
+
+	if err := setCELContextField(fields, "groups", &context.groups); err != nil {
+		return nil, err
+	}
+
+	if err := setCELContextField(fields, "roles", &context.roles); err != nil {
+		return nil, err
+	}
+
+	if err := setCELContextField(fields, "subject", &context.subject); err != nil {
+		return nil, err
+	}
+
+	if err := setCELContextField(fields, "username", &context.username); err != nil {
+		return nil, err
+	}
+
+	return context, nil
+}
+
+func setCELContextField[Value any](fields map[string]ref.Val, fieldName string, target *Value) error {
+	value, ok := fields[fieldName]
+	if !ok {
+		return nil
+	}
+
+	nativeValue, err := value.ConvertToNative(reflect.TypeFor[Value]())
+	if err != nil {
+		return fmt.Errorf("convert field %q: %w", fieldName, err)
+	}
+
+	typedValue, ok := nativeValue.(Value)
+	if !ok {
+		return fmt.Errorf("convert field %q: expected %T, got %T", fieldName, *target, nativeValue)
+	}
+
+	*target = typedValue
+
+	return nil
 }
 
 func newCELContextField[Context, Value any](fieldName string, fieldType *cel.Type, getValue func(Context) Value) celContextField {

--- a/internal/oauth2/cel_context_test.go
+++ b/internal/oauth2/cel_context_test.go
@@ -1,0 +1,211 @@
+package oauth2 //nolint:testpackage // The CEL environment and activation are internal implementation details.
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
+	oauth2types "github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCELContextSchema(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		expression   string
+		expectedType *cel.Type
+		err          string
+	}{
+		{
+			name:         "authentication field",
+			expression:   "auth.mode",
+			expectedType: cel.StringType,
+		},
+		{
+			name:         "OpenVPN field",
+			expression:   "openvpn.commonName",
+			expectedType: cel.StringType,
+		},
+		{
+			name:         "OpenVPN IP field",
+			expression:   "openvpn.ip",
+			expectedType: cel.StringType,
+		},
+		{
+			name:         "OpenVPN session state field",
+			expression:   "openvpn.sessionState",
+			expectedType: cel.StringType,
+		},
+		{
+			name:         "token claims field",
+			expression:   "token.claims",
+			expectedType: cel.MapType(cel.StringType, cel.DynType),
+		},
+		{
+			name:         "token field",
+			expression:   "token.ip",
+			expectedType: cel.StringType,
+		},
+		{
+			name:         "dynamic token claim",
+			expression:   "token.claims.department",
+			expectedType: cel.DynType,
+		},
+		{
+			name:         "normalized user email field",
+			expression:   "user.email",
+			expectedType: cel.StringType,
+		},
+		{
+			name:         "normalized user groups field",
+			expression:   "user.groups",
+			expectedType: cel.ListType(cel.StringType),
+		},
+		{
+			name:         "normalized user roles field",
+			expression:   "user.roles",
+			expectedType: cel.ListType(cel.StringType),
+		},
+		{
+			name:         "normalized user subject field",
+			expression:   "user.subject",
+			expectedType: cel.StringType,
+		},
+		{
+			name:         "normalized user username field",
+			expression:   "user.username",
+			expectedType: cel.StringType,
+		},
+		{
+			name:       "unknown authentication field",
+			expression: "auth.unknown",
+			err:        "undefined field 'unknown'",
+		},
+		{
+			name:       "unknown OpenVPN field",
+			expression: "openvpn.unknown",
+			err:        "undefined field 'unknown'",
+		},
+		{
+			name:       "unknown token field",
+			expression: "token.unknown",
+			err:        "undefined field 'unknown'",
+		},
+		{
+			name:       "unknown user field",
+			expression: "user.unknown",
+			err:        "undefined field 'unknown'",
+		},
+		{
+			name:       "incompatible normalized user operation",
+			expression: `user.groups == "vpn-users"`,
+			err:        "found no matching overload for '_==_'",
+		},
+		{
+			name:       "map-style user access",
+			expression: `user["username"]`,
+			err:        "found no matching overload for '_[_]'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			env, err := newCELEnvironment()
+			require.NoError(t, err)
+
+			ast, issues := env.Compile(tc.expression)
+			if tc.err != "" {
+				require.ErrorContains(t, issues.Err(), tc.err)
+
+				return
+			}
+
+			require.NoError(t, issues.Err())
+			assert.True(t, ast.OutputType().IsExactType(tc.expectedType), "expected %s, got %s", tc.expectedType, ast.OutputType())
+		})
+	}
+}
+
+func TestCELContextEvaluation(t *testing.T) {
+	t.Parallel()
+
+	program, err := compileCELProgram(`
+		has(auth.mode) &&
+		has(openvpn.commonName) &&
+		has(openvpn.ip) &&
+		has(openvpn.sessionState) &&
+		has(token.claims) &&
+		has(token.ip) &&
+		has(user.email) &&
+		has(user.groups) &&
+		has(user.roles) &&
+		has(user.subject) &&
+		has(user.username) &&
+		!has(token.claims.missing) &&
+		auth == auth &&
+		openvpn == openvpn &&
+		token == token &&
+		user == user &&
+		auth.mode == "interactive" &&
+		openvpn.commonName == user.username &&
+		openvpn.ip == "192.0.2.10" &&
+		openvpn.sessionState == "authenticated" &&
+		token.claims.department == "engineering" &&
+		token.ip == "192.0.2.20" &&
+		user.email == "alice@example.com" &&
+		user.groups == ["vpn-users"] &&
+		user.roles == ["vpn-admin"] &&
+		user.subject == "user-123"
+	`, cel.BoolType)
+	require.NoError(t, err)
+
+	out, _, err := program.Eval(newCELActivation(
+		CELAuthModeInteractive,
+		state.State{
+			Client:       state.ClientIdentifier{CommonName: "alice"},
+			IPAddr:       "192.0.2.10",
+			SessionState: "authenticated",
+		},
+		&idtoken.IDToken{IDTokenClaims: &idtoken.Claims{
+			Claims: map[string]any{"department": "engineering"},
+			IPAddr: "192.0.2.20",
+		}},
+		oauth2types.UserInfo{
+			Email:    "alice@example.com",
+			Groups:   []string{"vpn-users"},
+			Roles:    []string{"vpn-admin"},
+			Subject:  "user-123",
+			Username: "alice",
+		},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, true, out.Value())
+}
+
+func TestCELContextEmptyValues(t *testing.T) {
+	t.Parallel()
+
+	program, err := compileCELProgram(`
+		has(token.claims) &&
+		has(user.groups) &&
+		has(user.roles) &&
+		size(token.claims) == 0 &&
+		token.ip == "" &&
+		user.groups == [] &&
+		user.roles == []
+	`, cel.BoolType)
+	require.NoError(t, err)
+
+	out, _, err := program.Eval(newCELActivation(
+		CELAuthModeInteractive,
+		state.State{},
+		nil,
+		oauth2types.UserInfo{},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, true, out.Value())
+}

--- a/internal/oauth2/cel_context_test.go
+++ b/internal/oauth2/cel_context_test.go
@@ -150,6 +150,15 @@ func TestCELContextEvaluation(t *testing.T) {
 		openvpn == openvpn &&
 		token == token &&
 		user == user &&
+		type(auth) == openvpn_auth_oauth2.AuthContext &&
+		type(openvpn) == openvpn_auth_oauth2.OpenVPNContext &&
+		type(token) == openvpn_auth_oauth2.TokenContext &&
+		type(user) == openvpn_auth_oauth2.UserContext &&
+		[auth][0].mode == "interactive" &&
+		[openvpn][0].commonName == "alice" &&
+		[token][0].claims.department == "engineering" &&
+		[user].map(context, context.username) == ["alice"] &&
+		dyn(user).username == "alice" &&
 		auth.mode == "interactive" &&
 		openvpn.commonName == user.username &&
 		openvpn.ip == "192.0.2.10" &&
@@ -182,6 +191,38 @@ func TestCELContextEvaluation(t *testing.T) {
 			Username: "alice",
 		},
 	))
+	require.NoError(t, err)
+	assert.Equal(t, true, out.Value())
+}
+
+func TestCELContextConstruction(t *testing.T) {
+	t.Parallel()
+
+	program, err := compileCELProgram(`
+		openvpn_auth_oauth2.AuthContext{mode: "interactive"}.mode == "interactive" &&
+		openvpn_auth_oauth2.OpenVPNContext{
+			commonName: "alice",
+			ip: "192.0.2.10",
+			sessionState: "authenticated"
+		}.commonName == "alice" &&
+		openvpn_auth_oauth2.TokenContext{
+			claims: {"department": "engineering"},
+			ip: "192.0.2.20"
+		}.claims.department == "engineering" &&
+		openvpn_auth_oauth2.UserContext{
+			email: "alice@example.com",
+			groups: ["vpn-users"],
+			roles: ["vpn-admin"],
+			subject: "user-123",
+			username: "alice"
+		}.username == "alice" &&
+		type(openvpn_auth_oauth2.UserContext{username: "alice"}) == openvpn_auth_oauth2.UserContext &&
+		has(openvpn_auth_oauth2.UserContext{username: "alice"}.groups) &&
+		openvpn_auth_oauth2.UserContext{username: "alice"}.groups == []
+	`, cel.BoolType)
+	require.NoError(t, err)
+
+	out, _, err := program.Eval(map[string]any{})
 	require.NoError(t, err)
 	assert.Equal(t, true, out.Value())
 }

--- a/internal/oauth2/providers/github/user.go
+++ b/internal/oauth2/providers/github/user.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"strings"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
@@ -40,14 +39,12 @@ func (p Provider) GetUser(ctx context.Context, _ *slog.Logger, tokens *idtoken.I
 		Subject:  strconv.Itoa(user.ID),
 	}
 
-	if len(p.Conf.OAuth2.Validate.Groups) > 0 || p.usesUserField("groups") {
-		organizations, err := p.getOrganizations(ctx, tokens)
-		if err != nil {
-			return types.UserInfo{}, fmt.Errorf("error getting GitHub organizations: %w", err)
-		}
-
-		userInfo.Groups = organizations
+	organizations, err := p.getOrganizations(ctx, tokens)
+	if err != nil {
+		return types.UserInfo{}, fmt.Errorf("error getting GitHub organizations: %w", err)
 	}
+
+	userInfo.Groups = organizations
 
 	teams, err := p.getTeams(ctx, tokens)
 	if err != nil {
@@ -57,20 +54,4 @@ func (p Provider) GetUser(ctx context.Context, _ *slog.Logger, tokens *idtoken.I
 	userInfo.Roles = teams
 
 	return userInfo, nil
-}
-
-func (p Provider) usesUserField(field string) bool {
-	expressions := [...]string{
-		p.Conf.OAuth2.OpenVPNUsername,
-		p.Conf.OAuth2.Validate.Expression,
-		p.Conf.OpenVPN.ClientConfig.Expression,
-	}
-
-	for _, expression := range expressions {
-		if strings.Contains(expression, "user."+field) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/oauth2/providers/github/user.go
+++ b/internal/oauth2/providers/github/user.go
@@ -49,14 +49,12 @@ func (p Provider) GetUser(ctx context.Context, _ *slog.Logger, tokens *idtoken.I
 		userInfo.Groups = organizations
 	}
 
-	if p.usesUserField("roles") {
-		teams, err := p.getTeams(ctx, tokens)
-		if err != nil {
-			return types.UserInfo{}, fmt.Errorf("error getting GitHub teams: %w", err)
-		}
-
-		userInfo.Roles = teams
+	teams, err := p.getTeams(ctx, tokens)
+	if err != nil {
+		return types.UserInfo{}, fmt.Errorf("error getting GitHub teams: %w", err)
 	}
+
+	userInfo.Roles = teams
 
 	return userInfo, nil
 }

--- a/internal/oauth2/providers/github/user.go
+++ b/internal/oauth2/providers/github/user.go
@@ -69,9 +69,7 @@ func (p Provider) usesUserField(field string) bool {
 	}
 
 	for _, expression := range expressions {
-		if strings.Contains(expression, "user."+field) ||
-			strings.Contains(expression, `user["`+field+`"]`) ||
-			strings.Contains(expression, `user['`+field+`']`) {
+		if strings.Contains(expression, "user."+field) {
 			return true
 		}
 	}

--- a/internal/oauth2/providers/github/user_test.go
+++ b/internal/oauth2/providers/github/user_test.go
@@ -118,7 +118,7 @@ func TestGetUser(t *testing.T) {
 	}
 }
 
-func TestGetUserSkipsUnusedOrganizationAndTeamLookups(t *testing.T) {
+func TestGetUserFetchesTeamsWithoutRoleExpression(t *testing.T) {
 	t.Parallel()
 
 	token := &idtoken.IDToken{
@@ -133,10 +133,17 @@ func TestGetUserSkipsUnusedOrganizationAndTeamLookups(t *testing.T) {
 	httpClient := &http.Client{
 		Transport: testsuite.NewRoundTripperFunc(nil, func(_ http.RoundTripper, req *http.Request) (*http.Response, error) {
 			requests.Add(1)
-			require.Equal(t, "/user", req.URL.Path)
 
 			resp := httptest.NewRecorder()
-			_, _ = resp.WriteString(`{"login": "login", "email": "email", "id": 10}`)
+
+			switch req.URL.Path {
+			case "/user":
+				_, _ = resp.WriteString(`{"login": "login", "email": "email", "id": 10}`)
+			case "/user/teams":
+				_, _ = resp.WriteString(`[{"slug": "justice-league", "organization": {"login": "apple"}}]`)
+			default:
+				require.Failf(t, "unexpected GitHub API request", "path: %s", req.URL.Path)
+			}
 
 			return resp.Result(), nil
 		}),
@@ -149,5 +156,6 @@ func TestGetUserSkipsUnusedOrganizationAndTeamLookups(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "login", user.Username)
-	require.EqualValues(t, 1, requests.Load())
+	require.Equal(t, []string{"apple:justice-league"}, user.Roles)
+	require.EqualValues(t, 2, requests.Load())
 }

--- a/internal/oauth2/providers/github/user_test.go
+++ b/internal/oauth2/providers/github/user_test.go
@@ -118,15 +118,13 @@ func TestGetUser(t *testing.T) {
 	}
 }
 
-func TestGetUserFetchesTeamsWithoutRoleExpression(t *testing.T) {
+func TestGetUserFetchesOrganizationsAndTeamsWithoutExpressions(t *testing.T) {
 	t.Parallel()
 
 	token := &idtoken.IDToken{
 		Token: &oauth2.Token{AccessToken: "TOKEN"},
 	}
-	conf := types2.Config{
-		OAuth2: types2.OAuth2{OpenVPNUsername: "user.username"},
-	}
+	conf := types2.Config{}
 
 	var requests atomic.Int32
 
@@ -139,6 +137,8 @@ func TestGetUserFetchesTeamsWithoutRoleExpression(t *testing.T) {
 			switch req.URL.Path {
 			case "/user":
 				_, _ = resp.WriteString(`{"login": "login", "email": "email", "id": 10}`)
+			case "/user/orgs":
+				_, _ = resp.WriteString(`[{"login": "apple"}]`)
 			case "/user/teams":
 				_, _ = resp.WriteString(`[{"slug": "justice-league", "organization": {"login": "apple"}}]`)
 			default:
@@ -156,6 +156,7 @@ func TestGetUserFetchesTeamsWithoutRoleExpression(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "login", user.Username)
+	require.Equal(t, []string{"apple"}, user.Groups)
 	require.Equal(t, []string{"apple:justice-league"}, user.Roles)
-	require.EqualValues(t, 2, requests.Load())
+	require.EqualValues(t, 3, requests.Load())
 }

--- a/internal/oauth2/username_test.go
+++ b/internal/oauth2/username_test.go
@@ -65,13 +65,6 @@ func TestResolveUsername(t *testing.T) {
 			authMode:   CELAuthModeInteractive,
 			expected:   "client-cn",
 		},
-		{
-			name:       "invalid result type",
-			expression: "user.groups",
-			authMode:   CELAuthModeInteractive,
-			user:       types.UserInfo{Groups: []string{"group"}},
-			err:        "did not evaluate to a string",
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -137,6 +130,11 @@ func TestInitializeUsernameResolverRejectsInvalidExpressions(t *testing.T) {
 			name:       "boolean result",
 			expression: "true",
 			err:        "cel expression must evaluate to string, got bool",
+		},
+		{
+			name:       "typed context result",
+			expression: "user.groups",
+			err:        "cel expression must evaluate to string, got list(string)",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Register `auth`, `openvpn`, `token`, and `user` as typed CEL objects with exact fixed-field types ([environment declarations](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/internal/oauth2/cel.go#L22-L35), [field schemas](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/internal/oauth2/cel_context.go#L56-L107)).
- Use native activation structs and explicit field getters so the normal CEL selector path avoids reflection and nested map allocations ([adapter and provider](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/internal/oauth2/cel_context.go#L110-L324), [activation](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/internal/oauth2/cel.go#L170-L219)).
- Preserve the declared object type when contexts pass through lists, comprehensions, dynamic conversion, type inspection, or object construction ([runtime object implementation](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/internal/oauth2/cel_context.go#L174-L266)).
- Keep `token.claims` as `map<string, dynamic>` for provider-defined claims.
- Always load GitHub organizations and teams into normalized `user.groups` and `user.roles`, removing expression-string lookup heuristics ([GitHub user lookup](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/internal/oauth2/providers/github/user.go#L23-L56), [regression test](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/internal/oauth2/providers/github/user_test.go#L121-L162)).
- Document the typed contract and its v2 upgrade impact ([CEL guide](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/docs/CEL%20Language%20Features.md#L42-L56), [v2 guide](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/docs/Upgrade%20V2.md#L196-L206), [GitHub membership migration](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/docs/Upgrade%20V2.md#L544-L548)).
- Cover every fixed field, invalid field/type checks, presence semantics, empty values, composed values, type identity, and constructors ([tests](https://github.com/jkroepke/openvpn-auth-oauth2/blob/feat/strict-cel-context/internal/oauth2/cel_context_test.go#L14-L252)).

## Why

The previous map declarations left most context fields dynamically typed. Typos and incompatible operations could therefore survive configuration loading and fail during authentication. Dedicated object schemas catch these mistakes at startup.

The explicit fixed-field getter path also improves the authentication hot path. On an Apple M1, the existing CEL benchmarks measured approximately 49% lower evaluation time, 67% fewer bytes, and 37% fewer allocations compared with `main`.

## User impact

This is a breaking v2 change. Expressions must use the documented fixed context fields with dot notation. Unknown fixed fields and incompatible fixed-field operations now prevent startup. Provider-specific keys below `token.claims` remain dynamic and optional claims should still be guarded with `has()`.

GitHub authentication now always requests organization and team membership and populates `user.groups` and `user.roles`, independent of the configured CEL expressions.

## Testing

- `make fmt`
- `make lint`
- `make test`
- `go test -race -count=1 ./internal/oauth2 ./internal/oauth2/providers/github`
- `textlint --rule terminology` for the changed documentation
- `git diff --check`
- `BenchmarkCheckIdentityCEL`, 10 runs with `-cpu=1 -benchtime=1s`, compared with `origin/main` using `benchstat`
- Follow-up `BenchmarkCheckIdentityCEL`, 10 runs with `-cpu=1 -benchtime=500ms`, compared with commit `49947ec`; allocation counts are unchanged and timings remain within run-to-run noise
