### PR TITLE
feat: reduce timestamped string allocations

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -12,9 +12,9 @@ import (
 	"hash"
 	"io"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"golang.org/x/crypto/salsa20"
 )
@@ -28,6 +28,8 @@ const (
 	// timedPlainTextScratchSize covers typical authentication payloads while append retains a heap fallback.
 	timedPlainTextScratchSize = 128
 	timedEncryptedScratchSize = timedPlainTextScratchSize + salsa20NonceSize + hmacTagSize
+	base64SourceChunkSize     = timedEncryptedScratchSize - timedEncryptedScratchSize%3
+	base64EncodedChunkSize    = base64SourceChunkSize / 3 * 4
 )
 
 // ErrCipherTextBlockSize is returned when the ciphertext block size is too short.
@@ -133,18 +135,10 @@ func (c *Cipher) DecryptBytes(encryptedData []byte) ([]byte, error) {
 
 // EncryptBytesWithTime prefixes plaintext with the current Unix timestamp, encrypts it, and returns raw URL-base64 bytes.
 func (c *Cipher) EncryptBytesWithTime(plainText []byte) ([]byte, error) {
-	issued := time.Now().Round(time.Second).Unix()
-
-	var scratch [timedPlainTextScratchSize]byte
-
-	timedPlainText := strconv.AppendInt(scratch[:0], issued, 10)
-	timedPlainText = append(timedPlainText, ' ')
-	timedPlainText = append(timedPlainText, plainText...)
-
 	macHash := c.getMAC()
 	defer c.putMAC(macHash)
 
-	encrypted, err := c.encryptBytesInto(macHash.encrypted[:0], timedPlainText, macHash)
+	encrypted, err := c.encryptTimedBytes(plainText, macHash)
 	if err != nil {
 		return nil, err
 	}
@@ -159,14 +153,15 @@ func (c *Cipher) EncryptBytesWithTime(plainText []byte) ([]byte, error) {
 // EncryptStringWithTime prefixes plaintext with the current Unix timestamp,
 // encrypts it, and returns a raw URL-base64 string.
 func (c *Cipher) EncryptStringWithTime(plainText []byte) (string, error) {
-	encrypted, err := c.EncryptBytesWithTime(plainText)
+	macHash := c.getMAC()
+	defer c.putMAC(macHash)
+
+	encrypted, err := c.encryptTimedBytes(plainText, macHash)
 	if err != nil {
 		return "", err
 	}
 
-	// EncryptBytesWithTime returns uniquely owned bytes. No mutable alias remains,
-	// so the backing array can safely become the immutable result without a copy.
-	return unsafe.String(unsafe.SliceData(encrypted), len(encrypted)), nil
+	return encodeRawURLBase64String(encrypted), nil
 }
 
 // DecryptBytesWithTime decodes, authenticates, decrypts, and validates the timestamp on raw URL-base64 input.
@@ -198,6 +193,40 @@ func (c *Cipher) DecryptStringWithTime(encryptedBase64 string) ([]byte, error) {
 	}
 
 	return c.decryptTimedPayload(encrypted)
+}
+
+// encryptTimedBytes prefixes plaintext with a timestamp and encrypts it into pooled scratch.
+// The returned bytes are valid only until macHash is returned to the pool.
+func (c *Cipher) encryptTimedBytes(plainText []byte, macHash *pooledMAC) ([]byte, error) {
+	issued := time.Now().Round(time.Second).Unix()
+
+	var scratch [timedPlainTextScratchSize]byte
+
+	timedPlainText := strconv.AppendInt(scratch[:0], issued, 10)
+	timedPlainText = append(timedPlainText, ' ')
+	timedPlainText = append(timedPlainText, plainText...)
+
+	return c.encryptBytesInto(macHash.encrypted[:0], timedPlainText, macHash)
+}
+
+func encodeRawURLBase64String(src []byte) string {
+	var encoded strings.Builder
+	encoded.Grow(base64.RawURLEncoding.EncodedLen(len(src)))
+
+	var scratch [base64EncodedChunkSize]byte
+
+	for len(src) > base64SourceChunkSize {
+		base64.RawURLEncoding.Encode(scratch[:], src[:base64SourceChunkSize])
+		_, _ = encoded.Write(scratch[:])
+
+		src = src[base64SourceChunkSize:]
+	}
+
+	encodedLen := base64.RawURLEncoding.EncodedLen(len(src))
+	base64.RawURLEncoding.Encode(scratch[:encodedLen], src)
+	_, _ = encoded.Write(scratch[:encodedLen])
+
+	return encoded.String()
 }
 
 // encryptBytesInto encrypts plainText into dst, allocating only when its capacity is insufficient.

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"unsafe"
 
 	"golang.org/x/crypto/salsa20"
 )
@@ -153,6 +154,19 @@ func (c *Cipher) EncryptBytesWithTime(plainText []byte) ([]byte, error) {
 	base64.RawURLEncoding.Encode(encryptedBase64, encrypted)
 
 	return encryptedBase64, nil
+}
+
+// EncryptStringWithTime prefixes plaintext with the current Unix timestamp,
+// encrypts it, and returns a raw URL-base64 string.
+func (c *Cipher) EncryptStringWithTime(plainText []byte) (string, error) {
+	encrypted, err := c.EncryptBytesWithTime(plainText)
+	if err != nil {
+		return "", err
+	}
+
+	// EncryptBytesWithTime returns uniquely owned bytes. No mutable alias remains,
+	// so the backing array can safely become the immutable result without a copy.
+	return unsafe.String(unsafe.SliceData(encrypted), len(encrypted)), nil
 }
 
 // DecryptBytesWithTime decodes, authenticates, decrypts, and validates the timestamp on raw URL-base64 input.

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -263,27 +262,31 @@ func TestEncryptBytesWithTimeUsesRawURLBase64(t *testing.T) {
 	}
 }
 
-func TestEncryptStringWithTimeRemainsStable(t *testing.T) {
+func TestEncryptStringWithTimeUsesRawURLBase64(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
-	plainText := []byte("hello world")
+	for _, tc := range []struct {
+		name      string
+		plainText []byte
+	}{
+		{name: "small payload", plainText: []byte("hello world")},
+		{name: "large payload", plainText: bytes.Repeat([]byte("a"), 512)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	encrypted, err := cipher.EncryptStringWithTime(plainText)
-	require.NoError(t, err)
+			cipher := crypto.New("test-key")
 
-	expected := strings.Clone(encrypted)
+			encrypted, err := cipher.EncryptStringWithTime(tc.plainText)
+			require.NoError(t, err)
 
-	for range 10 {
-		_, err = cipher.EncryptStringWithTime(plainText)
-		require.NoError(t, err)
+			require.NotContains(t, encrypted, "=")
+
+			decrypted, err := cipher.DecryptStringWithTime(encrypted)
+			require.NoError(t, err)
+			require.Equal(t, tc.plainText, decrypted)
+		})
 	}
-
-	require.Equal(t, expected, encrypted)
-
-	decrypted, err := cipher.DecryptStringWithTime(encrypted)
-	require.NoError(t, err)
-	require.Equal(t, plainText, decrypted)
 }
 
 func TestDecryptBytesWithTimeMaxAge(t *testing.T) {

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -260,6 +261,29 @@ func TestEncryptBytesWithTimeUsesRawURLBase64(t *testing.T) {
 			require.Equal(t, tc.plainText, decrypted)
 		})
 	}
+}
+
+func TestEncryptStringWithTimeRemainsStable(t *testing.T) {
+	t.Parallel()
+
+	cipher := crypto.New("test-key")
+	plainText := []byte("hello world")
+
+	encrypted, err := cipher.EncryptStringWithTime(plainText)
+	require.NoError(t, err)
+
+	expected := strings.Clone(encrypted)
+
+	for range 10 {
+		_, err = cipher.EncryptStringWithTime(plainText)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, expected, encrypted)
+
+	decrypted, err := cipher.DecryptStringWithTime(encrypted)
+	require.NoError(t, err)
+	require.Equal(t, plainText, decrypted)
 }
 
 func TestDecryptBytesWithTimeMaxAge(t *testing.T) {

--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -673,12 +673,12 @@ func (c *Client) createProfileSelectorToken(encryptedState state.EncryptedState,
 		return "", fmt.Errorf("unable to marshal profile selector token: %w", err)
 	}
 
-	encryptedToken, err := c.stateCrypto.EncryptBytesWithTime(tokenBytes)
+	encryptedToken, err := c.stateCrypto.EncryptStringWithTime(tokenBytes)
 	if err != nil {
 		return "", fmt.Errorf("unable to encrypt profile selector token: %w", err)
 	}
 
-	return string(encryptedToken), nil
+	return encryptedToken, nil
 }
 
 // httpErrorHandler maps OAuth2 relying party errors to OpenVPN denial and an HTTP error page.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -66,12 +66,12 @@ func Encrypt(cipher *crypto.Cipher, state State) (EncryptedState, error) {
 
 	data := encodeState(scratch[:0], state)
 
-	encrypted, err := cipher.EncryptBytesWithTime(data)
+	encrypted, err := cipher.EncryptStringWithTime(data)
 	if err != nil {
 		return "", fmt.Errorf("encrypt state: %w", err)
 	}
 
-	return EncryptedState(encrypted), nil
+	return encrypted, nil
 }
 
 // Decrypt authenticates, decrypts, and deserializes an encrypted OAuth2 state value.


### PR DESCRIPTION
#### What this PR does / why we need it

Adds `Cipher.EncryptStringWithTime`, which safely Base64-encodes timestamped ciphertext directly into a pre-grown `strings.Builder` using fixed stack chunks. OAuth2 state tokens and profile-selector tokens now use this API, avoiding the intermediate encoded byte-slice allocation and subsequent string copy.

The state encryption hot path improves from:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Bytes/op | 192 | 96 | -50% |
| Allocs/op | 2 | 1 | -50% |

Results are from 10 runs on darwin/arm64 (Apple M1). Timing is intentionally omitted because it was too variable for a reliable claim.

#### Which issue this PR fixes

No issue.

#### Special notes for your reviewer

The implementation does not use `unsafe` or alias mutable bytes into a string. Encryption writes into the existing pooled scratch buffer; Base64 output is copied in fixed-size chunks into a builder that exclusively owns the returned immutable string. The large-payload test exercises the multi-chunk path.

Allocation benchmarks confirm the one-allocation result.

Checks run:

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/crypto ./internal/state ./internal/oauth2`

#### Particularly user-facing changes

None; this is an internal allocation reduction with unchanged token formats and behavior.

#### Checklist

Complete these before marking the PR as `ready to review`:

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
