### PR TITLE
feat: reduce OAuth2 session logger allocations

### DIFF
--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -280,8 +280,8 @@ func (c *Client) storeSelectedProfileRefreshState(
 
 // createSessionLogger creates a logger with common session information.
 func (c *Client) createSessionLogger(session state.State) *slog.Logger {
-	return c.logger.With(
-		slog.String("ip", fmt.Sprintf("%s:%s", session.IPAddr, session.IPPort)),
+	return loggerWithAttrs(c.logger,
+		slog.String("ip", session.IPAddr+":"+session.IPPort),
 		slog.Uint64("cid", session.Client.CID),
 		slog.Uint64("kid", session.Client.KID),
 		slog.String("common_name", session.Client.CommonName),
@@ -290,14 +290,19 @@ func (c *Client) createSessionLogger(session state.State) *slog.Logger {
 
 // createSessionLoggerWithState creates a logger with session information including session_id and session_state.
 func (c *Client) createSessionLoggerWithState(session state.State) *slog.Logger {
-	return c.logger.With(
-		slog.String("ip", fmt.Sprintf("%s:%s", session.IPAddr, session.IPPort)),
+	return loggerWithAttrs(c.logger,
+		slog.String("ip", session.IPAddr+":"+session.IPPort),
 		slog.Uint64("cid", session.Client.CID),
 		slog.Uint64("kid", session.Client.KID),
 		slog.String("common_name", session.Client.CommonName),
 		slog.String("session_id", session.Client.SessionID),
 		slog.String("session_state", session.SessionState),
 	)
+}
+
+// loggerWithAttrs retains typed attributes without converting them through Logger.With's []any arguments.
+func loggerWithAttrs(logger *slog.Logger, attrs ...slog.Attr) *slog.Logger {
+	return slog.New(logger.Handler().WithAttrs(attrs))
 }
 
 // postCodeExchangeHandler returns the callback that validates exchanged tokens and accepts or denies the OpenVPN client.

--- a/internal/oauth2/handler_bench_test.go
+++ b/internal/oauth2/handler_bench_test.go
@@ -1,0 +1,49 @@
+package oauth2 //nolint:testpackage
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
+)
+
+func BenchmarkCreateSessionLogger(b *testing.B) {
+	// Exercise a real handler that retains attributes; DiscardHandler intentionally drops them.
+	client := Client{logger: slog.New(slog.NewTextHandler(io.Discard, nil))} //nolint:sloglint
+	session := state.State{
+		Client: state.ClientIdentifier{
+			CID:        1,
+			KID:        2,
+			CommonName: "user@example.com",
+			SessionID:  "session-id",
+		},
+		IPAddr:       "192.0.2.1",
+		IPPort:       "1194",
+		SessionState: "session-state",
+	}
+
+	b.Run("common", func(b *testing.B) {
+		var logger *slog.Logger
+
+		b.ReportAllocs()
+
+		for b.Loop() {
+			logger = client.createSessionLogger(session)
+		}
+
+		_ = logger
+	})
+
+	b.Run("with-state", func(b *testing.B) {
+		var logger *slog.Logger
+
+		b.ReportAllocs()
+
+		for b.Loop() {
+			logger = client.createSessionLoggerWithState(session)
+		}
+
+		_ = logger
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Uses a typed `slog.Handler.WithAttrs` path for the two OAuth2 session logger constructors. This avoids converting each retained `slog.Attr` through `Logger.With(...any)`, which verbose compiler escape analysis showed was moving every attribute to the heap.

The IP and port are concatenated directly with the same output format instead of boxing both strings through `fmt.Sprintf`. All existing structured log keys and values are preserved.

A fresh end-to-end allocation profile after PR #1061 identified these two constructors as the next repeated project-owned allocation site: four allocations at `/oauth2/start` plus six at the OAuth2 callback for every complete authentication flow.

This PR also adds an isolated benchmark backed by a real retaining `slog.TextHandler`.

Interleaved precompiled benchmark comparison (10 runs, Apple M1):

| Benchmark | ns/op before | ns/op after | Change |
| --- | ---: | ---: | ---: |
| CreateSessionLogger/common | 729.8 | 464.8 | -36.32% |
| CreateSessionLogger/with-state | 1022.5 | 641.7 | -37.24% |

| Benchmark | B/op before | B/op after | Change |
| --- | ---: | ---: | ---: |
| CreateSessionLogger/common | 873 | 520 | -40.44% |
| CreateSessionLogger/with-state | 1481 | 792 | -46.52% |

| Benchmark | allocs/op before | allocs/op after | Change |
| --- | ---: | ---: | ---: |
| CreateSessionLogger/common | 17 | 9 | -47.06% |
| CreateSessionLogger/with-state | 21 | 10 | -52.38% |

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/oauth2`
- verbose compiler escape analysis with `-gcflags='-m -m'`
- 10-run interleaved `benchstat` comparison of precompiled baseline and candidate binaries
- confirmed the change contains no direct `unsafe` use

#### Particularly user-facing changes

Reduces heap churn in both the OAuth2 start and callback request paths without changing authentication behavior or structured logging fields.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR