### PR TITLE
feat!: normalize OAuth2 authentication style values

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -77,7 +77,7 @@ Usage of openvpn-auth-oauth2:
   --log.vpn-client-ip
         log IP of VPN client. Useful to have an identifier between OpenVPN and openvpn-auth-oauth2. (env: OPENVPN_AUTH_OAUTH2_LOG_VPN_CLIENT_IP) (default true)
   --oauth2.auth-style value
-        Auth style represents how requests for tokens are authenticated to the server. Possible values: AuthStyleAutoDetect, AuthStyleInParams, AuthStyleInHeader. See https://pkg.go.dev/golang.org/x/oauth2#AuthStyle (env: OPENVPN_AUTH_OAUTH2_OAUTH2_AUTH_STYLE) (default AuthStyleInParams)
+        Auth style represents how requests for tokens are authenticated to the server. Possible values: auto, params, header. See https://pkg.go.dev/golang.org/x/oauth2#AuthStyle (env: OPENVPN_AUTH_OAUTH2_OAUTH2_AUTH_STYLE) (default params)
   --oauth2.authorize-params string
         additional url query parameter to authorize endpoint (env: OPENVPN_AUTH_OAUTH2_OAUTH2_AUTHORIZE_PARAMS)
   --oauth2.client.id string

--- a/docs/Upgrade V2.md
+++ b/docs/Upgrade V2.md
@@ -204,6 +204,21 @@ The two password files must contain the same password. They can be separate
 files so OpenVPN and openvpn-auth-oauth2 can each read a file from the path
 allowed by their service permissions.
 
+## OAuth2 client authentication style
+
+Version 2 replaces the Go-specific `oauth2.auth-style` values with concise
+configuration values:
+
+| Version 1 value | Version 2 value |
+| --- | --- |
+| `AuthStyleAutoDetect` | `auto` |
+| `AuthStyleInParams` | `params` |
+| `AuthStyleInHeader` | `header` |
+
+Update the value in YAML, the `--oauth2.auth-style` command-line flag, or the
+`OPENVPN_AUTH_OAUTH2_OAUTH2_AUTH_STYLE` environment variable. The version 1
+values are no longer accepted.
+
 ## CEL context
 
 Version 2 uses one namespaced context for username resolution, validation, and

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,7 +87,7 @@ oauth2:
         - "test2"
         expression: "openvpn.commonName == token.claims.preferred_username"
     authorize-params: "a=c"
-    auth-style: "AuthStyleInHeader"
+    auth-style: "header"
     scopes:
     - "openid"
     - "profile"
@@ -302,10 +302,13 @@ func TestConfigHelpFlag(t *testing.T) {
 	assert.Contains(t, buf.String(), "(env: OPENVPN_AUTH_OAUTH2_HTTP_LISTEN)")
 	assert.Contains(t, buf.String(), "--openvpn.command-timeout duration")
 	assert.Contains(t, buf.String(), "(env: OPENVPN_AUTH_OAUTH2_OPENVPN_COMMAND_TIMEOUT)")
+	assert.Contains(t, buf.String(), "Possible values: auto, params, header.")
+	assert.Contains(t, buf.String(), "(default params)")
 	assert.Contains(t, buf.String(), "(default /etc/openvpn-auth-oauth2/client-config/)")
 	assert.Contains(t, buf.String(), "--openvpn.pass-through.socket-mode value")
 	assert.Contains(t, buf.String(), "(default 0660)")
 	assert.NotContains(t, buf.String(), "/etc/openvpn-auth-oauth2/client-config-dir/")
+	assert.NotContains(t, buf.String(), "AuthStyleInParams")
 	assert.NotContains(t, buf.String(), "--http.short-url")
 	assert.NotContains(t, buf.String(), "--openvpn.common-name.mode")
 	assert.NotContains(t, buf.String(), "(env: CONFIG_HTTP_LISTEN)")

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -345,7 +345,7 @@ func (c *Config) flagSetOAuth2(flagSet *flag.FlagSet) {
 		"oauth2.auth-style",
 		c.OAuth2.AuthStyle,
 		"Auth style represents how requests for tokens are authenticated to the server. "+
-			"Possible values: AuthStyleAutoDetect, AuthStyleInParams, AuthStyleInHeader. "+
+			"Possible values: auto, params, header. "+
 			"See https://pkg.go.dev/golang.org/x/oauth2#AuthStyle",
 	)
 	flagSet.BoolVar(

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -230,11 +230,11 @@ func (s OAuth2AuthStyle) AuthStyle() oauth2.AuthStyle {
 func (s OAuth2AuthStyle) MarshalText() ([]byte, error) {
 	switch s {
 	case OAuth2AuthStyle(oauth2.AuthStyleAutoDetect):
-		return []byte("AuthStyleAutoDetect"), nil
+		return []byte("auto"), nil
 	case OAuth2AuthStyle(oauth2.AuthStyleInParams):
-		return []byte("AuthStyleInParams"), nil
+		return []byte("params"), nil
 	case OAuth2AuthStyle(oauth2.AuthStyleInHeader):
-		return []byte("AuthStyleInHeader"), nil
+		return []byte("header"), nil
 	default:
 		return nil, fmt.Errorf("unknown auth-style: %d", s)
 	}
@@ -245,11 +245,11 @@ func (s OAuth2AuthStyle) MarshalText() ([]byte, error) {
 //goland:noinspection GoMixedReceiverTypes
 func (s *OAuth2AuthStyle) UnmarshalText(text []byte) error {
 	switch strings.ToLower(string(text)) {
-	case "authstyleautodetect":
+	case "auto":
 		*s = OAuth2AuthStyle(oauth2.AuthStyleAutoDetect)
-	case "authstyleinparams":
+	case "params":
 		*s = OAuth2AuthStyle(oauth2.AuthStyleInParams)
-	case "authstyleinheader":
+	case "header":
 		*s = OAuth2AuthStyle(oauth2.AuthStyleInHeader)
 	default:
 		return fmt.Errorf("unknown auth-style: %s", text)

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -58,18 +58,37 @@ func TestOpenVPNConfigStrategyString(t *testing.T) {
 func TestOAuth2AuthStyleUnmarshalText(t *testing.T) {
 	t.Parallel()
 
-	var oAuth2AuthStyle config.OAuth2AuthStyle
+	for _, tc := range []struct {
+		name      string
+		value     string
+		expected  config.OAuth2AuthStyle
+		wantError bool
+	}{
+		{name: "auto", value: "auto", expected: config.OAuth2AuthStyle(oauth2.AuthStyleAutoDetect)},
+		{name: "params", value: "params", expected: config.OAuth2AuthStyle(oauth2.AuthStyleInParams)},
+		{name: "header", value: "header", expected: config.OAuth2AuthStyle(oauth2.AuthStyleInHeader)},
+		{name: "unknown", value: "unknown", wantError: true},
+		{name: "legacy auto", value: "AuthStyleAutoDetect", wantError: true},
+		{name: "legacy params", value: "AuthStyleInParams", wantError: true},
+		{name: "legacy header", value: "AuthStyleInHeader", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.NoError(t, oAuth2AuthStyle.UnmarshalText([]byte("AuthStyleInHeader")))
-	assert.Equal(t, config.OAuth2AuthStyle(oauth2.AuthStyleInHeader), oAuth2AuthStyle)
+			var actual config.OAuth2AuthStyle
 
-	require.NoError(t, oAuth2AuthStyle.UnmarshalText([]byte("AuthStyleInParams")))
-	assert.Equal(t, config.OAuth2AuthStyle(oauth2.AuthStyleInParams), oAuth2AuthStyle)
+			err := actual.UnmarshalText([]byte(tc.value))
 
-	require.NoError(t, oAuth2AuthStyle.UnmarshalText([]byte("AuthStyleAutoDetect")))
-	assert.Equal(t, config.OAuth2AuthStyle(oauth2.AuthStyleAutoDetect), oAuth2AuthStyle)
+			if tc.wantError {
+				require.Error(t, err)
 
-	require.Error(t, oAuth2AuthStyle.UnmarshalText([]byte("unknown")))
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
 }
 
 func TestOAuth2AuthStyleMarshalText(t *testing.T) {
@@ -78,17 +97,17 @@ func TestOAuth2AuthStyleMarshalText(t *testing.T) {
 	oAuth2AuthStyle, err := config.OAuth2AuthStyle(oauth2.AuthStyleInHeader).MarshalText()
 
 	require.NoError(t, err)
-	assert.Equal(t, []byte("AuthStyleInHeader"), oAuth2AuthStyle)
+	assert.Equal(t, []byte("header"), oAuth2AuthStyle)
 
 	oAuth2AuthStyle, err = config.OAuth2AuthStyle(oauth2.AuthStyleInParams).MarshalText()
 
 	require.NoError(t, err)
-	assert.Equal(t, []byte("AuthStyleInParams"), oAuth2AuthStyle)
+	assert.Equal(t, []byte("params"), oAuth2AuthStyle)
 
 	oAuth2AuthStyle, err = config.OAuth2AuthStyle(oauth2.AuthStyleAutoDetect).MarshalText()
 
 	require.NoError(t, err)
-	assert.Equal(t, []byte("AuthStyleAutoDetect"), oAuth2AuthStyle)
+	assert.Equal(t, []byte("auto"), oAuth2AuthStyle)
 
 	_, err = config.OAuth2AuthStyle(-1).MarshalText()
 
@@ -98,9 +117,9 @@ func TestOAuth2AuthStyleMarshalText(t *testing.T) {
 func TestOAuth2AuthStyleString(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "AuthStyleInHeader", config.OAuth2AuthStyle(oauth2.AuthStyleInHeader).String())
-	assert.Equal(t, "AuthStyleInParams", config.OAuth2AuthStyle(oauth2.AuthStyleInParams).String())
-	assert.Equal(t, "AuthStyleAutoDetect", config.OAuth2AuthStyle(oauth2.AuthStyleAutoDetect).String())
+	assert.Equal(t, "header", config.OAuth2AuthStyle(oauth2.AuthStyleInHeader).String())
+	assert.Equal(t, "params", config.OAuth2AuthStyle(oauth2.AuthStyleInParams).String())
+	assert.Equal(t, "auto", config.OAuth2AuthStyle(oauth2.AuthStyleAutoDetect).String())
 
 	assert.Panics(t, func() { _ = config.OAuth2AuthStyle(-1).String() }, "The code did not panic")
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Replaces the Go-specific public `oauth2.auth-style` values with concise configuration values:

| Version 1 value | Version 2 value |
| --- | --- |
| `AuthStyleAutoDetect` | `auto` |
| `AuthStyleInParams` | `params` |
| `AuthStyleInHeader` | `header` |

The mapping applies consistently to YAML, environment variables, command-line flags, default rendering, and help output. Tests explicitly verify that the version 1 values are rejected.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

This is an intentional breaking change for version 2. The upgrade guide documents all value migrations.

#### Particularly user-facing changes

Users with an explicit `oauth2.auth-style` value must replace it with `auto`, `params`, or `header`. The default behavior remains token endpoint authentication through request parameters, now rendered as `params`.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR