### PR TITLE
chore: label test dependency updates as chore

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,31 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jkroepke/renovate-config"]
+  "extends": ["github>jkroepke/renovate-config"],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/containerd/errdefs",
+        "github.com/containerd/errdefs/pkg",
+        "github.com/docker/go-connections",
+        "github.com/ebitengine/purego",
+        "github.com/klauspost/compress",
+        "github.com/lufia/plan9stats",
+        "github.com/madflojo/testcerts",
+        "github.com/magiconair/properties",
+        "github.com/moby/go-archive",
+        "github.com/moby/moby/api",
+        "github.com/moby/moby/client",
+        "github.com/moby/sys/user",
+        "github.com/moby/sys/userns",
+        "github.com/power-devops/perfstat",
+        "github.com/shirou/gopsutil/v4",
+        "github.com/sirupsen/logrus",
+        "github.com/stretchr/testify",
+        "github.com/testcontainers/testcontainers-go",
+        "go.opentelemetry.io/**"
+      ],
+      "addLabels": ["chore"]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- add a Renovate package rule for Go dependencies used only by tests and integration tests
- append the `chore` label while preserving the inherited `🛠️ dependencies` label
- classify every `go.opentelemetry.io/**` dependency update as `chore`

## Why

Internal dependency updates were appearing in user-facing release notes. Renovate does not expose Go test-only dependency metadata, so the repository must identify these modules by package name.

## Impact

Future matching dependency PRs are excluded from the user-facing changelog. Runtime dependency updates retain their existing classification.

## Validation

- `npx --yes --package renovate@41.140.1 renovate-config-validator renovate.json`
- `make fmt`
- `make lint`
- `make test`
- `git diff --check`
