### PR TITLE
feat!: use one OpenVPN plugin filename on every platform

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
         -X github.com/jkroepke/openvpn-auth-oauth2/v2/internal/version.Date={{.Date}}
 
   - id: "openvpn-auth-oauth2.so"
-    binary: openvpn-auth-oauth2-{{ .Os }}-{{ .Arch }}
+    binary: openvpn-auth-oauth2
     main: ./lib/openvpn-auth-oauth2
     buildmode: c-shared
     env:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ integrating OpenVPN with OIDC providers such as
 The complete wiki is organized by task and remains available from the
 [documentation home](https://github.com/jkroepke/openvpn-auth-oauth2/wiki).
 
-OpenVPN can connect through the stable Linux AMD64 plugin or directly through
-its management interface. The
+OpenVPN can connect through the stable plugin on Linux AMD64, Linux ARM64, and
+FreeBSD AMD64, or directly through its management interface. The
 [Getting Started guide](https://github.com/jkroepke/openvpn-auth-oauth2/wiki/Getting-Started#4-choose-the-openvpn-integration)
 compares both supported options.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -234,7 +234,7 @@ See [Filesystem Permissions](Filesystem%20Permissions) for more information.
 
 | Integration | Main benefit | Limitation |
 | --- | --- | --- |
-| [OpenVPN plugin](OpenVPN%20Plugin) | Leaves OpenVPN's management interface available for other tools | Distributed only for Linux AMD64; does not support `openvpn.enforce-unique-user` |
+| [OpenVPN plugin](OpenVPN%20Plugin) | Leaves OpenVPN's management interface available for other tools | Distributed for Linux AMD64, Linux ARM64, and FreeBSD AMD64; does not support `openvpn.enforce-unique-user` |
 | Direct management interface | Provides the full management command set and supports `openvpn.enforce-unique-user` | Occupies OpenVPN's single management client connection |
 
 > [!NOTE]

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -78,7 +78,7 @@ username overrides, and client-specific configuration.
 
 | Integration | Choose it when | Trade-off |
 | --- | --- | --- |
-| [OpenVPN plugin](OpenVPN%20Plugin) | Your OpenVPN server uses Linux AMD64 | Keeps OpenVPN's management interface available, but cannot enforce one active session per OIDC username |
+| [OpenVPN plugin](OpenVPN%20Plugin) | Your OpenVPN server uses Linux AMD64, Linux ARM64, or FreeBSD AMD64 | Keeps OpenVPN's management interface available, but cannot enforce one active session per OIDC username |
 | Direct management interface | You need `openvpn.enforce-unique-user` or cannot use the plugin | Supports the full management command set, but occupies OpenVPN's single management client connection |
 
 > [!NOTE]
@@ -108,12 +108,12 @@ unset management_password
 
 ### Option A: OpenVPN plugin
 
-Linux AMD64 DEB and RPM packages install the plugin at
-`/usr/lib/openvpn/openvpn-auth-oauth2-linux-amd64.so`. Add it to the OpenVPN
-server configuration:
+Linux AMD64 and ARM64 DEB and RPM packages install the plugin at
+`/usr/lib/openvpn/openvpn-auth-oauth2.so`. Add it to the OpenVPN server
+configuration:
 
 ```ini
-plugin /usr/lib/openvpn/openvpn-auth-oauth2-linux-amd64.so "tcp://127.0.0.1:9002" "/etc/openvpn/management-password.txt"
+plugin /usr/lib/openvpn/openvpn-auth-oauth2.so "tcp://127.0.0.1:9002" "/etc/openvpn/management-password.txt"
 auth-user-pass-optional
 ```
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -30,8 +30,9 @@ Choose the path that matches what you want to do:
   supported identity providers.
 - [HTTPS Listener](HTTPS%20Listener) explains reverse-proxy and native TLS
   options.
-- [OpenVPN Plugin](OpenVPN%20Plugin) is a stable Linux AMD64 integration that
-  keeps OpenVPN's management interface available for other tools.
+- [OpenVPN Plugin](OpenVPN%20Plugin) is a stable integration for Linux AMD64,
+  Linux ARM64, and FreeBSD AMD64 that keeps OpenVPN's management interface
+  available for other tools.
 
 ### Control access and identity
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -22,11 +22,10 @@ sudo apt install openvpn-auth-oauth2
 > the URI in the sources file.
 
 > [!NOTE]
-> Linux AMD64 DEB and RPM packages include the stable
-> [OpenVPN plugin](OpenVPN%20Plugin). Packages for other operating systems and
-> architectures contain only the `openvpn-auth-oauth2` service because the
-> release pipeline does not cross-compile the CGO shared library for those
-> targets.
+> Linux AMD64 and ARM64 DEB and RPM packages include the matching stable
+> [OpenVPN plugin](OpenVPN%20Plugin). The FreeBSD AMD64 plugin is available in
+> the release archive. Packages and archives for other operating systems and
+> architectures contain only the `openvpn-auth-oauth2` service.
 
 **Alternatively, you can install the DEB package manually:**
 

--- a/docs/OpenVPN Plugin.md
+++ b/docs/OpenVPN Plugin.md
@@ -14,7 +14,7 @@ real management interface.
 
 Use the plugin when:
 
-- the OpenVPN server runs on Linux AMD64;
+- the OpenVPN server runs on Linux AMD64, Linux ARM64, or FreeBSD AMD64;
 - another tool needs OpenVPN's management interface; or
 - you prefer to isolate authentication from general management commands.
 
@@ -58,25 +58,26 @@ instead when `openvpn.enforce-unique-user` is required.
 ## Requirements
 
 - OpenVPN Community Server 2.6.2 or later.
-- Linux AMD64 for the prebuilt plugin artifact.
+- Linux AMD64, Linux ARM64, or FreeBSD AMD64 for a prebuilt plugin artifact.
 - The `openvpn-auth-oauth2` binary and plugin from the same release.
 - A dedicated password shared by the OpenVPN plugin and
   `openvpn-auth-oauth2`.
 
 > [!NOTE]
-> Release archives and DEB/RPM packages contain the plugin only for Linux AMD64.
-> The plugin uses CGO's `c-shared` build mode, and the GitHub Actions release
-> pipeline does not currently cross-compile that shared library for BSD or other
-> architectures. The `openvpn-auth-oauth2` service itself is released for more
-> operating systems and architectures; those artifacts do not include the
-> plugin.
+> Release archives contain the plugin for Linux AMD64, Linux ARM64, and FreeBSD
+> AMD64. Linux AMD64 and ARM64 DEB/RPM packages also contain the matching
+> plugin. The `openvpn-auth-oauth2` service itself is released for more operating
+> systems and architectures; those other artifacts do not include the plugin.
 
 ## 1. Install the plugin
 
-The Linux AMD64 DEB and RPM packages install the shared library at:
+Linux DEB and RPM packages install the shared library that matches the package
+architecture. On every supported platform, the shared library is named
+`openvpn-auth-oauth2.so`. Release archives contain the plugin beside the service
+binary, and Linux packages install it at:
 
 ```text
-/usr/lib/openvpn/openvpn-auth-oauth2-linux-amd64.so
+/usr/lib/openvpn/openvpn-auth-oauth2.so
 ```
 
 If you use the release archive, extract the matching `.so` file and place it in
@@ -112,7 +113,7 @@ unset plugin_password
 TCP loopback avoids Unix socket ownership differences between OpenVPN packages:
 
 ```ini
-plugin /usr/lib/openvpn/openvpn-auth-oauth2-linux-amd64.so "tcp://127.0.0.1:9002" "/etc/openvpn/management-password.txt"
+plugin /usr/lib/openvpn/openvpn-auth-oauth2.so "tcp://127.0.0.1:9002" "/etc/openvpn/management-password.txt"
 auth-user-pass-optional
 ```
 
@@ -121,7 +122,7 @@ auth-user-pass-optional
 A Unix socket avoids allocating a TCP port:
 
 ```ini
-plugin /usr/lib/openvpn/openvpn-auth-oauth2-linux-amd64.so "unix:///run/openvpn/openvpn-auth-oauth2.sock" "/etc/openvpn/management-password.txt"
+plugin /usr/lib/openvpn/openvpn-auth-oauth2.so "unix:///run/openvpn/openvpn-auth-oauth2.sock" "/etc/openvpn/management-password.txt"
 auth-user-pass-optional
 ```
 


### PR DESCRIPTION
#### What this PR does / why we need it

- documents prebuilt OpenVPN plugin support for Linux AMD64, Linux ARM64, and FreeBSD AMD64
- gives every plugin artifact the common openvpn-auth-oauth2.so filename
- updates package paths and OpenVPN configuration examples

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

This is a breaking deployment change for existing plugin users. Update the OpenVPN plugin directive from /usr/lib/openvpn/openvpn-auth-oauth2-linux-amd64.so to /usr/lib/openvpn/openvpn-auth-oauth2.so when upgrading.

#### Particularly user-facing changes

Prebuilt plugin artifacts are now documented for all supported platforms and use one platform-independent filename.

#### Testing

- [x] goreleaser check
- [x] make fmt
- [x] make lint
- [x] make test

#### Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect significant user-facing changes