### PR TITLE
chore: stabilize allocation benchmarks

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -14,7 +14,7 @@ func BenchmarkFull(b *testing.B) {
 	b.StopTimer()
 
 	conf := config.Config{}
-	suite := testsuite.New(&conf)
+	suite := testsuite.New(&conf, testsuite.WithDiscardLogger())
 	suite.SetupMockEnvironment(b.Context(), b, nil)
 	suite.ExpectVersionAndReleaseHold(b)
 

--- a/internal/openvpn/bench_test.go
+++ b/internal/openvpn/bench_test.go
@@ -25,7 +25,7 @@ func BenchmarkOpenVPNHandler(b *testing.B) {
 	conf.HTTP.Secret = testsuite.Secret
 	conf.OpenVPN.Bypass = config.OpenVPNBypass{CommonNames: make(types.RegexpSlice, 0)}
 
-	suite := testsuite.New(&conf)
+	suite := testsuite.New(&conf, testsuite.WithDiscardLogger())
 	errOpenVPNClientCh := suite.SetupManagementEnvironment(ctx, b, nil)
 	openVPNClient := suite.GetOpenVPNClient()
 	managementInterfaceConn := suite.GetManagementInterfaceConn()

--- a/internal/test/testlogger/logger.go
+++ b/internal/test/testlogger/logger.go
@@ -21,10 +21,18 @@ type Logger struct {
 // New returns a logger that stores all logs in memory so tests can inspect them.
 func New() *Logger {
 	syncBuffer := NewSyncBuffer()
-	syncBuffer.buffer.Grow(16 << 20)
 
+	return newLogger(syncBuffer, syncBuffer)
+}
+
+// NewDiscard returns a logger that formats logs but discards the output.
+func NewDiscard() *Logger {
+	return newLogger(io.Discard, NewSyncBuffer())
+}
+
+func newLogger(writer io.Writer, syncBuffer *SyncBuffer) *Logger {
 	return &Logger{
-		logger: slog.New(slog.NewTextHandler(syncBuffer, &slog.HandlerOptions{
+		logger: slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{
 			Level: slog.LevelDebug,
 		})),
 		buffer: syncBuffer,

--- a/internal/test/testlogger/logger_test.go
+++ b/internal/test/testlogger/logger_test.go
@@ -1,0 +1,30 @@
+package testlogger_test
+
+import (
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testlogger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogger(t *testing.T) {
+	t.Parallel()
+
+	t.Run("buffered", func(t *testing.T) {
+		t.Parallel()
+
+		logger := testlogger.New()
+		logger.Logger().Info("test message")
+
+		require.Contains(t, logger.String(), "test message")
+	})
+
+	t.Run("discard", func(t *testing.T) {
+		t.Parallel()
+
+		logger := testlogger.NewDiscard()
+		logger.Logger().Info("test message")
+
+		require.Empty(t, logger.String())
+	})
+}

--- a/internal/test/testsuite/connection.go
+++ b/internal/test/testsuite/connection.go
@@ -72,7 +72,10 @@ func (c *Conn) Reader() *bufio.Reader {
 func sendMessagef(tb testing.TB, conn net.Conn, logs func() string, sendMessage string, args ...any) {
 	tb.Helper()
 
-	require.NotNil(tb, conn, "connection is nil\n\n%s", logOutput(logs))
+	if conn == nil {
+		require.NotNil(tb, conn, "connection is nil\n\n%s", logOutput(logs))
+	}
+
 	require.NoError(tb, conn.SetWriteDeadline(time.Now().Add(time.Second*5)))
 
 	if sendMessage != "ENTER PASSWORD:" {
@@ -80,7 +83,9 @@ func sendMessagef(tb testing.TB, conn net.Conn, logs func() string, sendMessage 
 	}
 
 	_, err := fmt.Fprintf(conn, sendMessage, args...)
-	require.NoError(tb, err, "error sending message to management interface\n\n%s", logOutput(logs))
+	if err != nil {
+		require.NoError(tb, err, "error sending message to management interface\n\n%s", logOutput(logs))
+	}
 }
 
 func expectConnMessage(tb testing.TB, conn net.Conn, reader *bufio.Reader, logs func() string, expectMessage string) {
@@ -92,14 +97,21 @@ func expectConnMessage(tb testing.TB, conn net.Conn, reader *bufio.Reader, logs 
 	)
 	for expected := range strings.SplitSeq(strings.TrimSpace(expectMessage), "\n") {
 		err = conn.SetReadDeadline(time.Now().Add(time.Second * 5))
-		require.NoError(tb, err, "expected line: %s\nexpected message:\n%s\n\n%s", expected, expectMessage, logOutput(logs))
+		if err != nil {
+			require.NoError(tb, err, "expected line: %s\nexpected message:\n%s\n\n%s", expected, expectMessage, logOutput(logs))
+		}
 
 		line, err = reader.ReadString('\n')
 		if err != nil && !errors.Is(err, io.EOF) {
 			require.NoError(tb, err, "expected line: %s\nexpected message:\n%s\n\n%s", expected, expectMessage, logOutput(logs))
 		}
 
-		require.Equal(tb, strings.TrimRightFunc(expected, unicode.IsSpace), strings.TrimRightFunc(line, unicode.IsSpace), logOutput(logs))
+		expected = strings.TrimRightFunc(expected, unicode.IsSpace)
+		line = strings.TrimRightFunc(line, unicode.IsSpace)
+
+		if expected != line {
+			require.Equal(tb, expected, line, logOutput(logs))
+		}
 	}
 }
 

--- a/internal/test/testsuite/connection_test.go
+++ b/internal/test/testsuite/connection_test.go
@@ -1,0 +1,47 @@
+package testsuite_test
+
+import (
+	"bufio"
+	"net"
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testsuite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionDiagnosticsAreLazy(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	serverDone := make(chan error, 1)
+
+	go func() {
+		reader := bufio.NewReader(server)
+		if _, err := reader.ReadString('\n'); err != nil {
+			serverDone <- err
+
+			return
+		}
+
+		_, err := server.Write([]byte("response\r\n"))
+		serverDone <- err
+	}()
+
+	diagnosticCalls := 0
+	conn := testsuite.NewConn(client).WithLogs(func() string {
+		diagnosticCalls++
+
+		return "diagnostic logs"
+	})
+
+	conn.SendAndExpectMessage(t, "request", "response")
+
+	require.NoError(t, <-serverDone)
+	require.Zero(t, diagnosticCalls)
+}

--- a/internal/test/testsuite/options.go
+++ b/internal/test/testsuite/options.go
@@ -2,6 +2,8 @@ package testsuite
 
 import (
 	"net/http"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testlogger"
 )
 
 type Options func(*Suite) *Suite
@@ -9,6 +11,15 @@ type Options func(*Suite) *Suite
 func WithHTTPTransport(rt http.RoundTripper) Options {
 	return func(s *Suite) *Suite {
 		s.rt = rt
+
+		return s
+	}
+}
+
+// WithDiscardLogger configures the suite to format logs without retaining them.
+func WithDiscardLogger() Options {
+	return func(s *Suite) *Suite {
+		s.logger = testlogger.NewDiscard()
 
 		return s
 	}


### PR DESCRIPTION
#### What this PR does / why we need it

The allocation benchmarks retained every test log message and eagerly converted the complete, growing log buffer to a string for successful assertions. As the benchmark iteration count increased, the reported `B/op` therefore measured test-harness growth rather than application allocations.

This PR:

- evaluates connection diagnostic logs only when an assertion fails;
- adds a benchmark logger that runs the normal text handler but writes to `io.Discard`;
- uses that logger for the full-flow and OpenVPN handler allocation benchmarks;
- removes the unconditional 16 MiB test-log preallocation; and
- adds regression tests for buffered/discard logging and lazy diagnostics.

Fixed-iteration results on Go 1.26.5, darwin/arm64, Apple M1:

| Benchmark | `main`, 100x | `main`, 1000x | PR, 100x | PR, 1000x |
| --- | ---: | ---: | ---: | ---: |
| OpenVPNHandler/short | 185,721 B/op, 65 allocs/op | 1,679,877 B/op, 68 allocs/op | 5,011 B/op, 56 allocs/op | 4,063 B/op, 56 allocs/op |
| OpenVPNHandler/real | 931,198 B/op, 71 allocs/op | 8,998,095 B/op, 83 allocs/op | 13,038 B/op, 60 allocs/op | 13,532 B/op, 60 allocs/op |

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

Validation:

- `make fmt`
- `make test`
- `go test -race ./internal/test/testlogger ./internal/test/testsuite ./internal/openvpn ./internal`
- scoped golangci-lint for all changed packages: 0 issues
- `gopls check` for all changed Go files
- fixed-count allocation benchmarks at 100x and 1000x

`make lint` still reports the pre-existing unused `//nolint:revive` at `internal/oauth2/provider.go:22`. That file is unchanged by this PR; scoped lint for the changed packages passes.

#### Particularly user-facing changes

None. This only makes test and benchmark allocation measurements reliable.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR