### PR TITLE
fix: validate CEL result type at startup

### DIFF
--- a/internal/oauth2/cel.go
+++ b/internal/oauth2/cel.go
@@ -100,7 +100,7 @@ func (c *Client) initializeCELValidation() error {
 		return nil
 	}
 
-	program, err := compileCELProgram(c.conf.OAuth2.Validate.Expression, nil)
+	program, err := compileCELProgram(c.conf.OAuth2.Validate.Expression, cel.BoolType)
 	if err != nil {
 		return fmt.Errorf("failed to initialize validation CEL expression: %w", err)
 	}

--- a/internal/oauth2/cel_test.go
+++ b/internal/oauth2/cel_test.go
@@ -21,12 +21,13 @@ func TestCheckIdentityCEL(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name  string
-		conf  config.Config
-		state state.State
-		token *idtoken.IDToken
-		user  oauth2types.UserInfo
-		err   string
+		name    string
+		conf    config.Config
+		state   state.State
+		token   *idtoken.IDToken
+		user    oauth2types.UserInfo
+		initErr string
+		err     string
 	}{
 		{
 			name: "no CEL expression configured",
@@ -65,6 +66,7 @@ func TestCheckIdentityCEL(t *testing.T) {
 
 				return conf
 			}(),
+			initErr: "failed to compile CEL expression:",
 		},
 		{
 			name: "UserInfo identity without ID token claims",
@@ -192,7 +194,7 @@ func TestCheckIdentityCEL(t *testing.T) {
 			err:  oauth2.ErrCELValidationFailed.Error(),
 		},
 		{
-			name: "CEL expression evaluates to string",
+			name: "CEL expression statically evaluates to string",
 			conf: func() config.Config {
 				conf := config.Defaults
 				conf.OAuth2.Issuer = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
@@ -203,21 +205,28 @@ func TestCheckIdentityCEL(t *testing.T) {
 
 				return conf
 			}(),
-			state: state.State{
-				Client: state.ClientIdentifier{
-					CommonName: "test-client",
-				},
-				IPAddr: "127.0.0.1",
-			},
+			initErr: "cel expression must evaluate to bool, got string",
+		},
+		{
+			name: "dynamic CEL expression evaluates to string",
+			conf: func() config.Config {
+				conf := config.Defaults
+				conf.OAuth2.Issuer = types.URL{URL: &url.URL{Scheme: "http", Host: "localhost"}}
+				conf.OAuth2.Endpoints.Discovery = conf.OAuth2.Issuer
+				conf.OAuth2.Endpoints.Auth = conf.OAuth2.Issuer
+				conf.OAuth2.Endpoints.Token = conf.OAuth2.Issuer
+				conf.OAuth2.Validate.Expression = "token.claims.result"
+
+				return conf
+			}(),
 			token: &idtoken.IDToken{
 				IDTokenClaims: &idtoken.Claims{
 					Claims: map[string]any{
-						"preferred_username": "test-client",
+						"result": "not-a-boolean",
 					},
 				},
 			},
-			user: oauth2types.UserInfo{Username: "test-client"},
-			err:  "cel expression did not evaluate to a boolean value",
+			err: "cel expression did not evaluate to a boolean value",
 		},
 		{
 			name: "CEL expression with lowerAscii",
@@ -281,8 +290,8 @@ func TestCheckIdentityCEL(t *testing.T) {
 			require.NoError(t, err)
 
 			oAuth2Client, err := oauth2.New(t.Context(), slog.New(slog.DiscardHandler), &tc.conf, http.DefaultClient, testsuite.NewFakeStorage(), testsuite.Cipher, provider, testsuite.NewFakeOpenVPNClient())
-			if tc.conf.OAuth2.Validate.Expression == "-" {
-				require.ErrorContains(t, err, "failed to compile CEL expression:")
+			if tc.initErr != "" {
+				require.ErrorContains(t, err, tc.initErr)
 
 				return
 			}


### PR DESCRIPTION
#### What this PR does / why we need it

Require OAuth2 validation CEL expressions to have a boolean-compatible output type during compilation.

The validation initializer previously omitted the expected result type even though the shared compiler already supports output-type validation. As a result, statically non-boolean expressions started successfully and failed only during authentication. Statically invalid result types now fail during startup, while dynamically typed expressions retain the existing runtime boolean check.

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

The tests distinguish statically typed string results from dynamic token-claim results to preserve the runtime guard.

#### Particularly user-facing changes

Invalid statically non-boolean validation expressions are rejected when configuration is loaded instead of during authentication.

#### Testing

- `make fmt`
- `make lint`
- `make test`

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR