### PR TITLE
feat: reduce timestamped encryption allocations

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -23,6 +23,9 @@ const (
 	hmacTagSize      = 16
 	derivedKeySize   = 32
 	defaultMaxAge    = 2 * time.Minute
+
+	// timedPlainTextScratchSize covers typical authentication payloads while append retains a heap fallback.
+	timedPlainTextScratchSize = 128
 )
 
 // ErrCipherTextBlockSize is returned when the ciphertext block size is too short.
@@ -165,7 +168,10 @@ func (c *Cipher) DecryptBytes(encryptedData []byte) ([]byte, error) {
 // EncryptBytesWithTime prefixes plaintext with the current Unix timestamp, encrypts it, and returns raw URL-base64 bytes.
 func (c *Cipher) EncryptBytesWithTime(plainText []byte) ([]byte, error) {
 	issued := time.Now().Round(time.Second).Unix()
-	timedPlainText := strconv.AppendInt(make([]byte, 0, len(plainText)+12), issued, 10)
+
+	var scratch [timedPlainTextScratchSize]byte
+
+	timedPlainText := strconv.AppendInt(scratch[:0], issued, 10)
 	timedPlainText = append(timedPlainText, ' ')
 	timedPlainText = append(timedPlainText, plainText...)
 

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -235,16 +235,28 @@ func TestRoundTrip(t *testing.T) {
 func TestEncryptBytesWithTimeUsesRawURLBase64(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	for _, tc := range []struct {
+		name      string
+		plainText []byte
+	}{
+		{name: "small payload", plainText: []byte("hello world")},
+		{name: "large payload", plainText: bytes.Repeat([]byte("a"), 512)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	encrypted, err := cipher.EncryptBytesWithTime([]byte("hello world"))
-	require.NoError(t, err)
+			cipher := crypto.New("test-key")
 
-	require.NotContains(t, string(encrypted), "=")
+			encrypted, err := cipher.EncryptBytesWithTime(tc.plainText)
+			require.NoError(t, err)
 
-	decrypted, err := cipher.DecryptBytesWithTime(encrypted)
-	require.NoError(t, err)
-	require.Equal(t, []byte("hello world"), decrypted)
+			require.NotContains(t, string(encrypted), "=")
+
+			decrypted, err := cipher.DecryptBytesWithTime(encrypted)
+			require.NoError(t, err)
+			require.Equal(t, tc.plainText, decrypted)
+		})
+	}
 }
 
 func TestDecryptBytesWithTimeMaxAge(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it

`Cipher.EncryptBytesWithTime` previously created its timestamp-prefixed plaintext with a runtime-sized `make`. Go 1.26 escape analysis reported that slice as non-escaping, but its dynamic size still required a heap allocation; the baseline allocation profile attributed about 22.7% of allocated objects to that line.

This change builds typical timestamped authentication payloads in a fixed 128-byte stack scratch buffer. Normal `append` growth preserves behavior for larger state and profile-selector payloads.

A controlled ten-run comparison used precompiled merged-main and candidate test binaries in alternating order on an Apple M1:

| metric | before | after | change |
| --- | ---: | ---: | ---: |
| time/op | 562.1 ns | 554.6 ns | unchanged (`p=0.060`) |
| bytes/op | 304 B | 256 B | -15.79% |
| allocs/op | 4 | 3 | -25.00% |

The candidate allocation profile has no flat allocation on the timestamp-prefix construction; the remaining three allocations are the ciphertext, base64 output, and returned state string.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

Timestamped-encryption round-trip coverage now includes both a small payload and a 512-byte payload that exercises heap-backed append growth.

Validation:

- `make fmt`
- `make lint`
- `make test`
- compiler analysis with `-gcflags='-m=2'`
- before/after `pprof -alloc_objects` profiles
- interleaved `BenchmarkStateEncrypt` comparison with ten samples per revision

#### Particularly user-facing changes

None. Encryption format and behavior are unchanged.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR