### PR TITLE
feat: reduce HTTP server configuration footprint

### DIFF
--- a/internal/httpserver/main.go
+++ b/internal/httpserver/main.go
@@ -26,7 +26,9 @@ type Server struct {
 	server           *http.Server
 	tlsCertificate   *tls.Certificate
 	name             string
-	conf             config.HTTP
+	certFile         string
+	keyFile          string
+	tlsEnabled       bool
 	tlsCertificateMu sync.RWMutex
 }
 
@@ -36,9 +38,11 @@ type Server struct {
 // the configuration.
 func NewHTTPServer(name string, logger *slog.Logger, conf config.HTTP, fnHandler *http.ServeMux) *Server {
 	return &Server{
-		name:   name,
-		conf:   conf,
-		logger: logger,
+		name:       name,
+		certFile:   conf.CertFile,
+		keyFile:    conf.KeyFile,
+		tlsEnabled: conf.TLS,
+		logger:     logger,
 		server: &http.Server{
 			Addr:              conf.Listen,
 			ReadHeaderTimeout: 3 * time.Second,
@@ -63,7 +67,7 @@ func (s *Server) Listen(ctx context.Context) error {
 
 	errCh := make(chan error, 1)
 
-	if s.conf.TLS {
+	if s.tlsEnabled {
 		if err := s.Reload(ctx); err != nil {
 			return err
 		}
@@ -118,11 +122,11 @@ func (s *Server) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certifica
 // Reload loads the TLS certificate from disk and updates the server's
 // in-memory certificate. It does nothing if TLS support is disabled.
 func (s *Server) Reload(ctx context.Context) error {
-	if !s.conf.TLS {
+	if !s.tlsEnabled {
 		return nil
 	}
 
-	certs, err := tls.LoadX509KeyPair(s.conf.CertFile, s.conf.KeyFile)
+	certs, err := tls.LoadX509KeyPair(s.certFile, s.keyFile)
 	if err != nil {
 		return fmt.Errorf("tls.LoadX509KeyPair: %w", err)
 	}
@@ -161,13 +165,13 @@ func (s *Server) serve(ctx context.Context) error {
 	} else {
 		var listenConfig net.ListenConfig
 
-		listener, err = listenConfig.Listen(ctx, "tcp", s.conf.Listen)
+		listener, err = listenConfig.Listen(ctx, "tcp", s.server.Addr)
 		if err != nil {
 			return fmt.Errorf("net.Listen: %w", err)
 		}
 	}
 
-	if s.conf.TLS {
+	if s.tlsEnabled {
 		s.logger.LogAttrs(ctx, slog.LevelInfo, fmt.Sprintf(
 			"start HTTPS %s listener on %s", s.name, listener.Addr().String(),
 		))

--- a/internal/httpserver/main_bench_test.go
+++ b/internal/httpserver/main_bench_test.go
@@ -1,0 +1,53 @@
+package httpserver_test
+
+import (
+	"crypto/tls"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/httpserver"
+)
+
+func BenchmarkNewHTTPServer(b *testing.B) {
+	logger := slog.New(slog.DiscardHandler)
+	mux := http.NewServeMux()
+	conf := config.HTTP{Listen: "127.0.0.1:9000"}
+
+	var server *httpserver.Server
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		server = httpserver.NewHTTPServer(httpserver.ServerNameDefault, logger, conf, mux)
+	}
+
+	_ = server
+}
+
+func BenchmarkGetCertificate(b *testing.B) {
+	server := httpserver.NewHTTPServer(
+		httpserver.ServerNameDefault,
+		slog.New(slog.DiscardHandler),
+		config.HTTP{},
+		http.NewServeMux(),
+	)
+	getCertificate := server.GetCertificateFunc()
+
+	var (
+		certificate *tls.Certificate
+		err         error
+	)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		certificate, err = getCertificate(nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	_ = certificate
+}


### PR DESCRIPTION
#### What this PR does / why we need it

The HTTP server copied the complete `config.HTTP` value into its long-lived `Server`, although it only needs TLS certificate paths and the TLS enable flag after construction. The listener address was also retained twice: in the configuration copy and in `http.Server.Addr`.

This change:

- keeps `config.HTTP` as a value parameter, preserving snapshot semantics without pointer aliasing
- stores only the TLS reload fields used after construction
- reuses `http.Server.Addr` when creating the listener
- adds focused constructor and TLS certificate callback benchmarks
- does not import or call `unsafe` directly

Interleaved benchmark on Go 1.26.5, darwin/arm64, Apple M1:

```text
                │  baseline  │             candidate              │
                │    B/op    │    B/op     vs base                │
NewHTTPServer-8   592.0 ± 0%   480.0 ± 0%  -18.92% (p=0.000 n=10)
```

The constructor remains at 5 allocs/op. The recurring TLS certificate callback was measured separately at 0 B/op and 0 allocs/op and is unchanged.

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

This is a per-listener retained/startup footprint reduction, not a request-path allocation claim. Compiler escape analysis confirms that changing the configuration parameter to a pointer would not remove one of the five constructor allocations; it would instead couple the server to caller-owned mutable configuration.

#### Particularly user-facing changes

HTTP listeners retain 112 fewer allocated bytes during construction with no configuration, API, or TLS behavior change.

#### Testing

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/httpserver`
- compiler escape analysis with `go test -gcflags='-m -m' ./internal/httpserver`
- `pprof` alloc-objects and alloc-space profiles
- 10-run interleaved `benchstat` comparison

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR