### PR TITLE
feat: build OpenVPN plugins for Linux arm64 and FreeBSD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,10 @@ jobs:
           go-version-file: 'go.mod'
           cache: "${{ github.actor != 'renovate[bot]' }}"
 
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.15.2
+
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Write gpg sign key
@@ -174,6 +178,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.15.2
 
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,17 +38,19 @@ builds:
     env:
       - CGO_ENABLED=1
       - >-
-        {{- if eq .Arch "amd64"}}CC=x86_64-linux-gnu-gcc{{- end }}
-        {{- if eq .Arch "arm64"}}CC=aarch64-linux-gnu-gcc{{- end }}
-      - >-
-        {{- if eq .Arch "amd64"}}CXX=x86_64-linux-gnu-g++{{- end }}
-        {{- if eq .Arch "arm64"}}CXX=aarch64-linux-gnu-g++{{- end }}
+        {{- if and (eq .Os "linux") (eq .Arch "amd64")}}CC=zig cc -target x86_64-linux-gnu.2.17{{- end }}
+        {{- if and (eq .Os "linux") (eq .Arch "arm64")}}CC=zig cc -target aarch64-linux-gnu.2.17{{- end }}
+        {{- if and (eq .Os "freebsd") (eq .Arch "amd64")}}CC=zig cc -target x86_64-freebsd.14.0{{- end }}
     goos:
       - linux
-    #  - freebsd
+      - freebsd
     goarch:
       - amd64
-    #  - arm64
+      - arm64
+    ignore:
+      # Go does not support -buildmode=c-shared for freebsd/arm64.
+      - goos: freebsd
+        goarch: arm64
     mod_timestamp: '{{ .CommitTimestamp }}'
     tags:
       - no_otel


### PR DESCRIPTION
## Summary

- replace the architecture-specific GCC cross-compilers with Zig 0.15.2
- build the `c-shared` OpenVPN plugin for Linux amd64, Linux arm64, and FreeBSD amd64
- target glibc 2.17 for Linux and FreeBSD 14.0 for the FreeBSD artifact
- pin `mlugg/setup-zig` in snapshot and release jobs

FreeBSD arm64 remains excluded because the Go toolchain does not support `-buildmode=c-shared` for that target. OpenBSD is likewise not added because Go does not support `c-shared` there.

## Testing

- `goreleaser v2.18.0 check`
- parsed both changed YAML files with PyYAML
- `git diff --check`

The complete build and test suite is delegated to this PR's GitHub Actions jobs because the local environment does not provide the repository's Go 1.27 toolchain or Zig.