### PR TITLE
chore: avoid C allocations in plugin logging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
     name: Build & Test
     permissions:
       contents: read
+    env:
+      GOEXPERIMENT: 'cgocheck2'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,11 @@ Before merging, apply at least one changelog label defined in
 - `🐞 bug` for fixes
 - `🛠️ dependencies` for dependency updates
 - `📖 docs` for documentation
-- `chore` only for changes excluded from the user-facing changelog
+- `chore` for internal technical changes excluded from the user-facing changelog
+
+Use `chore` for implementation-only performance improvements, tests, CI, and
+maintenance that do not change user-facing behavior. Use `✨ enhancement` only
+when a change adds functionality that users can observe or use.
 
 Add `💥 breaking-change` whenever a change is breaking, even if another label
 also applies.
@@ -45,6 +49,17 @@ Configuration is usually done through a YAML file or environment variables. The
 project's `docs/` directory contains detailed guides such as
 [`docs/Configuration.md`](docs/Configuration.md) and
 [`docs/Home.md`](docs/Home.md).
+
+## Plugin cgo pointer checks
+
+All tests must be compiled with `GOEXPERIMENT=cgocheck2` so the plugin's Go/C
+boundary receives the complete, expensive cgo pointer checks. The `test` target
+in `Makefile` and the build-and-test job in `.github/workflows/ci.yaml` set the
+experiment at build time.
+
+Do not try to enable the experiment with `//go:debug cgocheck2=1`,
+`//go:debug cgocheck=2`, `GODEBUG=cgocheck=2`, or `t.Setenv`. The first is not a
+`GODEBUG` setting, while the others cannot enable the build-time instrumentation.
 
 ## OpenVPN management command size
 

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(PROJECT_NAME):
 
 .PHONY: test
 test:  ## Test the project
-	@go test -race ./...
+	@GOEXPERIMENT=cgocheck2 go test -race ./...
 
 .PHONY: lint
 lint: golangci  ## Run linter

--- a/lib/openvpn-auth-oauth2/internal/c/log_wrapper.go
+++ b/lib/openvpn-auth-oauth2/internal/c/log_wrapper.go
@@ -9,18 +9,26 @@ static char *MODULE = "openvpn-auth-oauth2";
 
 // A wrapper function is needed because go is not able to call C pointer functions
 // https://stackoverflow.com/questions/37157379/passing-function-pointer-to-the-c-code-using-cgo
-int plugin_log(struct openvpn_plugin_callbacks* cb, int flags, char *msg) {
+int plugin_log(struct openvpn_plugin_callbacks* cb, int flags, const char *msg) {
 	cb->plugin_log(flags, MODULE, "%s", msg);
 	return 0;
 }
 */
 import "C"
 
-import (
-	"unsafe"
-)
+import "unsafe"
 
-func PluginLog(cb *OpenVPNPluginCallbacks, flags PLogLevel, msg *Char) {
-	//nolint:nlreturn,unconvert // false positive
-	C.plugin_log((*C.struct_openvpn_plugin_callbacks)(unsafe.Pointer(cb)), C.int(flags), (*C.char)(msg))
+// PluginLog synchronously forwards a NUL-terminated message. The callback must
+// not retain a pointer to msg after it returns.
+func PluginLog(callbacks *OpenVPNPluginCallbacks, flags PLogLevel, msg []byte) {
+	if len(msg) == 0 || msg[len(msg)-1] != 0 {
+		panic("plugin log message must be NUL-terminated")
+	}
+
+	//nolint:nlreturn // false positive
+	C.plugin_log(
+		(*C.struct_openvpn_plugin_callbacks)(unsafe.Pointer(callbacks)),
+		C.int(flags),
+		(*C.char)(unsafe.Pointer(unsafe.SliceData(msg))),
+	)
 }

--- a/lib/openvpn-auth-oauth2/internal/pluginlog/logger.go
+++ b/lib/openvpn-auth-oauth2/internal/pluginlog/logger.go
@@ -2,18 +2,12 @@
 
 package pluginlog
 
-/*
-#include <stdlib.h>
-*/
-import "C"
-
 import (
 	"context"
 	"fmt"
 	"log/slog"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/lib/openvpn-auth-oauth2/internal/c"
 )
@@ -22,11 +16,11 @@ import (
 // OpenVPN's plugin logging system. It forwards log messages to OpenVPN using the
 // plugin_log callback function.
 type PluginHandler struct {
+	opts         Options
 	mu           *sync.Mutex
 	cb           *c.OpenVPNPluginCallbacks
-	opts         Options
-	preformatted []byte
 	bufPool      *sync.Pool
+	preformatted []byte
 }
 
 // Options configures the behavior of the PluginHandler.
@@ -102,13 +96,11 @@ func (h *PluginHandler) Handle(_ context.Context, record slog.Record) error {
 		return true
 	})
 
+	buf = append(buf, 0)
+
 	h.mu.Lock()
 
-	msg := c.CString(string(buf))
-
-	c.PluginLog(h.cb, h.pluginLogLevel(record.Level), msg)
-
-	C.free(unsafe.Pointer(msg))
+	c.PluginLog(h.cb, h.pluginLogLevel(record.Level), buf)
 
 	h.mu.Unlock()
 

--- a/lib/openvpn-auth-oauth2/internal/pluginlog/logger_bench_test.go
+++ b/lib/openvpn-auth-oauth2/internal/pluginlog/logger_bench_test.go
@@ -1,0 +1,82 @@
+//go:build (darwin || linux || openbsd || freebsd) && cgo
+
+package pluginlog_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/lib/openvpn-auth-oauth2/internal/pluginlog"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/lib/openvpn-auth-oauth2/internal/util/testutil"
+)
+
+func BenchmarkPluginHandler_Handle(b *testing.B) {
+	benchmarkTime := time.Date(2026, time.July, 2, 10, 11, 12, 13, time.UTC)
+
+	for _, tc := range []struct {
+		name       string
+		message    string
+		attributes []slog.Attr
+	}{
+		{
+			name:    "message",
+			message: "client connected",
+		},
+		{
+			name:    "attributes",
+			message: "client connected",
+			attributes: []slog.Attr{
+				slog.String("user", "alice"),
+				slog.Int("cid", 7),
+				slog.Bool("ok", true),
+				slog.Duration("wait", 1500*time.Microsecond),
+				slog.Time("at", benchmarkTime),
+				slog.Group("session", slog.String("id", "sid-1")),
+			},
+		},
+		{
+			name:    "max_message",
+			message: strings.Repeat("x", 375),
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.Run("serial", func(b *testing.B) {
+				handler, record := newBenchmarkHandler(tc.message, tc.attributes, benchmarkTime)
+				ctx := context.Background()
+
+				b.ReportAllocs()
+
+				for b.Loop() {
+					_ = handler.Handle(ctx, record)
+				}
+			})
+
+			b.Run("parallel", func(b *testing.B) {
+				handler, record := newBenchmarkHandler(tc.message, tc.attributes, benchmarkTime)
+				ctx := context.Background()
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						_ = handler.Handle(ctx, record)
+					}
+				})
+			})
+		})
+	}
+}
+
+func newBenchmarkHandler(message string, attributes []slog.Attr, recordTime time.Time) (slog.Handler, slog.Record) {
+	handler := pluginlog.NewOpenVPNPluginLogger(testutil.Callbacks()).WithAttrs([]slog.Attr{
+		slog.String("component", "plugin"),
+	})
+
+	record := slog.NewRecord(recordTime, slog.LevelInfo, message, 0)
+	record.AddAttrs(attributes...)
+
+	return handler, record
+}

--- a/lib/openvpn-auth-oauth2/internal/pluginlog/logger_test.go
+++ b/lib/openvpn-auth-oauth2/internal/pluginlog/logger_test.go
@@ -13,10 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPluginHandler_Handle(t *testing.T) {
-	t.Parallel()
-
-	handler := NewOpenVPNPluginLogger(testutil.Callbacks()).WithAttrs([]slog.Attr{
+func TestPluginHandler_Handle(t *testing.T) { //nolint:paralleltest // RecordingCallbacks uses process-wide state.
+	handler := NewOpenVPNPluginLogger(testutil.RecordingCallbacks()).WithAttrs([]slog.Attr{
 		slog.String("component", "plugin"),
 	})
 
@@ -31,6 +29,11 @@ func TestPluginHandler_Handle(t *testing.T) {
 	)
 
 	require.NoError(t, handler.Handle(t.Context(), record))
+	require.Equal(
+		t,
+		`INFO: client connected component="plugin" user="alice" cid=7 ok=true wait=1.5ms at=2026-07-02T10:11:12.000000013Z session={ id="sid-1"}`,
+		testutil.RecordedLog(),
+	)
 }
 
 func TestPluginHandler_WithAttrs(t *testing.T) {

--- a/lib/openvpn-auth-oauth2/internal/util/testutil/callbacks.go
+++ b/lib/openvpn-auth-oauth2/internal/util/testutil/callbacks.go
@@ -5,6 +5,8 @@ package testutil
 /*
 #cgo CFLAGS: -I../../../include
 #include <openvpn-plugin.h>
+#include <stdarg.h>
+#include <stdio.h>
 
 static void noop_plugin_log(openvpn_plugin_log_flags_t flags,
                             const char *module,
@@ -16,6 +18,34 @@ static void noop_plugin_log(openvpn_plugin_log_flags_t flags,
 struct openvpn_plugin_callbacks callbacks = {
     .plugin_log            = noop_plugin_log,
 };
+
+static char recorded_log[8192];
+
+static void recording_plugin_log(openvpn_plugin_log_flags_t flags,
+                                 const char *module,
+                                 const char *fmt, ...)
+{
+    (void)flags; (void)module;
+
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(recorded_log, sizeof(recorded_log), fmt, args);
+    va_end(args);
+}
+
+struct openvpn_plugin_callbacks recording_callbacks = {
+    .plugin_log            = recording_plugin_log,
+};
+
+static void reset_recorded_log(void)
+{
+    recorded_log[0] = '\0';
+}
+
+static const char *get_recorded_log(void)
+{
+    return recorded_log;
+}
 */
 import "C"
 
@@ -27,4 +57,14 @@ import (
 
 func Callbacks() *c.OpenVPNPluginCallbacks {
 	return (*c.OpenVPNPluginCallbacks)(unsafe.Pointer(&C.callbacks))
+}
+
+func RecordingCallbacks() *c.OpenVPNPluginCallbacks {
+	C.reset_recorded_log()
+
+	return (*c.OpenVPNPluginCallbacks)(unsafe.Pointer(&C.recording_callbacks))
+}
+
+func RecordedLog() string {
+	return C.GoString(C.get_recorded_log())
 }


### PR DESCRIPTION
#### What this PR does / why we need it

- Pass the pooled Go byte buffer directly to the synchronous OpenVPN plugin log callback.
- Remove the intermediate Go string plus C.CString and C.free allocation from every plugin log call.
- Verify the C callback receives the complete formatted message and add serial and parallel benchmarks for representative 50 to 400 byte messages.
- Enable GOEXPERIMENT=cgocheck2 for local and CI tests so the Go and C pointer boundary receives strict checking.
- Clarify that implementation-only performance, test, CI, and maintenance changes use the chore changelog label.

A local benchstat comparison against the original C.CString path reduced the benchmark geomean from 426.5 ns/op to 253.7 ns/op, a 40.52 percent improvement, while removing one allocation per log call.

#### Which issue this PR fixes

Not linked to an issue.

#### Special notes for your reviewer

The C callback is synchronous and must not retain the Go buffer pointer after returning. The buffer is returned to sync.Pool only after the callback completes.

#### Particularly user-facing changes

None. This is an internal implementation and test-hardening change.

#### Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes
- [x] The PR body summarizes the significant changes

#### Testing

- make fmt
- make lint
- make test
- make textlint
- GOEXPERIMENT=cgocheck2 go test ./lib/openvpn-auth-oauth2/internal/pluginlog -run benchmark-only -bench BenchmarkPluginHandler_Handle -benchmem