### PR TITLE
docs: extend OIDC authentication flow

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -79,4 +79,24 @@ sequenceDiagram
     IdP-->>Auth: ID and access tokens
     Auth->>Server: Accept or deny client
     Server-->>Client: Connection established
+
+    Server->>Auth: CLIENT:REAUTH
+    alt Non-interactive reauthentication
+        Auth->>IdP: Refresh token
+        IdP-->>Auth: New ID and access tokens
+        Auth->>Server: Accept or deny client
+    else Internal refresh authentication
+        Auth->>Auth: Validate stored authentication state
+        Auth->>Server: Accept or deny client
+    else Interactive reauthentication required
+        Auth-->>Server: WEB_AUTH URL
+        Server-->>Client: WEB_AUTH URL
+        Client->>Browser: Open URL
+        Browser->>IdP: Sign in
+        IdP-->>Browser: Redirect with authorization code
+        Browser->>Auth: OAuth2 callback
+        Auth->>IdP: Exchange authorization code
+        IdP-->>Auth: ID and access tokens
+        Auth->>Server: Accept or deny client
+    end
 ```

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -73,7 +73,10 @@ sequenceDiagram
     Server-->>Client: WEB_AUTH URL
     Client->>Browser: Open URL
     Browser->>IdP: Sign in
-    IdP-->>Auth: OAuth2 callback
+    IdP-->>Browser: Redirect with authorization code
+    Browser->>Auth: OAuth2 callback
+    Auth->>IdP: Exchange authorization code
+    IdP-->>Auth: ID and access tokens
     Auth->>Server: Accept or deny client
     Server-->>Client: Connection established
 ```


### PR DESCRIPTION
Extend the authentication flow diagram in `docs/Home.md` to show the authorization code redirect and token endpoint exchange between `openvpn-auth-oauth2` and the OIDC provider.

Closes #1123