### PR TITLE
chore: reduce OAuth2 start URL allocations

### DIFF
--- a/internal/openvpn/client.go
+++ b/internal/openvpn/client.go
@@ -199,11 +199,7 @@ func (c *Client) startClientAuth(ctx context.Context, logger *slog.Logger, clien
 		return fmt.Errorf("error encoding state: %w", err)
 	}
 
-	startURL := fmt.Sprintf(
-		"%s/oauth2/start?state=%s",
-		strings.TrimSuffix(c.conf.HTTP.BaseURL.String(), "/"),
-		encryptedOIDCState,
-	)
+	startURL := buildOAuth2StartURL(c.conf.HTTP.BaseURL.String(), encryptedOIDCState)
 
 	command, err := buildClientPendingAuthCommand(client, startURL, c.conf.OpenVPN.AuthPendingTimeout)
 	if err != nil {
@@ -218,6 +214,10 @@ func (c *Client) startClientAuth(ctx context.Context, logger *slog.Logger, clien
 	}
 
 	return nil
+}
+
+func buildOAuth2StartURL(baseURL string, encryptedOIDCState state.EncryptedState) string {
+	return strings.TrimSuffix(baseURL, "/") + "/oauth2/start?state=" + encryptedOIDCState
 }
 
 func buildClientPendingAuthCommand(client connection.Client, startURL string, timeout time.Duration) (string, error) {

--- a/internal/openvpn/client_bench_test.go
+++ b/internal/openvpn/client_bench_test.go
@@ -1,0 +1,20 @@
+package openvpn //nolint:testpackage
+
+import (
+	"strings"
+	"testing"
+)
+
+func BenchmarkBuildOAuth2StartURL(b *testing.B) {
+	encryptedOIDCState := strings.Repeat("a", 256)
+
+	var startURL string
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		startURL = buildOAuth2StartURL("https://vpn.example.com/", encryptedOIDCState)
+	}
+
+	_ = startURL
+}

--- a/internal/openvpn/client_test.go
+++ b/internal/openvpn/client_test.go
@@ -9,6 +9,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildOAuth2StartURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "without trailing slash",
+			baseURL: "https://vpn.example.com",
+			want:    "https://vpn.example.com/oauth2/start?state=encrypted-state",
+		},
+		{
+			name:    "with trailing slash",
+			baseURL: "https://vpn.example.com/",
+			want:    "https://vpn.example.com/oauth2/start?state=encrypted-state",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildOAuth2StartURL(tc.baseURL, "encrypted-state")
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestBuildClientPendingAuthCommandLimit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### What this PR does / why we need it

This internal technical chore reduces allocation churn while constructing the OAuth2 start URL sent through OpenVPN's `client-pending-auth` command.

- replaces `fmt.Sprintf` with direct string concatenation so the base URL and encrypted state are not boxed through interfaces
- extracts the URL construction into a small helper that the compiler inlines
- adds exact coverage for base URLs with and without a trailing slash
- adds an atomic `BenchmarkBuildOAuth2StartURL` benchmark

A fresh full-flow `alloc_objects` profile identified the two boxed string arguments in `startClientAuth` as the next removable project-owned allocations. The focused benchmark confirms that only the returned URL string now allocates.

Benchmark environment: `darwin/arm64`, Apple M1, Go 1.26.5, 10 interleaved samples.

```text
BuildOAuth2StartURL-8  131.40ns -> 62.34ns  -52.56% (p=0.000 n=10)
BuildOAuth2StartURL-8  352.0 B/op -> 320.0 B/op  -9.09% (p=0.000 n=10)
BuildOAuth2StartURL-8  3.000 -> 1.000 allocs/op  -66.67% (p=0.000 n=10)
```

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

- This is a performance-only technical `chore`, not a feature.
- No direct `unsafe` usage was added.
- Escape analysis confirms both inputs do not escape, the single result allocation is required, and the helper inlines into `startClientAuth`.
- The adjacent `client-pending-auth` command formatter remains separately scoped for a later chore.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race ./internal/openvpn`
- focused 10-sample interleaved benchmark comparison with `benchstat`
- full-flow allocation profile before and after
- compiler escape/inlining analysis with `-gcflags='-m -m'`

#### Particularly user-facing changes

None. The generated OAuth2 start URL remains byte-for-byte identical, including trailing-slash normalization.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR