### PR TITLE
docs: document OpenVPN 3 auth-token limitation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,12 @@ make lint
 make test
 ```
 
+If Markdown files are changed, also run:
+
+```shell
+make textlint
+```
+
 If a check cannot run because of missing dependencies or network restrictions,
 state that limitation in the pull request's testing notes.
 

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ test:  ## Test the project
 .PHONY: lint
 lint: golangci  ## Run linter
 
+.PHONY: textlint
+textlint:  ## Run textlint
+	npx textlint --rule terminology .
+
 .PHONY: fmt  ## Format code
 fmt:
 	@go mod tidy

--- a/docs/Non-interactive session refresh.md
+++ b/docs/Non-interactive session refresh.md
@@ -53,6 +53,11 @@ you must enable `auth-gen-token [lifetime] external-auth` on the OpenVPN server.
 If `auth-gen-token-secret [keyfile]` is configured, OpenVPN access server restarts can verify auth-tokens.
 To generate a new secret, utilize `openvpn --genkey auth-token [keyfile]`.
 
+> [!NOTE]
+> OpenVPN 3-based clients, such as OpenVPN Connect, do not reuse auth-tokens after an OpenVPN server restart.
+> As a result, `auth-gen-token-secret` cannot provide non-interactive reconnections for these clients.
+> See [issue #1124](https://github.com/jkroepke/openvpn-auth-oauth2/issues/1124) for details.
+
 > [!WARNING]
 > Keep the key file secret. Anyone with access to it can generate authentication
 > tokens that the OpenVPN server accepts as valid.


### PR DESCRIPTION
## Summary

- document that OpenVPN 3-based clients such as OpenVPN Connect do not reuse auth-tokens after server restarts
- explain that auth-gen-token-secret cannot provide non-interactive reconnections for those clients
- require make textlint when Markdown files change
- link the OpenVPN 3 behavior to issue #1124

## Testing

- make fmt
- make lint
- make test
- make textlint

Closes #1124