### PR TITLE
chore: use CEL native type descriptors

### DIFF
--- a/internal/oauth2/cel.go
+++ b/internal/oauth2/cel.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/google/cel-go/cel"
+	celtypes "github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/ext"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	celcontext "github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/openvpn_auth_oauth2"
@@ -70,14 +71,13 @@ func (a *celActivation) Parent() cel.Activation {
 
 // newCELEnvironment returns the common CEL environment used by all configurable expressions.
 func newCELEnvironment() (*cel.Env, error) {
+	nativeTypes, err := newCELNativeTypes()
+	if err != nil {
+		return nil, fmt.Errorf("create CEL native context types: %w", err)
+	}
+
 	env, err := cel.NewEnv(
-		ext.NativeTypes(
-			reflect.TypeFor[celcontext.AuthContext](),
-			reflect.TypeFor[celcontext.OpenVPNContext](),
-			reflect.TypeFor[celcontext.TokenContext](),
-			reflect.TypeFor[celcontext.UserContext](),
-			ext.ParseStructTag("cel"),
-		),
+		nativeTypes,
 		cel.VariableWithDoc("auth", cel.ObjectType(celAuthContextTypeName), "Authentication context"),
 		cel.VariableWithDoc("openvpn", cel.ObjectType(celOpenVPNContextTypeName), "OpenVPN session context"),
 		cel.VariableWithDoc("token", cel.ObjectType(celTokenContextTypeName), "OAuth2 token context"),
@@ -90,6 +90,27 @@ func newCELEnvironment() (*cel.Env, error) {
 	}
 
 	return env, nil
+}
+
+func newCELNativeTypes() (cel.EnvOption, error) {
+	contextTypes := []reflect.Type{
+		reflect.TypeFor[celcontext.AuthContext](),
+		reflect.TypeFor[celcontext.OpenVPNContext](),
+		reflect.TypeFor[celcontext.TokenContext](),
+		reflect.TypeFor[celcontext.UserContext](),
+	}
+	descriptors := make([]any, 0, len(contextTypes))
+
+	for _, contextType := range contextTypes {
+		descriptor, err := celtypes.NewNativeType(contextType, celtypes.ParseStructTag("cel"))
+		if err != nil {
+			return nil, fmt.Errorf("create descriptor for %s: %w", contextType, err)
+		}
+
+		descriptors = append(descriptors, descriptor)
+	}
+
+	return cel.Types(descriptors...), nil
 }
 
 func (c *Client) initializeCELPrograms() error {


### PR DESCRIPTION
#### What this PR does / why we need it

- constructs the four CEL context descriptors with the CEL-Go v0.31 core `types.NewNativeType` API
- registers those descriptors directly through `cel.Types`
- retains the existing `cel` struct-tag mapping and CEL behavior

CEL-Go v0.31 introduced self-describing and self-adapting native struct types in the core type registry. Using those interfaces directly removes this integration's dependency on the legacy `ext.NativeTypes` composition helper and keeps native-value registration aligned with the new API.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

The existing CEL characterization tests cover field schemas, object construction and equality, dynamic token claims, lists, and presence checks. Benchmarks showed unchanged allocations and no stable end-to-end timing difference, so this PR intentionally avoids adding custom field-access wrappers.

#### Particularly user-facing changes

None. This is an internal CEL integration update with no intended expression-language or configuration changes.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR

Validation:

- `make fmt`
- `make lint`
- `make test`
