### PR TITLE
fix: halt replaced unique-user sessions

### DIFF
--- a/docs/OpenVPN Username.md
+++ b/docs/OpenVPN Username.md
@@ -159,11 +159,18 @@ is also enabled.
 
 Before accepting a client, openvpn-auth-oauth2 requests `status 3`, finds every
 active client with an exactly matching `Username` field, and sends
-`client-kill <CID>` for each match except the CID currently authenticating. The
-status lookup and client acceptance are serialized so two concurrent logins
-cannot both pass the check. A status, parsing, or kill error prevents the new
-client from being accepted. If a matching CID disconnected after the status
-lookup, authentication continues because the old session is already gone.
+`client-kill <CID> HALT` for each match except the CID currently
+authenticating. `HALT` tells the displaced client to clear cached
+authentication and exit instead of automatically reconnecting with a cached
+authentication token. The status lookup and client acceptance are serialized
+so two concurrent logins cannot both pass the check. A status, parsing, or kill
+error prevents the new client from being accepted. If a matching CID
+disconnected after the status lookup, authentication continues because the old
+session is already gone.
+
+`HALT` does not revoke an `auth-gen-token` on the server. It prevents the
+displaced client from immediately reusing an in-memory token; a later manual
+connection starts a new authentication flow.
 
 The check applies to interactive authentication, silent reauthentication, and
 non-interactive reconnects. When `oauth2.refresh.validate-user=false`, the

--- a/docs/demo/openvpn-server.conf
+++ b/docs/demo/openvpn-server.conf
@@ -14,7 +14,6 @@ push "dhcp-option DNS 1.1.1.1"
 
 keepalive 10 120
 reneg-sec 120
-persist-key
 persist-tun
 
 dh none

--- a/internal/it_test.go
+++ b/internal/it_test.go
@@ -70,7 +70,6 @@ duplicate-cn
 disable-dco
 explicit-exit-notify
 keepalive 10 60
-persist-key
 persist-tun
 reneg-sec 600
 verb 3
@@ -86,7 +85,6 @@ remote 127.0.0.1 1194 udp4
 remote-cert-tls server
 connect-retry-max 2
 tls-cert-profile preferred
-persist-key
 persist-tun
 disable-dco
 reneg-sec 0
@@ -152,7 +150,10 @@ func TestITEnforceUniqueUser(t *testing.T) {
 	authenticateUniqueUserITClient(t, client2, httpServer, server)
 
 	waitForOpenVPNITMessage(t, client1, server, func(line string) bool {
-		return strings.HasPrefix(line, ">HOLD:Waiting for hold release:")
+		return strings.HasPrefix(line, ">NOTIFY:info,server-pushed-halt,")
+	})
+	waitForOpenVPNITMessage(t, client1, server, func(line string) bool {
+		return strings.HasPrefix(line, ">STATE:") && strings.Contains(line, ",EXITING,server-pushed-halt,")
 	})
 }
 

--- a/internal/openvpn/callbacks_test.go
+++ b/internal/openvpn/callbacks_test.go
@@ -165,9 +165,9 @@ func TestAcceptClientEnforcesUniqueUser(t *testing.T) {
 			"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.5\t\t1\t2\tnow\t1\talice\t12\t0\tAES-256-GCM\r\nEND",
 	)
 
-	suite.ExpectMessage(t, "client-kill 7")
+	suite.ExpectMessage(t, "client-kill 7 HALT")
 	suite.SendMessagef(t, "SUCCESS: client-kill command succeeded")
-	suite.ExpectMessage(t, "client-kill 12")
+	suite.ExpectMessage(t, "client-kill 12 HALT")
 	suite.SendMessagef(t, "ERROR: client-kill command failed")
 	suite.ExpectMessage(t, "client-auth 10 2\r\noverride-username \"alice\"\r\nEND")
 	suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")
@@ -292,7 +292,7 @@ func TestAcceptClientSerializesSessionReplacement(t *testing.T) {
 		statusHeader+"\r\n"+
 			"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.2\t\t1\t2\tnow\t1\talice\t1\t0\tAES-256-GCM\r\nEND",
 	)
-	suite.ExpectMessage(t, "client-kill 1")
+	suite.ExpectMessage(t, "client-kill 1 HALT")
 	suite.SendMessagef(t, "SUCCESS: client-kill command succeeded")
 	suite.ExpectMessage(t, "client-auth 2 1\r\noverride-username \"alice\"\r\nEND")
 	suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")

--- a/internal/openvpn/client_refresh_test.go
+++ b/internal/openvpn/client_refresh_test.go
@@ -165,7 +165,7 @@ func TestSilentAuthenticationEnforcesUniqueUser(t *testing.T) {
 					"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.2\t\t1\t2\tnow\t1\talice\t7\t0\tAES-256-GCM\r\n"+
 					"CLIENT_LIST\tclient\t127.0.0.1:1194\t10.8.0.3\t\t1\t2\tnow\t1\talice\t10\t0\tAES-256-GCM\r\nEND",
 			)
-			suite.ExpectMessage(t, "client-kill 7")
+			suite.ExpectMessage(t, "client-kill 7 HALT")
 			suite.SendMessagef(t, "SUCCESS: client-kill command succeeded")
 			suite.ExpectMessage(t, "client-auth 10 3\r\noverride-username \"alice\"\r\nEND")
 			suite.SendMessagef(t, "SUCCESS: client-auth command succeeded")

--- a/internal/openvpn/status.go
+++ b/internal/openvpn/status.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-const clientKillMissingResponse = "ERROR: client-kill command failed"
+const (
+	clientKillHaltMessage     = "HALT"
+	clientKillMissingResponse = "ERROR: client-kill command failed"
+)
 
 func (c *Client) enforceUniqueUser(ctx context.Context, logger *slog.Logger, currentCID uint64, username string) error {
 	if username == "" {
@@ -34,7 +37,7 @@ func (c *Client) enforceUniqueUser(ctx context.Context, logger *slog.Logger, cur
 			slog.Uint64("existing_cid", clientID),
 		)
 
-		response, err := c.SendCommandf(ctx, "client-kill %d", clientID)
+		response, err := c.SendCommandf(ctx, "client-kill %d %s", clientID, clientKillHaltMessage)
 
 		response = strings.TrimSpace(response)
 		if errors.Is(err, ErrErrorResponse) && response == clientKillMissingResponse {

--- a/lib/openvpn-auth-oauth2/plugin_it_test.go
+++ b/lib/openvpn-auth-oauth2/plugin_it_test.go
@@ -61,7 +61,6 @@ key /etc/openvpn/pki/private/server.key
 cert /etc/openvpn/pki/issued/server.crt
 dh none
 keepalive 10 60
-persist-key
 persist-tun
 explicit-exit-notify
 

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -51,7 +51,6 @@ services:
         cert /etc/openvpn/pki/issued/server.crt
         dh none
         keepalive 10 60
-        #persist-key
         persist-tun
         explicit-exit-notify
 


### PR DESCRIPTION
## Summary

- send `client-kill <CID> HALT` when replacing a session through `openvpn.enforce-unique-user`
- assert that the displaced client receives the expected `server-pushed-halt` notification and exits
- remove obsolete `persist-key` directives; OpenVPN 2.7+ always persists keys across restarts
- document that HALT prevents an immediate cached-token reconnect but does not revoke the server-side `auth-gen-token`

## Why

The default `client-kill` message is `RESTART`, allowing the replaced client to reconnect with its still-valid cached authentication token. Two clients sharing one allowed session can then continuously displace each other.

Fixes #1103.

## Validation

- `make fmt`
- `make lint`
- `make test`
- `OPENVPN_IT_TEST=1 go test -race -count=1 -timeout=15m -run '^TestITEnforceUniqueUser$' ./internal`