### PR TITLE
chore: reduce OAuth2 user logger allocations

### DIFF
--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -325,10 +325,7 @@ func (c *Client) postCodeExchangeHandler(
 			return
 		}
 
-		logger = logger.With(
-			slog.String("user_subject", user.Subject),
-			slog.String("user_username", user.Username),
-		)
+		logger = withUserLogger(logger, user.Subject, user.Username)
 
 		if err = c.validateInteractiveUser(ctx, session, user, tokens); err != nil {
 			c.openvpn.DenyClient(ctx, logger, session.Client, err.openvpnReason)
@@ -372,6 +369,14 @@ func withIDTokenClaimsLogger(ctx context.Context, logger *slog.Logger, tokens *i
 	logger.LogAttrs(ctx, slog.LevelDebug, "claims", slog.Any("claims", tokens.IDTokenClaims.Claims))
 
 	return logger
+}
+
+// withUserLogger enriches the logger with resolved user fields.
+func withUserLogger(logger *slog.Logger, subject, username string) *slog.Logger {
+	return loggerWithAttrs(logger,
+		slog.String("user_subject", subject),
+		slog.String("user_username", username),
+	)
 }
 
 type userValidationError struct {

--- a/internal/oauth2/handler_bench_test.go
+++ b/internal/oauth2/handler_bench_test.go
@@ -71,3 +71,18 @@ func BenchmarkWithIDTokenClaimsLogger(b *testing.B) {
 
 	_ = loggerWithClaims
 }
+
+func BenchmarkWithUserLogger(b *testing.B) {
+	// Exercise a real handler that retains attributes; DiscardHandler intentionally drops them.
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+
+	var loggerWithUser *slog.Logger
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		loggerWithUser = withUserLogger(logger, "subject", "user")
+	}
+
+	_ = loggerWithUser
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Reduces allocation pressure while attaching resolved-user fields to the OAuth2 callback logger. The hot path now retains typed `slog.Attr` values directly instead of converting them through `Logger.With`'s variadic `any` arguments.

A fresh full-flow `alloc_objects` profile attributed 36 allocations to the two resolved-user attributes over 18 authentication flows. After the change, one typed attribute slice is retained per flow.

Atomic benchmark on Apple M1, darwin/arm64 (20 interleaved runs):

- `B/op`: 504 → 360 (-28.57%, p=0.000)
- `allocs/op`: 10 → 7 (-30.00%, p=0.000)
- `sec/op`: 388.4 ns ±10% → 295.2 ns ±2% (-24.01%, p=0.000); the baseline timing was noisy, so the exact memory metrics are the primary result

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

This is categorized as a technical `chore`, not a feature. No direct `unsafe` usage was introduced, and log fields and values are unchanged.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/oauth2`
- compiler escape analysis
- before/after full-flow allocation profiles

#### Particularly user-facing changes

None. This is an internal allocation optimization with no configuration or behavior change.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR