### PR TITLE
chore: reduce command name parsing allocations

### DIFF
--- a/internal/openvpn/main.go
+++ b/internal/openvpn/main.go
@@ -304,14 +304,12 @@ func managementCommandForError(cmd string, passthrough bool) string {
 }
 
 func managementCommandName(cmd string) string {
-	cmdFirstLine := strings.SplitN(cmd, "\r\n", 2)[0]
-
-	fields := strings.Fields(cmdFirstLine)
-	if len(fields) == 0 {
-		return ""
+	cmdFirstLine, _, _ := strings.Cut(cmd, "\r\n")
+	for field := range strings.FieldsSeq(cmdFirstLine) {
+		return field
 	}
 
-	return fields[0]
+	return ""
 }
 
 // readMessage .

--- a/internal/openvpn/main_bench_test.go
+++ b/internal/openvpn/main_bench_test.go
@@ -1,0 +1,19 @@
+package openvpn //nolint:testpackage
+
+import "testing"
+
+func BenchmarkManagementCommandName(b *testing.B) {
+	const command = "client-pending-auth 123 456 \"WEB_AUTH::https://example.com/oauth2/start\" 300\r\n"
+
+	var name string
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		name = managementCommandName(command)
+	}
+
+	if name != "client-pending-auth" {
+		b.Fatalf("unexpected command name %q", name)
+	}
+}

--- a/internal/openvpn/main_internal_test.go
+++ b/internal/openvpn/main_internal_test.go
@@ -1,0 +1,29 @@
+package openvpn
+
+import "testing"
+
+func TestManagementCommandName(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		command string
+		expect  string
+	}{
+		{name: "empty", command: "", expect: ""},
+		{name: "whitespace", command: " \t\n", expect: ""},
+		{name: "arguments", command: "status 3", expect: "status"},
+		{name: "leading whitespace", command: " \tstatus 3", expect: "status"},
+		{name: "unicode whitespace", command: "\u2003status 3", expect: "status"},
+		{name: "first line", command: "status 3\r\npassword Auth secret", expect: "status"},
+		{name: "empty first line", command: "\r\nstatus 3", expect: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if name := managementCommandName(tc.command); name != tc.expect {
+				t.Errorf("managementCommandName(%q) = %q, want %q", tc.command, name, tc.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Replace the temporary slices created by `strings.SplitN` and `strings.Fields` in management command-name parsing with `strings.Cut` and the Go 1.26 `strings.FieldsSeq` iterator.

This preserves CRLF and Unicode whitespace handling while removing two allocations from every management command. It is a technical maintenance chore, not a feature.

Interleaved old/new benchmarks (10 samples):

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| time | 141.45 ns/op | 32.56 ns/op | -76.98% |
| memory | 112 B/op | 0 B/op | -100% |
| allocations | 2 allocs/op | 0 allocs/op | -100% |

The full OpenVPN handler benchmark drops from 38 to 36 allocations per operation, and the post-change allocation profile contains no samples for `managementCommandName`.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

- Adds behavior coverage for empty input, leading whitespace, Unicode whitespace, and CRLF boundaries.
- Adds an atomic allocation benchmark.
- This change does not directly import or use `unsafe`.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race -count=1 ./internal/openvpn`
- `git diff --check`

#### Particularly user-facing changes

None.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR