### PR TITLE
feat: reduce OpenVPN client logger allocations

### DIFF
--- a/internal/openvpn/client.go
+++ b/internal/openvpn/client.go
@@ -18,15 +18,15 @@ import (
 const openVPNManagementCommandBodyLimit = 1023
 
 func (c *Client) processClient(ctx context.Context, client connection.Client) error {
-	logger := c.logger.With(
-		slog.String("ip", fmt.Sprintf("%s:%s", client.IPAddr, client.IPPort)),
+	logger := slog.New(c.logger.Handler().WithAttrs([]slog.Attr{
+		slog.String("ip", client.IPAddr+":"+client.IPPort),
 		slog.Uint64("cid", client.CID),
 		slog.Uint64("kid", client.KID),
 		slog.String("common_name", client.CommonName),
 		slog.String("reason", client.Reason),
 		slog.String("session_id", client.SessionID),
 		slog.String("session_state", client.SessionState),
-	)
+	}))
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()


### PR DESCRIPTION
#### What this PR does / why we need it

Uses the typed `slog.Handler.WithAttrs` path when creating the logger for an OpenVPN client event. This avoids converting every retained `slog.Attr` through `Logger.With(...any)`, which verbose compiler escape analysis showed was moving each attribute to the heap.

The IP and port are concatenated directly with the same output format instead of passing both strings through `fmt.Sprintf`.

The existing end-to-end allocation profile identified `(*Client).processClient` as the largest repeated project-owned allocation site in the OpenVPN request path.

Interleaved precompiled benchmark comparison (10 runs, Apple M1):

| Benchmark | B/op before | B/op after | Change |
| --- | ---: | ---: | ---: |
| OpenVPNHandler/short | 3.758 KiB | 3.064 KiB | -18.45% |
| OpenVPNHandler/real | 12.35 KiB | 11.57 KiB | -6.33% |

| Benchmark | allocs/op before | allocs/op after | Change |
| --- | ---: | ---: | ---: |
| OpenVPNHandler/short | 51 | 40 | -21.57% |
| OpenVPNHandler/real | 54 | 42 | -22.22% |

Runtime did not change significantly, so this PR makes no execution-time claim.

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/openvpn`
- verbose compiler escape analysis with `-gcflags='-m -m'`
- 10-run interleaved `benchstat` comparison of precompiled baseline and candidate binaries
- confirmed the diff introduces no direct `unsafe` use

#### Particularly user-facing changes

Reduces heap churn while processing each OpenVPN client management event without changing authentication behavior or log fields.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR