### PR TITLE
feat: reduce OAuth2 ID token logger allocations

### DIFF
--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -363,7 +363,7 @@ func withIDTokenClaimsLogger(ctx context.Context, logger *slog.Logger, tokens *i
 		return logger
 	}
 
-	logger = logger.With(
+	logger = loggerWithAttrs(logger,
 		slog.String("idtoken_subject", tokens.IDTokenClaims.Subject),
 		slog.String("idtoken_email", tokens.IDTokenClaims.EMail),
 		slog.String("idtoken_preferred_username", tokens.IDTokenClaims.PreferredUsername),

--- a/internal/oauth2/handler_bench_test.go
+++ b/internal/oauth2/handler_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 )
 
@@ -46,4 +47,27 @@ func BenchmarkCreateSessionLogger(b *testing.B) {
 
 		_ = logger
 	})
+}
+
+func BenchmarkWithIDTokenClaimsLogger(b *testing.B) {
+	// Exercise a real handler that retains attributes while keeping the debug record disabled.
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})) //nolint:sloglint
+	claims := &idtoken.Claims{
+		Claims:            map[string]any{"sub": "subject"},
+		EMail:             "user@example.com",
+		PreferredUsername: "user",
+	}
+	claims.Subject = "subject"
+	tokens := &idtoken.IDToken{IDTokenClaims: claims}
+	ctx := b.Context()
+
+	var loggerWithClaims *slog.Logger
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		loggerWithClaims = withIDTokenClaimsLogger(ctx, logger, tokens)
+	}
+
+	_ = loggerWithClaims
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Reduces allocation pressure while enriching OAuth2 loggers with ID token claim fields. The hot path now passes typed `slog.Attr` values directly to the handler instead of converting them through `Logger.With`'s variadic `any` arguments.

A fresh full-flow `alloc_objects` profile attributed 54 caller-side allocations to the three claim attributes over 18 authentication flows. After the change, that site retains one typed attribute slice per flow (18 allocations).

Atomic benchmark on Apple M1, darwin/arm64 (10 interleaved runs):

- `sec/op`: 611.9 ns → 429.4 ns (-29.82%, p=0.000)
- `B/op`: 840 → 536 (-36.19%, p=0.000)
- `allocs/op`: 13 → 8 (-38.46%, p=0.000)

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

No direct `unsafe` usage was introduced. Log fields, levels, and emitted values are unchanged.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/oauth2`
- compiler escape analysis for the changed hot path
- before/after pprof allocation profiles

#### Particularly user-facing changes

Lower OAuth2 authentication allocation pressure and GC work; no configuration or behavior change.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR