### PR TITLE
feat: reduce state IP formatting allocations

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -15,6 +15,9 @@ const (
 	// stateEncodingScratchSize covers typical states while retaining a heap fallback for larger values.
 	stateEncodingScratchSize = 128
 
+	// ipAddrTextScratchSize holds any canonical IP address without a zone.
+	ipAddrTextScratchSize = len("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+
 	flagSessionID         = 1 << 0
 	flagCommonName        = 1 << 1
 	flagIPAddrV4          = 1 << 2
@@ -153,7 +156,15 @@ func encodeStateFlags(state State) (byte, netip.Addr) {
 	}
 
 	addr, err := netip.ParseAddr(state.IPAddr)
-	if err != nil || addr.String() != state.IPAddr {
+	if err != nil {
+		flags |= flagIPAddrText
+
+		return flags, ipAddr
+	}
+
+	var scratch [ipAddrTextScratchSize]byte
+
+	if string(addr.AppendTo(scratch[:0])) != state.IPAddr {
 		flags |= flagIPAddrText
 
 		return flags, ipAddr

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -24,6 +24,8 @@ func TestState(t *testing.T) {
 		{name: "non-empty session state", commonName: "", ipAddr: "127.0.0.1", ipPort: "12345", sessionState: "Authenticated"},
 		{name: "empty ip address and port", commonName: "foobar", ipAddr: "", ipPort: "", sessionState: "Authenticated"},
 		{name: "ipv6 address", commonName: "foobar", ipAddr: "2001:db8::1", ipPort: "12345", sessionState: "Authenticated"},
+		{name: "maximum length ipv6 address", commonName: "foobar", ipAddr: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", ipPort: "12345", sessionState: "Authenticated"},
+		{name: "noncanonical ipv6 address", commonName: "foobar", ipAddr: "2001:0DB8:0:0:0:0:0:1", ipPort: "12345", sessionState: "Authenticated"},
 		{name: "with special characters", commonName: "foo bar/baz@qux", ipAddr: "127.0.0.1", ipPort: "12345", sessionState: "AuthenticatedEmptyUser"},
 		{name: "with unicode characters", commonName: "foo bar/baz@qux 你好", ipAddr: "127.0.0.1", ipPort: "12345", sessionState: "ExpiredEmptyUser"},
 		{name: "larger than encoding scratch", commonName: strings.Repeat("a", 512), ipAddr: "::", ipPort: "12345", sessionState: "Authenticated"},


### PR DESCRIPTION
#### What this PR does / why we need it

State serialization checks whether an IP address is canonical before choosing its compact binary representation. That check previously called `netip.Addr.String`, creating a heap string for every canonical address.

This change uses `netip.Addr.AppendTo` with a bounded stack buffer and compares the appended bytes without an escaping string allocation. `append` retains heap-backed growth for zoned addresses longer than the buffer.

A controlled ten-run comparison used precompiled merged-main and candidate test binaries in alternating order on an Apple M1:

| metric | before | after | change |
| --- | ---: | ---: | ---: |
| time/op | 575.3 ns | 562.9 ns | -2.16% (`p=0.001`) |
| bytes/op | 320 B | 304 B | -5.00% |
| allocs/op | 5 | 4 | -20.00% |

The baseline allocation profile attributed 19.7% of allocated objects to `netip.Addr.string4`; the candidate profile contains no `Addr.string4` or `encodeStateFlags` allocation site.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

Go 1.26 escape analysis reports that the temporary `string(addr.AppendTo(...))` comparison does not escape. Round-trip tests cover the maximum 39-byte unzoned IPv6 representation and preservation of noncanonical IPv6 text.

Validation:

- `make fmt`
- `make lint`
- `make test`
- compiler escape analysis with `-gcflags='-m=2'`
- before/after allocation profiles with `pprof -alloc_objects`
- interleaved `BenchmarkStateEncrypt` comparison with ten samples per revision

#### Particularly user-facing changes

None. State encoding and round-trip behavior are unchanged.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR