### PR TITLE
chore: reuse management command timeout timer

### DIFF
--- a/internal/openvpn/main.go
+++ b/internal/openvpn/main.go
@@ -40,11 +40,13 @@ func New(logger *slog.Logger, conf *config.Config) *Client {
 
 		clientsCh:         make(chan connection.Client, 10),
 		commandResponseCh: make(chan string),
+		commandTimer:      time.NewTimer(conf.OpenVPN.CommandTimeout),
 		commandsCh:        make(chan string, 10),
 		passThroughCh:     make(chan string, 10),
 	}
 
 	client.commandsBuffer.Grow(512)
+	client.commandTimer.Stop()
 
 	return client
 }
@@ -241,6 +243,9 @@ func (c *Client) SendCommand(_ context.Context, cmd string, passthrough bool) (s
 	}
 
 	c.commandsCh <- cmd
+	// commandMu serializes resets and receives on the reusable timer.
+	c.commandTimer.Reset(c.conf.OpenVPN.CommandTimeout)
+	defer c.commandTimer.Stop()
 
 	select {
 	case resp, ok := <-c.commandResponseCh:
@@ -264,7 +269,7 @@ func (c *Client) SendCommand(_ context.Context, cmd string, passthrough bool) (s
 		}
 
 		return resp, nil
-	case <-time.After(c.conf.OpenVPN.CommandTimeout):
+	case <-c.commandTimer.C:
 		return "", fmt.Errorf("command error '%s': %w", managementCommandForError(cmd, passthrough), ErrTimeout)
 	}
 }

--- a/internal/openvpn/main_bench_test.go
+++ b/internal/openvpn/main_bench_test.go
@@ -1,6 +1,12 @@
 package openvpn //nolint:testpackage
 
-import "testing"
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
+)
 
 func BenchmarkManagementCommandName(b *testing.B) {
 	const command = "client-pending-auth 123 456 \"WEB_AUTH::https://example.com/oauth2/start\" 300\r\n"
@@ -15,5 +21,32 @@ func BenchmarkManagementCommandName(b *testing.B) {
 
 	if name != "client-pending-auth" {
 		b.Fatalf("unexpected command name %q", name)
+	}
+}
+
+func BenchmarkSendCommand(b *testing.B) {
+	conf := config.Defaults
+	client := New(slog.New(slog.NewTextHandler(io.Discard, nil)), &conf) //nolint:sloglint
+	doneCh := make(chan struct{})
+
+	go func() {
+		defer close(doneCh)
+
+		for range client.commandsCh {
+			client.commandResponseCh <- "SUCCESS: command succeeded"
+		}
+	}()
+
+	b.Cleanup(func() {
+		client.Shutdown(b.Context())
+		<-doneCh
+	})
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := client.SendCommand(b.Context(), "status 3", false); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/internal/openvpn/types.go
+++ b/internal/openvpn/types.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
@@ -25,6 +26,7 @@ type Client struct {
 	oauth2               oauth2Client
 	conn                 net.Conn
 	commandResponseCh    chan string
+	commandTimer         *time.Timer
 	commandsCh           chan string
 	logger               *slog.Logger
 	scanner              *bufio.Scanner


### PR DESCRIPTION
#### What this PR does / why we need it

Reuse one client-owned `time.Timer` for management command timeouts instead of creating a `time.After` timer for every command.

`SendCommand` already serializes the complete command round trip with `commandMu`, so timer resets and receives cannot overlap. Go 1.26 also guarantees that channel-based timer resets and stops cannot expose stale timer values.

This is a technical maintenance chore, not a feature.

Interleaved old/new benchmarks (10 samples):

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| time | 608.0 ns/op | 443.9 ns/op | -27.00% |
| memory | 248 B/op | 0 B/op | -100% |
| allocations | 3 allocs/op | 0 allocs/op | -100% |

The full OpenVPN handler benchmark drops from 36 to 33 allocations per operation.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

- Timeout, error-response, and concurrent command serialization tests pass across 20 repetitions.
- Adds an atomic successful-command benchmark with deterministic responder cleanup.
- This change does not directly import or use `unsafe`.

Validation:

- `make fmt`
- `make lint`
- `make test`
- `go test -race -count=1 ./internal/openvpn`
- `git diff --check`

#### Particularly user-facing changes

None.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR