### PR TITLE
fix: clear pooled crypto scratch

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -374,6 +374,8 @@ func (c *Cipher) getMAC() *pooledMAC {
 // putMAC resets and returns an HMAC-SHA256 instance to the cipher-local pool.
 func (c *Cipher) putMAC(macHash *pooledMAC) {
 	macHash.Reset()
+	// In-place decryption may leave OAuth state plaintext in the pooled scratch.
+	clear(macHash.encrypted[:])
 	c.macPool.Put(macHash)
 }
 

--- a/internal/crypto/crypto_internal_test.go
+++ b/internal/crypto/crypto_internal_test.go
@@ -1,0 +1,22 @@
+package crypto
+
+import "testing"
+
+func TestPutMACClearsEncryptedScratch(t *testing.T) {
+	t.Parallel()
+
+	cipher := New("test-key")
+	macHash := cipher.getMAC()
+
+	for index := range macHash.encrypted {
+		macHash.encrypted[index] = 0xff
+	}
+
+	cipher.putMAC(macHash)
+
+	for index, value := range macHash.encrypted {
+		if value != 0 {
+			t.Fatalf("encrypted scratch byte %d was not cleared", index)
+		}
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Clear the cipher-local pooled scratch buffer before returning its HMAC object to `sync.Pool`.

Timestamped state decryption uses exact-overlap decryption in this buffer. Without clearing it, OAuth state plaintext such as session IDs, common names, and client IP addresses could remain in pooled heap memory until the buffer was overwritten or evicted.

A package-internal regression test verifies that the complete scratch buffer is zeroed at the pool handoff.

#### Which issue this PR fixes

Not applicable.

#### Special notes for your reviewer

The buffer has a fixed size, and `clear` does not allocate. Focused benchmarks retained the existing allocation counts:

- state decryption: 24 B/op, 1 alloc/op
- public encryption: 48 B/op, 1 alloc/op
- public decryption: 24 B/op, 1 alloc/op

Validation:

- `make fmt`
- `make lint`
- `make test`
- focused race-enabled regression tests across 50 repetitions
- focused allocation benchmarks
- `git diff --check`

#### Particularly user-facing changes

None. This reduces sensitive plaintext retention in process memory without changing token formats or authentication behavior.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR