### PR TITLE
feat: reduce encrypted token decryption allocations

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -183,7 +183,7 @@ func (c *Cipher) EncryptBytesWithTime(plainText []byte) ([]byte, error) {
 
 // DecryptBytesWithTime decodes, authenticates, decrypts, and validates the timestamp on raw URL-base64 input.
 func (c *Cipher) DecryptBytesWithTime(encryptedBase64 []byte) ([]byte, error) {
-	if err := checkTokenSize(encryptedBase64); err != nil {
+	if err := checkTokenSize(len(encryptedBase64)); err != nil {
 		return nil, err
 	}
 
@@ -194,7 +194,28 @@ func (c *Cipher) DecryptBytesWithTime(encryptedBase64 []byte) ([]byte, error) {
 		return nil, fmt.Errorf("base64 decode %q: %w", encryptedBase64, err)
 	}
 
-	data, err := c.DecryptBytes(encrypted[:decodedLen])
+	return c.decryptTimedPayload(encrypted[:decodedLen])
+}
+
+// DecryptStringWithTime decodes, authenticates, decrypts, and validates
+// the timestamp on raw URL-base64 string input.
+func (c *Cipher) DecryptStringWithTime(encryptedBase64 string) ([]byte, error) {
+	if err := checkTokenSize(len(encryptedBase64)); err != nil {
+		return nil, err
+	}
+
+	encrypted, err := base64.RawURLEncoding.DecodeString(encryptedBase64)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode %q: %w", encryptedBase64, err)
+	}
+
+	return c.decryptTimedPayload(encrypted)
+}
+
+// decryptTimedPayload authenticates, decrypts, and validates
+// an already base64-decoded timestamped payload.
+func (c *Cipher) decryptTimedPayload(encrypted []byte) ([]byte, error) {
+	data, err := c.DecryptBytes(encrypted)
 	if err != nil {
 		return nil, err
 	}
@@ -230,8 +251,8 @@ func (c *Cipher) putMAC(macHash *pooledMAC) {
 }
 
 // checkTokenSize rejects unreasonably large encoded payloads before allocating decode buffers.
-func checkTokenSize(encodedState []byte) error {
-	if len(encodedState) > 4096 {
+func checkTokenSize(encodedLength int) error {
+	if encodedLength > 4096 {
 		return fmt.Errorf("%w: token too large", ErrInvalid)
 	}
 

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -269,6 +269,19 @@ func TestDecryptBytesWithTimeMaxAge(t *testing.T) {
 	require.Equal(t, []byte("payload"), decrypted)
 }
 
+func TestDecryptStringWithTime(t *testing.T) {
+	t.Parallel()
+
+	cipher := crypto.New("test-key")
+
+	encrypted, err := cipher.EncryptBytesWithTime([]byte("hello world"))
+	require.NoError(t, err)
+
+	decrypted, err := cipher.DecryptStringWithTime(string(encrypted))
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello world"), decrypted)
+}
+
 func TestCipherConsistency(t *testing.T) {
 	t.Parallel()
 

--- a/internal/crypto/doc.go
+++ b/internal/crypto/doc.go
@@ -13,8 +13,8 @@
 // the configured secret with HKDF-SHA256 and different info strings.
 //
 // EncryptBytesWithTime wraps the encrypted payload with an issued timestamp and
-// encodes the result using unpadded URL-safe base64. DecryptBytesWithTime only
-// accepts that raw URL-base64 form, rejects oversized input, verifies integrity,
-// and rejects data older than the cipher's configured maximum age or issued
-// more than five seconds in the future.
+// encodes the result using unpadded URL-safe base64. DecryptBytesWithTime and
+// DecryptStringWithTime only accept that raw URL-base64 form, reject oversized
+// input, verify integrity, and reject data older than the cipher's configured
+// maximum age or issued more than five seconds in the future.
 package crypto

--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -157,7 +157,7 @@ func (c *Client) OAuth2ProfileSubmit() http.Handler {
 			return
 		}
 
-		tokenBytes, err := c.stateCrypto.DecryptBytesWithTime([]byte(encryptedToken))
+		tokenBytes, err := c.stateCrypto.DecryptStringWithTime(encryptedToken)
 		if err != nil {
 			c.writeHTTPError(ctx, w, c.logger, http.StatusBadRequest, "Invalid token", err.Error())
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -72,7 +72,7 @@ func Decrypt(cipher *crypto.Cipher, encryptedState EncryptedState) (State, error
 		return State{}, errors.New("cipher is required")
 	}
 
-	data, err := cipher.DecryptBytesWithTime([]byte(encryptedState))
+	data, err := cipher.DecryptStringWithTime(encryptedState)
 	if err != nil {
 		return State{}, fmt.Errorf("decrypt state: %w", err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it

Allocation profiling of OAuth state decryption showed that converting the raw URL-base64 state string to `[]byte` created one full copy before decoding. The same conversion occurred when decrypting profile-selector form tokens.

This PR adds a string-oriented timestamped decrypt entry point that uses `encoding/base64.DecodeString`, retains the existing byte-oriented API, and shares authentication and timestamp validation between both paths. OAuth state and profile-selector token decryption now use the string path directly.

Go 1.26.5 escape analysis reports the standard-library decoder's conversion as `zero-copy string->[]byte conversion`, and the post-change allocation profile no longer attributes an allocation to `state.Decrypt`.

Ten-run benchmark results on Go 1.26.5, darwin/arm64, Apple M1:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| state decrypt time | 535.8 ns/op | 509.3 ns/op | -4.95% |
| state decrypt bytes | 232 B/op | 136 B/op | -41.38% |
| state decrypt allocations | 6 allocs/op | 5 allocs/op | -16.67% |

All differences are statistically significant (`p=0.000`, `n=10`). A final verification after rebasing onto the latest dependency updates retained `136 B/op` and `5 allocs/op`.

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -run '^$' -bench '^BenchmarkStateDecrypt$' -benchmem -count=10 ./internal/state`
- `go run golang.org/x/perf/cmd/benchstat@latest <before> <after>`
- allocation profiles inspected with `go tool pprof -alloc_objects`
- compiler escape analysis inspected with `go test -gcflags='all=-m=2'`

#### Particularly user-facing changes

OAuth state and profile-selector tokens are decrypted without first copying their encoded strings. Token format, validation, configuration, and error behavior are unchanged.

#### Checklist

Complete these before marking the PR as `ready to review`:

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR