### PR TITLE
chore: skip disabled client message logging

### DIFF
--- a/internal/openvpn/handler.go
+++ b/internal/openvpn/handler.go
@@ -153,7 +153,9 @@ func (c *Client) handleMessage(ctx context.Context, message string) error {
 }
 
 func (c *Client) handleClientMessage(ctx context.Context, message string) error {
-	c.logger.LogAttrs(ctx, slog.LevelDebug, reMaskClientPassword.ReplaceAllLiteralString(message, "CLIENT:ENV,password=***\r\n"))
+	if c.logger.Enabled(ctx, slog.LevelDebug) {
+		c.logger.LogAttrs(ctx, slog.LevelDebug, reMaskClientPassword.ReplaceAllLiteralString(message, "CLIENT:ENV,password=***\r\n"))
+	}
 
 	client, err := connection.NewClient(c.conf, message)
 	if err != nil {

--- a/internal/openvpn/handler_bench_test.go
+++ b/internal/openvpn/handler_bench_test.go
@@ -1,0 +1,49 @@
+package openvpn //nolint:testpackage
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/openvpn/connection"
+)
+
+func BenchmarkHandleClientMessage(b *testing.B) {
+	const message = ">CLIENT:CONNECT,0,1\r\n" +
+		">CLIENT:ENV,password=secret\r\n" +
+		">CLIENT:ENV,common_name=test\r\n" +
+		">CLIENT:ENV,END\r\n"
+
+	for _, tc := range []struct {
+		name  string
+		level slog.Level
+	}{
+		{name: "debug-disabled", level: slog.LevelInfo},
+		{name: "debug-enabled", level: slog.LevelDebug},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			conf := config.Defaults
+			clientsCh := make(chan connection.Client, 1)
+			client := Client{
+				conf:      &conf,
+				logger:    slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: tc.level})), //nolint:sloglint
+				clientsCh: clientsCh,
+			}
+
+			var parsedClient connection.Client
+
+			b.ReportAllocs()
+
+			for b.Loop() {
+				if err := client.handleClientMessage(b.Context(), message); err != nil {
+					b.Fatal(err)
+				}
+
+				parsedClient = <-clientsCh
+			}
+
+			_ = parsedClient
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Avoid running the client-password masking regexp when debug logging is disabled. Go evaluates log arguments before `slog` checks the handler level, so the default info-level path previously paid for a discarded masked string on every client message.

This is a technical maintenance chore, not a feature.

Interleaved old/new benchmarks (10 samples):

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| debug disabled, time | 624.1 ns/op | 188.2 ns/op | -69.85% |
| debug disabled, memory | 283 B/op | 0 B/op | -100% |
| debug disabled, allocations | 5 allocs/op | 0 allocs/op | -100% |
| debug enabled | 1.563 µs/op, 284.5 B/op, 5 allocs/op | 1.601 µs/op, 284.5 B/op, 5 allocs/op | no significant change |

The focused allocation profile reports no samples in `handleClientMessage` on the debug-disabled path after the change.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

- Password redaction remains covered by the existing debug-log test.
- The benchmark exercises both enabled and disabled debug levels.
- This change does not directly import or use `unsafe`.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race -count=1 ./internal/openvpn`
- `git diff --check`

#### Particularly user-facing changes

None.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR