### PR TITLE
chore: reduce OAuth2 HTTP error allocations

### DIFF
--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -713,12 +713,17 @@ func (c *Client) writeHTTPError(ctx context.Context, w http.ResponseWriter, logg
 		httpCode = http.StatusForbidden
 	}
 
-	h := sha256.New()
-	h.Write([]byte(time.Now().String()))
+	var timestamp [len(time.RFC3339Nano)]byte
 
-	errorID := hex.EncodeToString(h.Sum(nil))
+	formattedTimestamp := time.Now().AppendFormat(timestamp[:0], time.RFC3339Nano)
+	errorIDHash := sha256.Sum256(formattedTimestamp)
 
-	logger.LogAttrs(ctx, slog.LevelWarn, fmt.Sprintf("%s: %s", errorType, errorDesc), slog.String("error_id", errorID))
+	var errorIDBuffer [sha256.Size * 2]byte
+
+	hex.Encode(errorIDBuffer[:], errorIDHash[:])
+	errorID := string(errorIDBuffer[:])
+
+	logger.LogAttrs(ctx, slog.LevelWarn, errorType+": "+errorDesc, slog.String("error_id", errorID))
 	w.WriteHeader(httpCode)
 
 	err := c.conf.HTTP.Template.Execute(w, map[string]string{

--- a/internal/oauth2/handler_bench_test.go
+++ b/internal/oauth2/handler_bench_test.go
@@ -3,11 +3,25 @@ package oauth2 //nolint:testpackage
 import (
 	"io"
 	"log/slog"
+	"net/http"
 	"testing"
 
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 )
+
+type benchmarkResponseWriter struct{}
+
+func (benchmarkResponseWriter) Header() http.Header {
+	return nil
+}
+
+func (benchmarkResponseWriter) Write(body []byte) (int, error) {
+	return len(body), nil
+}
+
+func (benchmarkResponseWriter) WriteHeader(_ int) {}
 
 func BenchmarkCreateSessionLogger(b *testing.B) {
 	// Exercise a real handler that retains attributes; DiscardHandler intentionally drops them.
@@ -85,4 +99,18 @@ func BenchmarkWithUserLogger(b *testing.B) {
 	}
 
 	_ = loggerWithUser
+}
+
+func BenchmarkWriteHTTPError(b *testing.B) {
+	conf := config.Defaults
+	client := Client{conf: &conf}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+	ctx := b.Context()
+	w := benchmarkResponseWriter{}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		client.writeHTTPError(ctx, w, logger, http.StatusBadRequest, "Bad Request", "state is empty")
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

This internal technical chore reduces allocation churn while rendering OAuth2 denial pages.

- builds the timestamp, SHA-256 digest, and hexadecimal error ID with fixed stack-backed buffers
- replaces `fmt.Sprintf` with direct concatenation for the unchanged warning message
- adds an atomic `BenchmarkWriteHTTPError` benchmark

A fresh full-flow `alloc_objects` profile identified `writeHTTPError` as the next project-owned allocation hot path. The focused benchmark confirms the change reduces the path from 43 to 35 allocations per response.

Benchmark environment: `darwin/arm64`, Apple M1, Go 1.26.5, 20 interleaved samples.

```text
WriteHTTPError-8  3.806µ -> 3.487µ  -8.37% (p=0.000 n=20)
WriteHTTPError-8  1.408KiB -> 1.096KiB  -22.19% (p=0.000 n=20)
WriteHTTPError-8  43.00 -> 35.00 allocs/op  -18.60% (p=0.000 n=20)
```

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

- This is a performance-only technical `chore`, not a feature.
- No direct `unsafe` usage was added.
- Escape analysis confirms the timestamp and digest buffers remain on the stack.
- The documented lowercase custom-template keys remain unchanged.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/oauth2`
- focused 20-sample interleaved benchmark comparison with `benchstat`
- full-flow allocation profile before and after
- compiler escape analysis with `-gcflags='-m -m'`

#### Particularly user-facing changes

None. HTTP status handling, rendered template data, 64-character hexadecimal error IDs, and warning message text remain unchanged.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR