### PR TITLE
feat: reduce state encryption allocations

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -12,6 +12,9 @@ import (
 const (
 	binaryStateVersion = 2
 
+	// stateEncodingScratchSize covers typical states while retaining a heap fallback for larger values.
+	stateEncodingScratchSize = 128
+
 	flagSessionID         = 1 << 0
 	flagCommonName        = 1 << 1
 	flagIPAddrV4          = 1 << 2
@@ -56,7 +59,9 @@ func Encrypt(cipher *crypto.Cipher, state State) (EncryptedState, error) {
 		return "", errors.New("cipher is required")
 	}
 
-	data := encodeState(state)
+	var scratch [stateEncodingScratchSize]byte
+
+	data := encodeState(scratch[:0], state)
 
 	encrypted, err := cipher.EncryptBytesWithTime(data)
 	if err != nil {
@@ -85,15 +90,8 @@ func Decrypt(cipher *crypto.Cipher, encryptedState EncryptedState) (State, error
 	return state, nil
 }
 
-// encodeState serializes State into the compact binary payload protected by Encrypt.
-func encodeState(state State) []byte {
-	data := make([]byte, 0, 4+
-		binary.MaxVarintLen64*2+
-		len(state.Client.SessionID)+
-		len(state.Client.CommonName)+
-		len(state.IPAddr)+
-		len(state.IPPort))
-
+// encodeState appends State as the compact binary payload protected by Encrypt.
+func encodeState(data []byte, state State) []byte {
 	flags, ipAddr := encodeStateFlags(state)
 
 	data = append(data, binaryStateVersion, flags, encodeSessionState(state.SessionState)[0])

--- a/internal/state/state_binary_test.go
+++ b/internal/state/state_binary_test.go
@@ -10,7 +10,7 @@ import (
 func TestEncodeStateUsesCompactBinaryPayload(t *testing.T) {
 	t.Parallel()
 
-	payload := encodeState(State{
+	payload := encodeState(nil, State{
 		Client: ClientIdentifier{
 			CID:        1,
 			KID:        2,

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -26,6 +26,7 @@ func TestState(t *testing.T) {
 		{name: "ipv6 address", commonName: "foobar", ipAddr: "2001:db8::1", ipPort: "12345", sessionState: "Authenticated"},
 		{name: "with special characters", commonName: "foo bar/baz@qux", ipAddr: "127.0.0.1", ipPort: "12345", sessionState: "AuthenticatedEmptyUser"},
 		{name: "with unicode characters", commonName: "foo bar/baz@qux 你好", ipAddr: "127.0.0.1", ipPort: "12345", sessionState: "ExpiredEmptyUser"},
+		{name: "larger than encoding scratch", commonName: strings.Repeat("a", 512), ipAddr: "::", ipPort: "12345", sessionState: "Authenticated"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
#### What this PR does / why we need it

State encryption previously allocated a temporary serialization buffer on every call. This change appends the compact state payload into a bounded 128-byte stack scratch buffer. Oversized states retain safe heap-backed growth through `append`.

A 10-run `BenchmarkStateEncrypt` comparison on an Apple M1 shows:

| metric | before | after | change |
| --- | ---: | ---: | ---: |
| time/op | 579.4 ns | 579.1 ns | unchanged (`p=0.669`) |
| bytes/op | 368 B | 320 B | -13.04% |
| allocs/op | 6 | 5 | -16.67% |

An allocation profile confirms that `encodeState` now has zero flat allocations on the benchmarked hot path.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

The round-trip state test includes an oversized payload with a compact IPv6 address to exercise the heap-growth fallback.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -run '^$' -bench '^BenchmarkStateEncrypt$' -benchmem -count=10 ./internal/state`
- allocation profile and compiler escape analysis

#### Particularly user-facing changes

None. This is an internal allocation optimization with unchanged state encoding and behavior.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR