### PR TITLE
fix: prevent OpenVPN plugin authentication races

### DIFF
--- a/internal/openvpn/main.go
+++ b/internal/openvpn/main.go
@@ -223,8 +223,6 @@ func (c *Client) Shutdown(ctx context.Context) {
 
 	if c.conn != nil {
 		_ = c.conn.Close()
-
-		c.conn = nil
 	}
 
 	close(c.commandsCh)

--- a/lib/openvpn-auth-oauth2/internal/management/management.go
+++ b/lib/openvpn-auth-oauth2/internal/management/management.go
@@ -39,11 +39,20 @@ type Server struct {
 }
 
 type Response struct {
+	acknowledge  func(error)
 	Message      string
 	Timeout      string
 	ClientConfig string
 	ClientAuth   ClientAuth
 	ClientID     uint32
+}
+
+// Acknowledge reports whether the plugin applied the response successfully.
+// Every response delivered by the server must be acknowledged exactly once.
+func (r *Response) Acknowledge(err error) {
+	if r.acknowledge != nil {
+		r.acknowledge(err)
+	}
 }
 
 type ClientAuth int
@@ -354,31 +363,7 @@ scan:
 		}
 
 		s.logger.DebugContext(ctx, line)
-
-		resp, err := s.parseResponse(line)
-		if err != nil {
-			s.logger.ErrorContext(
-				ctx, "unable to parse client response",
-				slog.Any("err", err),
-				slog.String("response", line),
-			)
-			_ = s.writeToClient(fmt.Sprintf("ERROR: %s command failed", cmd))
-		} else {
-			_ = s.writeToClient(fmt.Sprintf("SUCCESS: %s command succeeded", cmd))
-		}
-
-		if resp == nil {
-			continue
-		}
-
-		s.respChMu.Lock()
-		respCh, exists := s.respChs[uint64(resp.ClientID)]
-		delete(s.respChs, uint64(resp.ClientID))
-		s.respChMu.Unlock()
-
-		if exists {
-			respCh <- resp
-		}
+		s.handleClientResponse(ctx, line, cmd)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -390,6 +375,61 @@ scan:
 	}
 
 	return nil
+}
+
+func (s *Server) handleClientResponse(ctx context.Context, line, command string) {
+	resp, parseErr := s.parseResponse(line)
+	if parseErr != nil {
+		s.logger.ErrorContext(
+			ctx, "unable to parse client response",
+			slog.Any("err", parseErr),
+			slog.String("response", line),
+		)
+	}
+
+	if resp == nil {
+		s.writeCommandResult(command, parseErr)
+
+		return
+	}
+
+	s.respChMu.Lock()
+	respCh, exists := s.respChs[uint64(resp.ClientID)]
+	delete(s.respChs, uint64(resp.ClientID))
+	s.respChMu.Unlock()
+
+	if !exists {
+		if parseErr == nil {
+			parseErr = fmt.Errorf("no response poller for client ID %d", resp.ClientID)
+			s.logger.ErrorContext(ctx, "unable to handle client response", slog.Any("err", parseErr))
+		}
+
+		s.writeCommandResult(command, parseErr)
+
+		return
+	}
+
+	if parseErr != nil {
+		s.writeCommandResult(command, parseErr)
+
+		respCh <- resp
+
+		return
+	}
+
+	var acknowledgeOnce sync.Once
+
+	resp.acknowledge = func(err error) {
+		acknowledgeOnce.Do(func() {
+			if err != nil {
+				s.logger.ErrorContext(ctx, "unable to handle client response", slog.Any("err", err))
+			}
+
+			s.writeCommandResult(command, err)
+		})
+	}
+
+	respCh <- resp
 }
 
 func (s *Server) handleManagementClientAuth(_ context.Context, conn net.Conn, scanner *bufio.Scanner) error {
@@ -486,4 +526,14 @@ func (s *Server) writeToClient(message string) error {
 	}
 
 	return nil
+}
+
+func (s *Server) writeCommandResult(command string, err error) {
+	if err != nil {
+		_ = s.writeToClient(fmt.Sprintf("ERROR: %s command failed", command))
+
+		return
+	}
+
+	_ = s.writeToClient(fmt.Sprintf("SUCCESS: %s command succeeded", command))
 }

--- a/lib/openvpn-auth-oauth2/internal/management/management_test.go
+++ b/lib/openvpn-auth-oauth2/internal/management/management_test.go
@@ -4,6 +4,7 @@ package management_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -310,6 +311,7 @@ func TestServer_PendingPoller(t *testing.T) {
 		name    string
 		command string
 		resp    string
+		ackErr  error
 		testFn  func(t *testing.T, response *management.Response)
 	}{
 		{
@@ -324,8 +326,25 @@ func TestServer_PendingPoller(t *testing.T) {
 			},
 		},
 		{
+			name:    "client-auth-nt handler error",
+			command: "client-auth-nt 5 0",
+			resp:    "ERROR: client-auth command failed",
+			ackErr:  errors.New("unable to write auth control file"),
+			testFn: func(t *testing.T, response *management.Response) {
+				t.Helper()
+
+				require.Equal(t, uint32(5), response.ClientID)
+				require.Equal(t, management.ClientAuthAccept, response.ClientAuth)
+			},
+		},
+		{
 			name:    "client-auth-nt invalid",
 			command: "client-auth-nt A B",
+			resp:    "ERROR: client-auth command failed",
+		},
+		{
+			name:    "client-auth-nt without poller invalid",
+			command: "client-auth-nt 6 0",
 			resp:    "ERROR: client-auth command failed",
 		},
 		{
@@ -446,9 +465,9 @@ func TestServer_PendingPoller(t *testing.T) {
 			clientConn.ExpectMessage(t, openvpn.WelcomeBanner)
 			clientConn.SendMessagef(t, tc.command)
 
-			clientConn.ExpectMessage(t, tc.resp)
-
 			if strings.HasSuffix(tc.name, "invalid") {
+				clientConn.ExpectMessage(t, tc.resp)
+
 				return
 			}
 
@@ -457,11 +476,23 @@ func TestServer_PendingPoller(t *testing.T) {
 			response := <-responseCh
 			require.NotNil(t, response)
 
-			if tc.testFn == nil {
+			if tc.testFn != nil {
+				tc.testFn(t, response)
+			}
+
+			if strings.HasPrefix(tc.resp, "ERROR:") && tc.ackErr == nil {
+				clientConn.ExpectMessage(t, tc.resp)
+
 				return
 			}
 
-			tc.testFn(t, response)
+			require.NoError(t, client.SetReadDeadline(time.Now().Add(50*time.Millisecond)))
+
+			_, err = clientConn.Reader().ReadString('\n')
+			require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+
+			response.Acknowledge(tc.ackErr)
+			clientConn.ExpectMessage(t, tc.resp)
 		})
 	}
 }
@@ -592,7 +623,11 @@ func TestServer_ReconnectDuringPendingAuth(t *testing.T) {
 
 	// Register a pending poller that will wait for a response
 	go func() {
-		_, err := managementServer.WaitPendingPoller(ctx, 99, time.Second*3, pendingRespCh)
+		response, err := managementServer.WaitPendingPoller(ctx, 99, time.Second*3, pendingRespCh)
+		if err == nil {
+			response.Acknowledge(nil)
+		}
+
 		errCh <- err
 	}()
 

--- a/lib/openvpn-auth-oauth2/internal/openvpn/handle.go
+++ b/lib/openvpn-auth-oauth2/internal/openvpn/handle.go
@@ -127,13 +127,15 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 
 	switch resp.ClientAuth {
 	case management.ClientAuthAccept:
-		logger.InfoContext(p.ctx, "authentication accepted")
-
 		perClientContext.setClientConfig(resp.ClientConfig)
+		resp.Acknowledge(nil)
+
+		logger.InfoContext(p.ctx, "authentication accepted")
 
 		return c.OpenVPNPluginFuncSuccess
 	case management.ClientAuthDeny:
 		handleAuthDenied(p.ctx, logger, openVPNClient, resp)
+		resp.Acknowledge(nil)
 
 		return c.OpenVPNPluginFuncError
 	case management.ClientAuthPending:
@@ -141,6 +143,7 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 
 		pendingRespCh, err := p.managementClient.RegisterPendingPoller(currentClientID)
 		if err != nil {
+			resp.Acknowledge(err)
 			logger.ErrorContext(
 				p.ctx, "register deferred auth poller",
 				slog.Any("err", err),
@@ -152,6 +155,7 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 		// Write "2" to auth control file to indicate deferred auth
 		if err := openVPNClient.WriteAuthPending(resp); err != nil {
 			p.managementClient.CancelPendingPoller(currentClientID)
+			resp.Acknowledge(err)
 			logger.ErrorContext(
 				p.ctx, "write to auth file",
 				slog.Any("err", err),
@@ -184,6 +188,7 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 				perClientContext.setClientConfig(resp.ClientConfig)
 
 				if err := openVPNClient.WriteToAuthFile("1"); err != nil {
+					resp.Acknowledge(err)
 					logger.ErrorContext(
 						p.ctx, "write to auth file",
 						slog.Any("err", err),
@@ -192,11 +197,13 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 					return
 				}
 
+				resp.Acknowledge(nil)
 				logger.InfoContext(p.ctx, "authentication accepted")
 			case management.ClientAuthDeny:
 				handleAuthDenied(p.ctx, logger, openVPNClient, resp)
 
 				if err := openVPNClient.WriteToAuthFile("0"); err != nil {
+					resp.Acknowledge(err)
 					logger.ErrorContext(
 						p.ctx, "write to auth file",
 						slog.Any("err", err),
@@ -204,14 +211,22 @@ func (p *PluginHandle) handleAuthUserPassVerify(clientEnvList **c.Char, perClien
 
 					return
 				}
+
+				resp.Acknowledge(nil)
 			default:
-				logger.ErrorContext(p.ctx, "unknown auth state")
+				err := fmt.Errorf("unknown auth state: %s", resp.ClientAuth)
+				resp.Acknowledge(err)
+				logger.ErrorContext(p.ctx, "unknown auth state", slog.Any("err", err))
 			}
 		}(pendingRespCh)
 
+		resp.Acknowledge(nil)
+
 		return c.OpenVPNPluginFuncDeferred
 	default:
-		p.logger.ErrorContext(p.ctx, "unknown client auth response from management interface")
+		err := fmt.Errorf("unknown client auth response from management interface: %s", resp.ClientAuth)
+		resp.Acknowledge(err)
+		p.logger.ErrorContext(p.ctx, "unknown client auth response from management interface", slog.Any("err", err))
 
 		return c.OpenVPNPluginFuncError
 	}


### PR DESCRIPTION
#### What this PR does / why we need it

The plugin management bridge previously reported a successful `client-auth` command before the plugin had applied the response. The OAuth callback could therefore finish before the deferred-auth file was updated, and file-write failures were hidden from the daemon.

This PR:

- waits for the plugin to acknowledge that a management response was applied before returning command success ([response handoff](https://github.com/jkroepke/openvpn-auth-oauth2/blob/fix/plugin-auth-control-test/lib/openvpn-auth-oauth2/internal/management/management.go#L380), [plugin acknowledgement](https://github.com/jkroepke/openvpn-auth-oauth2/blob/fix/plugin-auth-control-test/lib/openvpn-auth-oauth2/internal/openvpn/handle.go#L128))
- propagates plugin processing failures and rejects responses that have no registered poller
- stops clearing the OpenVPN management connection while command handling can still read it, eliminating the reported shutdown race ([shutdown lifecycle](https://github.com/jkroepke/openvpn-auth-oauth2/blob/fix/plugin-auth-control-test/internal/openvpn/main.go#L210))
- adds coverage for delayed acknowledgement, acknowledgement failures, missing pollers, and reconnects

#### Which issue this PR fixes

No linked issue.

#### Special notes for your reviewer

The OAuth flow remains asynchronous. Only the final management response handoff is synchronized: the bridge responds after the plugin has written the auth-control file or reported an error.

Validation completed:

- `make fmt`
- `make lint` — 0 issues
- `make test`
- `go test -race -cover -count=1 -shuffle=1785091103532848152 ./...`
- both reported plugin shuffle seeds passed 100 race-enabled iterations each

#### Particularly user-facing changes

Deferred plugin authentication no longer reports OAuth success before OpenVPN has received the final authentication result. Failures while applying that result are now returned to the daemon.

#### Checklist

Complete these before marking the PR as `ready to review`:

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR