### PR TITLE
feat: reduce CEL evaluation allocations

### DIFF
--- a/internal/oauth2/cel.go
+++ b/internal/oauth2/cel.go
@@ -18,6 +18,36 @@ const (
 	CELAuthModeNonInteractive = types.AuthModeNonInteractive
 )
 
+// celActivation keeps the fixed CEL variables inline and resolves pointers to them,
+// avoiding the map allocation and interface boxing required by map-based activations.
+type celActivation struct {
+	auth    celAuthContext
+	openvpn celOpenVPNContext
+	token   celTokenContext
+	user    celUserContext
+}
+
+var _ cel.Activation = (*celActivation)(nil)
+
+func (a *celActivation) ResolveName(name string) (any, bool) {
+	switch name {
+	case "auth":
+		return &a.auth, true
+	case "openvpn":
+		return &a.openvpn, true
+	case "token":
+		return &a.token, true
+	case "user":
+		return &a.user, true
+	default:
+		return nil, false
+	}
+}
+
+func (a *celActivation) Parent() cel.Activation {
+	return nil
+}
+
 // newCELEnvironment returns the common CEL environment used by all configurable expressions.
 func newCELEnvironment() (*cel.Env, error) {
 	env, err := cel.NewEnv(
@@ -172,7 +202,7 @@ func newCELActivation(
 	session state.State,
 	tokens *idtoken.IDToken,
 	userInfo types.UserInfo,
-) map[string]any {
+) *celActivation {
 	var claims map[string]any
 
 	tokenIP := ""
@@ -195,20 +225,20 @@ func newCELActivation(
 		roles = make([]string, 0)
 	}
 
-	return map[string]any{
-		"auth": celAuthContext{
+	return &celActivation{
+		auth: celAuthContext{
 			mode: string(authMode),
 		},
-		"openvpn": celOpenVPNContext{
+		openvpn: celOpenVPNContext{
 			commonName:   session.Client.CommonName,
 			ip:           session.IPAddr,
 			sessionState: session.SessionState,
 		},
-		"token": celTokenContext{
+		token: celTokenContext{
 			claims: claims,
 			ip:     tokenIP,
 		},
-		"user": celUserContext{
+		user: celUserContext{
 			email:    userInfo.Email,
 			groups:   groups,
 			roles:    roles,

--- a/internal/oauth2/cel_context.go
+++ b/internal/oauth2/cel_context.go
@@ -145,13 +145,13 @@ type celContextTypeAdapter struct {
 
 func (a *celContextTypeAdapter) NativeToValue(value any) ref.Val {
 	switch value.(type) {
-	case celAuthContext:
+	case celAuthContext, *celAuthContext:
 		return a.newContextValue(celAuthContextTypeName, value)
-	case celOpenVPNContext:
+	case celOpenVPNContext, *celOpenVPNContext:
 		return a.newContextValue(celOpenVPNContextTypeName, value)
-	case celTokenContext:
+	case celTokenContext, *celTokenContext:
 		return a.newContextValue(celTokenContextTypeName, value)
-	case celUserContext:
+	case celUserContext, *celUserContext:
 		return a.newContextValue(celUserContextTypeName, value)
 	default:
 		return a.Adapter.NativeToValue(value)
@@ -189,6 +189,11 @@ func (v *celContextValue) ConvertToNative(typeDesc reflect.Type) (any, error) {
 		return v.value, nil
 	}
 
+	valueReflection := reflect.ValueOf(v.value)
+	if valueType.Kind() == reflect.Pointer && !valueReflection.IsNil() && valueType.Elem().AssignableTo(typeDesc) {
+		return valueReflection.Elem().Interface(), nil
+	}
+
 	if typeDesc.Kind() == reflect.Pointer && valueType.AssignableTo(typeDesc.Elem()) {
 		valuePtr := reflect.New(typeDesc.Elem())
 		valuePtr.Elem().Set(reflect.ValueOf(v.value))
@@ -217,7 +222,7 @@ func (v *celContextValue) Equal(other ref.Val) ref.Val {
 		return celtypes.False
 	}
 
-	return celtypes.Bool(reflect.DeepEqual(v.value, otherContext.value))
+	return celtypes.Bool(reflect.DeepEqual(dereferenceCELContext(v.value), dereferenceCELContext(otherContext.value)))
 }
 
 func (v *celContextValue) Get(field ref.Val) ref.Val {
@@ -248,7 +253,7 @@ func (v *celContextValue) Type() ref.Type {
 }
 
 func (v *celContextValue) Value() any {
-	return v.value
+	return dereferenceCELContext(v.value)
 }
 
 func (v *celContextValue) findField(field ref.Val) (*celtypes.FieldType, ref.Val) {
@@ -441,12 +446,12 @@ func newCELContextField[Context, Value any](fieldName string, fieldType *cel.Typ
 		fieldType: &celtypes.FieldType{
 			Type: fieldType,
 			IsSet: func(target any) bool {
-				_, ok := target.(Context)
+				_, ok := asCELContext[Context](target)
 
 				return ok
 			},
 			GetFrom: func(target any) (any, error) {
-				context, ok := target.(Context)
+				context, ok := asCELContext[Context](target)
 				if !ok {
 					return nil, fmt.Errorf("invalid cel context for field %q: %T", fieldName, target)
 				}
@@ -455,4 +460,29 @@ func newCELContextField[Context, Value any](fieldName string, fieldType *cel.Typ
 			},
 		},
 	}
+}
+
+func asCELContext[Context any](target any) (Context, bool) {
+	context, ok := target.(Context)
+	if ok {
+		return context, true
+	}
+
+	contextPtr, ok := target.(*Context)
+	if ok && contextPtr != nil {
+		return *contextPtr, true
+	}
+
+	var zero Context
+
+	return zero, false
+}
+
+func dereferenceCELContext(value any) any {
+	valueReflection := reflect.ValueOf(value)
+	if valueReflection.Kind() == reflect.Pointer && !valueReflection.IsNil() {
+		return valueReflection.Elem().Interface()
+	}
+
+	return value
 }

--- a/internal/oauth2/cel_context_test.go
+++ b/internal/oauth2/cel_context_test.go
@@ -147,6 +147,7 @@ func TestCELContextEvaluation(t *testing.T) {
 		has(user.username) &&
 		!has(token.claims.missing) &&
 		auth == auth &&
+		auth == openvpn_auth_oauth2.AuthContext{mode: "interactive"} &&
 		openvpn == openvpn &&
 		token == token &&
 		user == user &&


### PR DESCRIPTION
## Summary

- replace the per-evaluation CEL variable map with a concrete `cel.Activation`
- keep the four context values inline and resolve pointers, avoiding interface-boxed context copies
- preserve native conversion and value equality between pointer-backed inputs and CEL-constructed values

## Why

Allocation profiling and compiler escape analysis identified `newCELActivation` as the dominant avoidable allocation site in the CEL identity-check hot path. The map literal and all four context values escaped independently on every evaluation.

The concrete activation reduces that to one intentional activation object. It remains request-local and immutable during evaluation; no pooling or cross-request retention is introduced.

## Benchmark

Apple M1, darwin/arm64, Go 1.26.5, 10 runs:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| equality time | 396.1 ns/op | 192.3 ns/op | -51.46% |
| equality bytes | 584 B/op | 256 B/op | -56.16% |
| equality allocations | 10 allocs/op | 5 allocs/op | -50.00% |
| lower-ascii time | 627.6 ns/op | 420.8 ns/op | -32.95% |
| lower-ascii bytes | 648 B/op | 320 B/op | -50.62% |
| lower-ascii allocations | 14 allocs/op | 9 allocs/op | -35.71% |

All differences are statistically significant (`p=0.000`, `n=10`).

## Testing

- `make fmt`
- `make lint`
- `make test`
- `go test -run '^$' -bench '^BenchmarkCheckIdentityCEL$' -benchmem -count=10 ./internal/oauth2`
- `go test -run '^$' -gcflags='-m -m' ./internal/oauth2`