### PR TITLE
feat: reduce CEL string field allocations

### DIFF
--- a/internal/oauth2/cel_context.go
+++ b/internal/oauth2/cel_context.go
@@ -58,21 +58,21 @@ func newCELContextSchemas() map[string]*celContextSchema {
 		celAuthContextTypeName: newCELContextSchema(
 			celAuthContextTypeName,
 			newCELAuthContext,
-			newCELContextField("mode", cel.StringType, func(context celAuthContext) string {
-				return context.mode
+			newCELStringContextField("mode", func(context *celAuthContext) *string {
+				return &context.mode
 			}),
 		),
 		celOpenVPNContextTypeName: newCELContextSchema(
 			celOpenVPNContextTypeName,
 			newCELOpenVPNContext,
-			newCELContextField("commonName", cel.StringType, func(context celOpenVPNContext) string {
-				return context.commonName
+			newCELStringContextField("commonName", func(context *celOpenVPNContext) *string {
+				return &context.commonName
 			}),
-			newCELContextField("ip", cel.StringType, func(context celOpenVPNContext) string {
-				return context.ip
+			newCELStringContextField("ip", func(context *celOpenVPNContext) *string {
+				return &context.ip
 			}),
-			newCELContextField("sessionState", cel.StringType, func(context celOpenVPNContext) string {
-				return context.sessionState
+			newCELStringContextField("sessionState", func(context *celOpenVPNContext) *string {
+				return &context.sessionState
 			}),
 		),
 		celTokenContextTypeName: newCELContextSchema(
@@ -81,15 +81,15 @@ func newCELContextSchemas() map[string]*celContextSchema {
 			newCELContextField("claims", cel.MapType(cel.StringType, cel.DynType), func(context celTokenContext) map[string]any {
 				return context.claims
 			}),
-			newCELContextField("ip", cel.StringType, func(context celTokenContext) string {
-				return context.ip
+			newCELStringContextField("ip", func(context *celTokenContext) *string {
+				return &context.ip
 			}),
 		),
 		celUserContextTypeName: newCELContextSchema(
 			celUserContextTypeName,
 			newCELUserContext,
-			newCELContextField("email", cel.StringType, func(context celUserContext) string {
-				return context.email
+			newCELStringContextField("email", func(context *celUserContext) *string {
+				return &context.email
 			}),
 			newCELContextField("groups", cel.ListType(cel.StringType), func(context celUserContext) []string {
 				return context.groups
@@ -97,11 +97,11 @@ func newCELContextSchemas() map[string]*celContextSchema {
 			newCELContextField("roles", cel.ListType(cel.StringType), func(context celUserContext) []string {
 				return context.roles
 			}),
-			newCELContextField("subject", cel.StringType, func(context celUserContext) string {
-				return context.subject
+			newCELStringContextField("subject", func(context *celUserContext) *string {
+				return &context.subject
 			}),
-			newCELContextField("username", cel.StringType, func(context celUserContext) string {
-				return context.username
+			newCELStringContextField("username", func(context *celUserContext) *string {
+				return &context.username
 			}),
 		),
 	}
@@ -460,6 +460,43 @@ func newCELContextField[Context, Value any](fieldName string, fieldType *cel.Typ
 			},
 		},
 	}
+}
+
+// newCELStringContextField returns pointers to activation-owned strings so the
+// CEL adapter can convert them without first allocating an interface-boxed copy.
+func newCELStringContextField[Context any](fieldName string, getValue func(*Context) *string) celContextField {
+	return celContextField{
+		name: fieldName,
+		fieldType: &celtypes.FieldType{
+			Type: cel.StringType,
+			IsSet: func(target any) bool {
+				_, ok := asCELContext[Context](target)
+
+				return ok
+			},
+			GetFrom: func(target any) (any, error) {
+				context, ok := target.(*Context)
+				if ok && context != nil {
+					return getValue(context), nil
+				}
+
+				return getCELStringContextFieldFromValue(fieldName, target, getValue)
+			},
+		},
+	}
+}
+
+func getCELStringContextFieldFromValue[Context any](
+	fieldName string,
+	target any,
+	getValue func(*Context) *string,
+) (any, error) {
+	context, ok := target.(Context)
+	if !ok {
+		return nil, fmt.Errorf("invalid cel context for field %q: %T", fieldName, target)
+	}
+
+	return getValue(&context), nil
 }
 
 func asCELContext[Context any](target any) (Context, bool) {


### PR DESCRIPTION
## Summary

- return pointers for string fields stored in request-local CEL activation contexts
- let `cel-go` adapt those pointers directly instead of first allocating interface-boxed string copies
- retain a value-backed fallback for CEL-constructed context objects

## Why

After the concrete activation change, allocation profiling showed that `newCELContextField` still allocated once for each accessed string field. The generic getter returned a string through `any`, forcing an interface-boxed copy before `cel-go` converted it to `types.String`.

String fields now use a focused getter that returns a pointer when the context comes from the request-local activation. Map and list fields are unchanged. The existing construction path continues to support value-backed contexts.

A post-change allocation profile contains only the single activation object and the two concrete `cel-go` string values required by the equality expression; project field-getter allocation sites are gone.

## Benchmark

Apple M1, darwin/arm64, Go 1.26.5, 10 runs:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| equality time | 201.2 ns/op | 149.3 ns/op | -25.80% |
| equality bytes | 256 B/op | 224 B/op | -12.50% |
| equality allocations | 5 allocs/op | 3 allocs/op | -40.00% |
| lower-ascii time | 421.6 ns/op | 371.8 ns/op | -11.79% |
| lower-ascii bytes | 320 B/op | 288 B/op | -10.00% |
| lower-ascii allocations | 9 allocs/op | 7 allocs/op | -22.22% |

All differences are statistically significant (`p=0.000`, `n=10`).

## Testing

- `make fmt`
- `make lint`
- `make test`
- `go test -run '^$' -bench '^BenchmarkCheckIdentityCEL$' -benchmem -count=10 ./internal/oauth2`
- benchmark allocation profiles inspected with `go tool pprof -alloc_objects` and `-alloc_space`
- compiler escape analysis inspected with `go test -gcflags='-m -m'`