### PR TITLE
chore: cover plugin authentication response transitions

### DIFF
--- a/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go
+++ b/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go
@@ -288,6 +288,18 @@ func TestParsePendingPollerTimeout(t *testing.T) {
 func TestPluginDenyNonWebAuthClient(t *testing.T) {
 	t.Parallel()
 
+	testPluginDenyClient(t, false, "", "OpenVPN Client does not support SSO authentication via webauth")
+}
+
+func TestPluginDenyOversizedAuthenticationURL(t *testing.T) {
+	t.Parallel()
+
+	testPluginDenyClient(t, true, strings.Repeat("a", 1024), "internal error")
+}
+
+func testPluginDenyClient(t *testing.T, supportsWebAuth bool, baseURLPath, expectedReason string) {
+	t.Helper()
+
 	unixSocket, err := nettest.LocalPath()
 	require.NoError(t, err)
 
@@ -340,6 +352,7 @@ func TestPluginDenyNonWebAuthClient(t *testing.T) {
 
 	suite := testsuite.New(&conf)
 	suite.SetupOIDCServer(t, clientListener, nil)
+	suite.GetConfig().HTTP.BaseURL.Path = baseURLPath
 
 	_, openVPNClient := suite.SetupOpenVPNOAuth2Clients(t.Context(), t, nil)
 
@@ -366,8 +379,7 @@ func TestPluginDenyNonWebAuthClient(t *testing.T) {
 		require.NoError(t, authFailedReasonFile.Close())
 	})
 
-	// Client without webauth support (no IV_SSO=webauth)
-	envp, envCStrings := testutil.CreateCStringArray([]string{
+	clientEnv := []string{
 		"n_clients=0",
 		"password=",
 		"session_id=SESSIONID",
@@ -378,7 +390,13 @@ func TestPluginDenyNonWebAuthClient(t *testing.T) {
 		"session_state=Initial",
 		"auth_control_file=" + authControlFile.Name(),
 		"auth_failed_reason_file=" + authFailedReasonFile.Name(),
-	})
+	}
+
+	if supportsWebAuth {
+		clientEnv = append(clientEnv, "IV_SSO=webauth")
+	}
+
+	envp, envCStrings := testutil.CreateCStringArray(clientEnv)
 
 	t.Cleanup(func() {
 		testutil.FreeCStringArray(envp, envCStrings)
@@ -393,13 +411,12 @@ func TestPluginDenyNonWebAuthClient(t *testing.T) {
 	}
 	ret = &c.OpenVPNPluginArgsFuncReturn{}
 
-	// A client without webauth support must be denied: the plugin must return ERROR.
 	status = PluginFuncV3(PluginStructVerMin, args, ret)
 	require.Equal(t, c.OpenVPNPluginFuncError, status, suite.Logs())
 
 	data, err := os.ReadFile(authFailedReasonFile.Name())
 	require.NoError(t, err)
-	require.Equal(t, "OpenVPN Client does not support SSO authentication via webauth", string(data))
+	require.Equal(t, expectedReason, string(data))
 
 	PluginClientDestructorV1(args.Handle, clientContextPtr)
 }

--- a/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go
+++ b/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,8 +34,11 @@ func TestPlugin(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name string
-		conf config.Config
+		name                string
+		conf                config.Config
+		directAccept        bool
+		denyAfterPending    bool
+		testInvalidCommands bool
 	}{
 		{
 			name: "default config",
@@ -60,6 +64,23 @@ func TestPlugin(t *testing.T) {
 
 				return conf
 			}(),
+		},
+		{
+			name: "direct accept",
+			conf: func() config.Config {
+				conf := config.Defaults
+				conf.OpenVPN.AuthTokenUser = false
+				conf.OpenVPN.Bypass.CommonNames = types.RegexpSlice{regexp.MustCompile(`^user@example\.com$`)}
+
+				return conf
+			}(),
+			directAccept: true,
+		},
+		{
+			name:                "deny after pending",
+			conf:                config.Defaults,
+			denyAfterPending:    true,
+			testInvalidCommands: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -152,6 +173,9 @@ func TestPlugin(t *testing.T) {
 
 			clientContextPtr := PluginClientConstructorV1(openRet.Handle)
 			require.NotNil(t, clientContextPtr)
+			t.Cleanup(func() {
+				PluginClientDestructorV1(openRet.Handle, clientContextPtr)
+			})
 
 			authControlFile, err := os.CreateTemp(t.TempDir(), "auth_control_file")
 			require.NoError(t, err)
@@ -163,6 +187,12 @@ func TestPlugin(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				require.NoError(t, authPendingFile.Close())
+			})
+
+			authFailedReasonFile, err := os.CreateTemp(t.TempDir(), "auth_failed_reason_file")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, authFailedReasonFile.Close())
 			})
 
 			// PluginFuncV3 - OpenVPNPluginAuthUserPassVerify
@@ -178,6 +208,7 @@ func TestPlugin(t *testing.T) {
 				"session_state=Initial",
 				"auth_pending_file=" + authPendingFile.Name(),
 				"auth_control_file=" + authControlFile.Name(),
+				"auth_failed_reason_file=" + authFailedReasonFile.Name(),
 			})
 
 			t.Cleanup(func() {
@@ -193,39 +224,84 @@ func TestPlugin(t *testing.T) {
 			}
 			ret = &c.OpenVPNPluginArgsFuncReturn{}
 
-			status = PluginFuncV3(PluginStructVerMin, args, ret)
-			require.Equal(t, c.OpenVPNPluginFuncDeferred, status)
-
-			data, err := os.ReadFile(authPendingFile.Name())
-			require.NoError(t, err)
-			require.Contains(t, string(data), "180\nwebauth\nWEB_AUTH::http://")
-
-			authURL := strings.TrimSpace(strings.SplitN(string(data), "\n", 3)[2][10:])
-
-			jar, err := cookiejar.New(nil)
-			require.NoError(t, err)
-
-			httpClient := &http.Client{
-				Timeout: 5 * time.Second,
-				Jar:     jar,
+			sendInvalidCommand := func() {
+				response, err := openVPNClient.SendCommand(t.Context(), "client-invalid 0 0", false)
+				require.Error(t, err)
+				require.Equal(t, "ERROR: unknown command, enter 'help' for more options", strings.TrimSpace(response))
 			}
 
-			var resp *http.Response
+			if tc.testInvalidCommands {
+				sendInvalidCommand()
+			}
 
-			wg := sync.WaitGroup{}
-			wg.Go(func() {
-				resp, _, err = testsuite.DoHTTPRequest(t, httpClient, "", http.MethodGet, authURL, nil, http.NoBody) //nolint:bodyclose
-			})
+			status = PluginFuncV3(PluginStructVerMin, args, ret)
+			if tc.directAccept {
+				require.Equal(t, c.OpenVPNPluginFuncSuccess, status)
 
-			wg.Wait()
+				data, err := os.ReadFile(authPendingFile.Name())
+				require.NoError(t, err)
+				require.Empty(t, data)
+			} else {
+				require.Equal(t, c.OpenVPNPluginFuncDeferred, status)
 
-			require.NoError(t, err)
+				data, err := os.ReadFile(authPendingFile.Name())
+				require.NoError(t, err)
+				require.Contains(t, string(data), "180\nwebauth\nWEB_AUTH::http://")
 
-			require.Equal(t, http.StatusOK, resp.StatusCode, suite.Logs())
+				if tc.testInvalidCommands {
+					sendInvalidCommand()
+				}
 
-			data, err = os.ReadFile(authControlFile.Name())
-			require.NoError(t, err)
-			require.Equal(t, "1", string(data))
+				if tc.denyAfterPending {
+					clientContext := clientContextFromPointer(clientContextPtr)
+					require.NotNil(t, clientContext)
+
+					clientContext.mu.Lock()
+					clientID := clientContext.clientID
+					clientContext.mu.Unlock()
+
+					response, err := openVPNClient.SendCommandf(t.Context(), `client-deny %d 0 "access denied"`, clientID)
+					require.NoError(t, err)
+					require.Equal(t, "SUCCESS: client-deny command succeeded", strings.TrimSpace(response))
+
+					data, err = os.ReadFile(authControlFile.Name())
+					require.NoError(t, err)
+					require.Equal(t, "0", string(data))
+
+					data, err = os.ReadFile(authFailedReasonFile.Name())
+					require.NoError(t, err)
+					require.Equal(t, "access denied", string(data))
+
+					return
+				}
+
+				authURL := strings.TrimSpace(strings.SplitN(string(data), "\n", 3)[2][10:])
+
+				jar, err := cookiejar.New(nil)
+				require.NoError(t, err)
+
+				httpClient := &http.Client{
+					Timeout: 5 * time.Second,
+					Jar:     jar,
+				}
+
+				var resp *http.Response
+
+				wg := sync.WaitGroup{}
+				wg.Go(func() {
+					resp, _, err = testsuite.DoHTTPRequest(t, httpClient, "", http.MethodGet, authURL, nil, http.NoBody) //nolint:bodyclose
+				})
+
+				wg.Wait()
+
+				require.NoError(t, err)
+
+				require.Equal(t, http.StatusOK, resp.StatusCode, suite.Logs())
+
+				data, err = os.ReadFile(authControlFile.Name())
+				require.NoError(t, err)
+				require.Equal(t, "1", string(data))
+			}
 
 			// PluginFuncV3 - OpenVPNPluginClientConnectV2
 			args.Type = c.OpenVPNPluginClientConnectV2
@@ -250,9 +326,6 @@ func TestPlugin(t *testing.T) {
 
 			status = PluginFuncV3(PluginStructVerMin, args, ret)
 			require.Equal(t, c.OpenVPNPluginFuncSuccess, status)
-
-			// PluginClientDestructorV1
-			PluginClientDestructorV1(args.Handle, clientContextPtr)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

- Expands the end-to-end plugin matrix to cover a direct `management.ClientAuthAccept` response without pending authentication ([direct-accept case](https://github.com/jkroepke/openvpn-auth-oauth2/blob/7027e74c24560654f3234fb4c157f790f1d72faa/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go#L68-L78), [assertions](https://github.com/jkroepke/openvpn-auth-oauth2/blob/7027e74c24560654f3234fb4c157f790f1d72faa/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go#L237-L244)).
- Covers `management.ClientAuthDeny` after a pending response and verifies both the `0` auth-control value and failure reason ([pending-deny assertions](https://github.com/jkroepke/openvpn-auth-oauth2/blob/7027e74c24560654f3234fb4c157f790f1d72faa/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go#L245-L275)).
- Sends `client-invalid 0 0` before and after `client-pending-auth`, proving invalid commands are rejected without disrupting the pending poller ([invalid-command checks](https://github.com/jkroepke/openvpn-auth-oauth2/blob/7027e74c24560654f3234fb4c157f790f1d72faa/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go#L227-L253)).
- Retains the oversized authentication URL denial test added as the original scope of this PR ([oversized URL case](https://github.com/jkroepke/openvpn-auth-oauth2/blob/7027e74c24560654f3234fb4c157f790f1d72faa/lib/openvpn-auth-oauth2/internal/openvpn/plugin_test.go#L357-L370)).

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

Coverage for the plugin package with `-coverpkg=./...` changes from the base branch as follows:

- Overall statements: 38.0% → 38.9%
- `handleAuthUserPassVerify`: 60.8% → 70.3%
- `startClientAuth`: 85.0% → 90.0%
- `buildClientPendingAuthCommand`: 75.0% → 100.0%

The post-pending denial uses the real management connection and waits for the command acknowledgement. The acknowledgement is sent only after the plugin writes the auth-control and failure-reason files, avoiding timing-based polling.

Testing:

- `make fmt` — passed
- `make lint` — passed
- `make test` — passed
- Full `TestPlugin` matrix with `-count=10 -shuffle=on -race` — passed

#### Particularly user-facing changes

None. This is test-only coverage for plugin authentication state transitions.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR