### PR TITLE
feat: reduce proxy-header allocations

### DIFF
--- a/internal/oauth2/utils.go
+++ b/internal/oauth2/utils.go
@@ -38,21 +38,28 @@ func checkClientIPAddr(r *http.Request, conf *config.Config, session state.State
 }
 
 func clientIPFromForwardedChain(remoteAddr string, forwardedForHeaders, trustedProxies []string) string {
-	forwardedFor := strings.Join(forwardedForHeaders, ",")
-	forwardedAddrs := strings.Split(forwardedFor, ",")
 	currentAddr := remoteAddr
 
-	for _, forwardedAddr := range slices.Backward(forwardedAddrs) {
-		if !addrTrustedProxy(currentAddr, trustedProxies) {
-			return currentAddr
-		}
+	for _, forwardedFor := range slices.Backward(forwardedForHeaders) {
+		for {
+			if !addrTrustedProxy(currentAddr, trustedProxies) {
+				return currentAddr
+			}
 
-		forwardedAddr = strings.TrimSpace(forwardedAddr)
-		if forwardedAddr == "" {
-			continue
-		}
+			comma := strings.LastIndexByte(forwardedFor, ',')
+			forwardedAddr := forwardedFor[comma+1:]
+			forwardedAddr = strings.TrimSpace(forwardedAddr)
 
-		currentAddr = forwardedAddr
+			if forwardedAddr != "" {
+				currentAddr = forwardedAddr
+			}
+
+			if comma < 0 {
+				break
+			}
+
+			forwardedFor = forwardedFor[:comma]
+		}
 	}
 
 	return currentAddr


### PR DESCRIPTION
#### What this PR does / why we need it

Allocation profiling of the client-IP check attributed the proxy-header path's only allocation to `strings.Split`. The helper first joined all `X-Forwarded-For` header values and then split the combined string before walking it from right to left.

This PR traverses the existing header values and their comma-separated entries directly in reverse order. It preserves the trusted-proxy boundary checks, whitespace handling, empty entries, and multiple-header behavior without materializing a temporary slice.

Ten-run benchmark results on Go 1.26.5, darwin/arm64, Apple M1:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| proxy-header time | 229.6 ns/op | 203.0 ns/op | -11.60% |
| proxy-header bytes | 32 B/op | 0 B/op | -100.00% |
| proxy-header allocations | 1 alloc/op | 0 allocs/op | -100.00% |
| direct time | 13.42 ns/op | 13.42 ns/op | no significant change |

The proxy-header differences are statistically significant (`p=0.000`, `n=10`).

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -run '^$' -bench '^BenchmarkCheckClientIPAddr$' -benchmem -count=10 ./internal/oauth2`
- `go run golang.org/x/perf/cmd/benchstat@latest <before> <after>`
- allocation profile inspected with `go tool pprof -alloc_objects`
- compiler escape and inlining decisions inspected with `go test -gcflags='-m=2'`

#### Particularly user-facing changes

OAuth2 callbacks using trusted proxy headers perform the client-IP verification without allocating a temporary split slice. Behavior and configuration are unchanged.

#### Checklist

Complete these before marking the PR as `ready to review`:

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR