### PR TITLE
chore: prevent secrets from appearing in CLI help

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
@@ -15,6 +16,7 @@ import (
 const (
 	configArgument            = "--config"
 	environmentVariablePrefix = "OPENVPN_AUTH_OAUTH2_"
+	versionArgument           = "version"
 )
 
 var ErrVersion = errors.New("flag: version requested")
@@ -24,6 +26,14 @@ var ErrVersion = errors.New("flag: version requested")
 //goland:noinspection GoMixedReceiverTypes
 func New(args []string, writer io.Writer) (*Config, error) {
 	config := Defaults
+
+	if err := lookupInformationalArgument(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			config.newFlagSet(writer).Usage()
+		}
+
+		return nil, err
+	}
 
 	if configFilePath := lookupConfigArgument(args); configFilePath != "" {
 		if err := config.ReadFromConfigFile(configFilePath); err != nil && !errors.Is(err, io.EOF) {
@@ -67,6 +77,28 @@ func (c *Config) ReadFromConfigFile(configFilePath string) error {
 //goland:noinspection GoMixedReceiverTypes
 func (c *Config) ReadFromFlagAndEnvironment(args []string, writer io.Writer) error {
 	// Load the c from command line arguments
+	flagSet := c.newFlagSet(writer)
+
+	if err := applyEnvironment(flagSet); err != nil {
+		return fmt.Errorf("error parsing environment variables: %w", err)
+	}
+
+	if err := flagSet.Parse(args[1:]); err != nil {
+		return fmt.Errorf("error parsing command line arguments: %w", err)
+	}
+
+	if flagSet.NArg() != 0 {
+		return errors.New("error parsing command line arguments: positional arguments are not supported")
+	}
+
+	if flagSet.Lookup(versionArgument).Value.String() == "true" {
+		return ErrVersion
+	}
+
+	return nil
+}
+
+func (c *Config) newFlagSet(writer io.Writer) *flag.FlagSet {
 	flagSet := flag.NewFlagSet("openvpn-auth-oauth2", flag.ContinueOnError)
 	flagSet.SetOutput(writer)
 	flagSet.Usage = func() {
@@ -86,7 +118,7 @@ func (c *Config) ReadFromFlagAndEnvironment(args []string, writer io.Writer) err
 	)
 
 	flagSet.Bool(
-		"version",
+		versionArgument,
 		false,
 		"show version",
 	)
@@ -99,30 +131,64 @@ func (c *Config) ReadFromFlagAndEnvironment(args []string, writer io.Writer) err
 	c.flagSetProvider(flagSet)
 
 	flagSet.VisitAll(func(flag *flag.Flag) {
-		if flag.Name == "version" {
+		if flag.Name == versionArgument {
 			return
 		}
 
 		flag.Usage += fmt.Sprintf(" (env: %s)", getEnvironmentVariableByFlagName(flag.Name))
 	})
 
-	if err := applyEnvironment(flagSet); err != nil {
-		return fmt.Errorf("error parsing environment variables: %w", err)
+	return flagSet
+}
+
+func lookupInformationalArgument(args []string) error {
+	if len(args) < 2 {
+		return nil
 	}
 
-	if err := flagSet.Parse(args[1:]); err != nil {
-		return fmt.Errorf("error parsing command line arguments: %w", err)
+	versionRequested := false
+
+	for _, arg := range args[1:] {
+		if arg == "--" {
+			break
+		}
+
+		name, value, hasValue := splitFlagArgument(arg)
+
+		switch name {
+		case "h", "help":
+			return flag.ErrHelp
+		case versionArgument:
+			versionRequested = requestedBoolFlag(value, hasValue)
+		}
 	}
 
-	if flagSet.NArg() != 0 {
-		return errors.New("error parsing command line arguments: positional arguments are not supported")
-	}
-
-	if flagSet.Lookup("version").Value.String() == "true" {
+	if versionRequested {
 		return ErrVersion
 	}
 
 	return nil
+}
+
+func splitFlagArgument(arg string) (string, string, bool) {
+	if !strings.HasPrefix(arg, "-") || arg == "-" {
+		return "", "", false
+	}
+
+	nameValue := strings.TrimPrefix(arg, "-")
+	nameValue = strings.TrimPrefix(nameValue, "-")
+
+	return strings.Cut(nameValue, "=")
+}
+
+func requestedBoolFlag(value string, hasValue bool) bool {
+	if !hasValue {
+		return true
+	}
+
+	requested, _ := strconv.ParseBool(value)
+
+	return requested
 }
 
 func lookupConfigArgument(args []string) string {
@@ -184,7 +250,7 @@ func getFlagsByEnvironmentVariable(flagSet *flag.FlagSet) (map[string]*flag.Flag
 	var mappingError error
 
 	flagSet.VisitAll(func(configurationFlag *flag.Flag) {
-		if configurationFlag.Name == "version" {
+		if configurationFlag.Name == versionArgument {
 			return
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"testing"
@@ -310,6 +311,58 @@ func TestConfigHelpFlag(t *testing.T) {
 	assert.NotContains(t, buf.String(), "(env: CONFIG_HTTP_LISTEN)")
 }
 
+func TestConfigHelpFlagDoesNotExposeSecrets(t *testing.T) {
+	const commandLineSecret = "command-line-secret-marker"
+
+	var buf bytes.Buffer
+
+	t.Setenv("OPENVPN_AUTH_OAUTH2_UNKNOWN", "value")
+
+	_, err := config.New(
+		[]string{
+			"openvpn-auth-oauth2",
+			"--config",
+			filepath.Join(t.TempDir(), "missing.yaml"),
+			"--oauth2.client.secret=" + commandLineSecret,
+			"--help",
+		},
+		&buf,
+	)
+
+	require.ErrorIs(t, err, flag.ErrHelp)
+	assert.Contains(t, buf.String(), "Usage of openvpn-auth-oauth2")
+	assert.NotContains(t, buf.String(), commandLineSecret)
+}
+
+func TestConfigHelpFlagRedactsLoadedSecrets(t *testing.T) {
+	conf := config.Defaults
+	conf.HTTP.Secret = "http-secret-marker"
+	conf.OpenVPN.Password = "openvpn-secret-marker"
+	conf.OpenVPN.Passthrough.Password = "pass-through-secret-marker"
+	conf.OAuth2.Client.PrivateKey = "private-key-marker"
+	conf.OAuth2.Client.Secret = "oauth2-secret-marker"
+	conf.OAuth2.Refresh.Secret = "refresh-secret-marker"
+
+	t.Setenv("OPENVPN_AUTH_OAUTH2_OAUTH2_CLIENT_SECRET", "environment-secret-marker")
+
+	var buf bytes.Buffer
+
+	err := conf.ReadFromFlagAndEnvironment([]string{"openvpn-auth-oauth2", "--help"}, &buf)
+
+	require.ErrorIs(t, err, flag.ErrHelp)
+
+	for _, secret := range []string{
+		conf.HTTP.Secret.String(),
+		conf.OpenVPN.Password.String(),
+		conf.OpenVPN.Passthrough.Password.String(),
+		conf.OAuth2.Client.PrivateKey.String(),
+		conf.OAuth2.Client.Secret.String(),
+		conf.OAuth2.Refresh.Secret.String(),
+	} {
+		assert.NotContains(t, buf.String(), secret)
+	}
+}
+
 func TestConfigFileEnvironmentVariable(t *testing.T) {
 	var buf bytes.Buffer
 
@@ -418,7 +471,15 @@ func TestConfigVersionFlag(t *testing.T) {
 
 	_ = io.Writer(&buf)
 
-	_, err := config.New([]string{"openvpn-auth-oauth2", "--version"}, &buf)
+	_, err := config.New(
+		[]string{
+			"openvpn-auth-oauth2",
+			"--config",
+			filepath.Join(t.TempDir(), "missing.yaml"),
+			"--version",
+		},
+		&buf,
+	)
 
 	require.ErrorIs(t, err, config.ErrVersion)
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -62,10 +62,9 @@ func (c *Config) flagSetHTTP(flagSet *flag.FlagSet) {
 		c.HTTP.BaseURL,
 		"listen addr for client listener",
 	)
-	flagSet.TextVar(
-		&c.HTTP.Secret,
+	flagSet.Var(
+		newSecretFlagValue(&c.HTTP.Secret),
 		"http.secret",
-		c.HTTP.Secret,
 		"Random generated secret for cookie encryption. Must be 16, 24 or 32 characters. "+
 			"If argument starts with file:// it reads the secret from a file.",
 	)
@@ -122,10 +121,9 @@ func (c *Config) flagSetOpenVPN(flagSet *flag.FlagSet) {
 		c.OpenVPN.Addr,
 		"openvpn management interface addr. Must start with unix:// or tcp://",
 	)
-	flagSet.TextVar(
-		&c.OpenVPN.Password,
+	flagSet.Var(
+		newSecretFlagValue(&c.OpenVPN.Password),
 		"openvpn.password",
-		c.OpenVPN.Password,
 		"openvpn management interface password. If argument starts with file:// it reads the secret from a file.",
 	)
 	flagSet.BoolVar(
@@ -222,10 +220,9 @@ func (c *Config) flagSetOpenVPN(flagSet *flag.FlagSet) {
 		c.OpenVPN.Passthrough.Address,
 		"The address of the pass-through socket. Must start with unix:// or tcp://",
 	)
-	flagSet.TextVar(
-		&c.OpenVPN.Passthrough.Password,
+	flagSet.Var(
+		newSecretFlagValue(&c.OpenVPN.Passthrough.Password),
 		"openvpn.pass-through.password",
-		c.OpenVPN.Passthrough.Password,
 		"The password for the pass-through socket. If argument starts with file:// it reads the secret from a file.",
 	)
 	flagSet.StringVar(
@@ -294,10 +291,9 @@ func (c *Config) flagSetOAuth2(flagSet *flag.FlagSet) {
 		c.OAuth2.Client.ID,
 		"oauth2 client id",
 	)
-	flagSet.TextVar(
-		&c.OAuth2.Client.PrivateKey,
+	flagSet.Var(
+		newSecretFlagValue(&c.OAuth2.Client.PrivateKey),
 		"oauth2.client.private-key",
-		c.OAuth2.Client.PrivateKey,
 		"oauth2 client private key. Secure alternative to oauth2.client.secret. If argument starts with file:// it reads the secret from a file.",
 	)
 	flagSet.StringVar(
@@ -306,10 +302,9 @@ func (c *Config) flagSetOAuth2(flagSet *flag.FlagSet) {
 		c.OAuth2.Client.PrivateKeyID,
 		"oauth2 client private key id. If specified, JWT assertions will be generated with the specific kid header.",
 	)
-	flagSet.TextVar(
-		&c.OAuth2.Client.Secret,
+	flagSet.Var(
+		newSecretFlagValue(&c.OAuth2.Client.Secret),
 		"oauth2.client.secret",
-		c.OAuth2.Client.Secret,
 		"oauth2 client secret. If argument starts with file:// it reads the secret from a file.",
 	)
 	flagSet.BoolVar(
@@ -365,10 +360,9 @@ func (c *Config) flagSetOAuth2(flagSet *flag.FlagSet) {
 		c.OAuth2.Refresh.Expires,
 		"TTL of stored oauth2 token.",
 	)
-	flagSet.TextVar(
-		&c.OAuth2.Refresh.Secret,
+	flagSet.Var(
+		newSecretFlagValue(&c.OAuth2.Refresh.Secret),
 		"oauth2.refresh.secret",
-		c.OAuth2.Refresh.Secret,
 		"Required, if oauth2.refresh.enabled=true. Random generated secret for token encryption. "+
 			"Must be 16, 24 or 32 characters. If argument starts with file:// it reads the secret from a file.",
 	)

--- a/internal/config/secret_flag.go
+++ b/internal/config/secret_flag.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config/types"
+)
+
+type secretFlagValue struct {
+	target *types.Secret
+}
+
+func newSecretFlagValue(target *types.Secret) *secretFlagValue {
+	return &secretFlagValue{target: target}
+}
+
+func (s *secretFlagValue) Set(value string) error {
+	if err := s.target.UnmarshalText([]byte(value)); err != nil {
+		return fmt.Errorf("set secret flag: %w", err)
+	}
+
+	return nil
+}
+
+func (s *secretFlagValue) String() string {
+	return ""
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Handles `--help` and `--version` before loading configuration files or environment variables, and prevents loaded secret values from being used as flag help defaults.

The previous flag setup derived default strings from the fully loaded configuration. Running `openvpn-auth-oauth2 --config <file> --help` could therefore print configured credentials.

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

The change preserves normal secret parsing from command-line arguments, environment variables, and `file://` references.

#### Particularly user-facing changes

`--help` and `--version` no longer depend on a valid runtime configuration, and command help no longer contains configured secret values.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

#### Testing

- `make fmt`
- `make lint`
- `make test`