### PR TITLE
feat: reduce crypto hot-path allocations

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -39,6 +39,14 @@ type Cipher struct {
 	maxAge  time.Duration
 }
 
+// pooledMAC keeps the hash and Sum destination together. A local Sum scratch
+// array escapes because hash.Hash is an interface, causing an allocation per call.
+type pooledMAC struct {
+	hash.Hash
+
+	sum [sha256.Size]byte
+}
+
 // New creates a new Cipher instance with the given encryption key.
 // Both the encryption key and the MAC key are independently derived from the
 // input using HKDF-SHA256 with distinct info strings ("salsa20-encryption" and
@@ -65,7 +73,9 @@ func NewWithMaxAge(encryptionKey string, maxAge time.Duration) *Cipher {
 		maxAge: maxAge,
 	}
 	cipher.macPool.New = func() any {
-		return hmac.New(sha256.New, cipher.macKey)
+		return &pooledMAC{
+			Hash: hmac.New(sha256.New, cipher.macKey),
+		}
 	}
 
 	return cipher
@@ -113,9 +123,7 @@ func (c *Cipher) EncryptBytes(plainText []byte) ([]byte, error) {
 	macHash.Write(nonce)
 	macHash.Write(cipherText)
 
-	var tagScratch [sha256.Size]byte
-
-	tag := macHash.Sum(tagScratch[:0])
+	tag := macHash.Sum(macHash.sum[:0])
 	copy(result[len(result)-hmacTagSize:], tag[:hmacTagSize])
 
 	return result, nil
@@ -141,9 +149,7 @@ func (c *Cipher) DecryptBytes(encryptedData []byte) ([]byte, error) {
 	macHash.Write(nonce)
 	macHash.Write(cipherText)
 
-	var tagScratch [sha256.Size]byte
-
-	expectedTag := macHash.Sum(tagScratch[:0])
+	expectedTag := macHash.Sum(macHash.sum[:0])
 
 	if !hmac.Equal(tag, expectedTag[:hmacTagSize]) {
 		return nil, ErrHMACVerificationFailed
@@ -206,17 +212,19 @@ func (c *Cipher) DecryptBytesWithTime(encryptedBase64 []byte) ([]byte, error) {
 }
 
 // getMAC returns a reset HMAC-SHA256 instance from the cipher-local pool.
-func (c *Cipher) getMAC() hash.Hash {
-	macHash, ok := c.macPool.Get().(hash.Hash)
+func (c *Cipher) getMAC() *pooledMAC {
+	macHash, ok := c.macPool.Get().(*pooledMAC)
 	if !ok {
-		return hmac.New(sha256.New, c.macKey)
+		return &pooledMAC{
+			Hash: hmac.New(sha256.New, c.macKey),
+		}
 	}
 
 	return macHash
 }
 
 // putMAC resets and returns an HMAC-SHA256 instance to the cipher-local pool.
-func (c *Cipher) putMAC(macHash hash.Hash) {
+func (c *Cipher) putMAC(macHash *pooledMAC) {
 	macHash.Reset()
 	c.macPool.Put(macHash)
 }

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -304,6 +305,45 @@ func TestMultipleEncryptionRounds(t *testing.T) {
 		require.NoError(t, err, "round %d DecryptBytes failed", i+1)
 		require.Equal(t, plainText, decrypted, "round %d failed", i+1)
 	}
+}
+
+func TestCipherConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	const workerCount = 16
+
+	cipher := crypto.New("test-key")
+	plainText := []byte("concurrent message")
+
+	var wg sync.WaitGroup
+
+	for range workerCount {
+		wg.Go(func() {
+			for range 100 {
+				encrypted, err := cipher.EncryptBytes(plainText)
+				if err != nil {
+					t.Errorf("EncryptBytes failed: %v", err)
+
+					return
+				}
+
+				decrypted, err := cipher.DecryptBytes(encrypted)
+				if err != nil {
+					t.Errorf("DecryptBytes failed: %v", err)
+
+					return
+				}
+
+				if !bytes.Equal(plainText, decrypted) {
+					t.Errorf("decrypted text %q does not match %q", decrypted, plainText)
+
+					return
+				}
+			}
+		})
+	}
+
+	wg.Wait()
 }
 
 func BenchmarkDeriveKey(b *testing.B) {


### PR DESCRIPTION
#### What this PR does / why we need it

`EncryptBytes` and `DecryptBytes` each used a local SHA-256 `Sum` scratch array. Passing that array through the `hash.Hash` interface caused Go to move it to the heap, adding one 32-byte allocation to every encryption and decryption operation.

This PR stores the `Sum` destination alongside each existing pooled HMAC instance. It therefore reuses the scratch space without adding another pool or lock. A concurrent shared-cipher regression test exercises the pool under race detection.

Benchmark comparison on Go 1.26.5, darwin/arm64, Apple M1 (`n=6`):

| Benchmark | Time | Bytes | Allocations |
| --- | ---: | ---: | ---: |
| EncryptBytes | 371.2 ns → 338.0 ns (-8.93%) | 80 → 48 B/op (-40.00%) | 2 → 1 (-50.00%) |
| DecryptBytes | 276.9 ns → 258.2 ns (-6.77%) | 56 → 24 B/op (-57.14%) | 2 → 1 (-50.00%) |
| RoundTrip | 617.8 ns → 607.5 ns (-1.66%) | 136 → 72 B/op (-47.06%) | 4 → 2 (-50.00%) |

The reduction also propagates to state operations (one fewer allocation each) and in-memory token storage (`Set`: 1 allocation, `Get`: 2 allocations).

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

There are no API, wire-format, or cryptographic behavior changes. HMAC instances are still reset before returning to the cipher-local `sync.Pool`, and tag comparison remains constant-time.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/crypto`
- `gopls check internal/crypto/crypto.go internal/crypto/crypto_test.go`
- compiler escape analysis with `-gcflags=-m=2`
- six-run `benchstat` comparison for encrypt, decrypt, and round-trip
- downstream state and token-storage allocation benchmarks

#### Particularly user-facing changes

Reduces allocation rate and GC pressure during encrypted OAuth state and refresh-token operations without changing behavior.

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR