### PR TITLE
chore: add OpenVPN plugin string list helper

### DIFF
--- a/lib/openvpn-auth-oauth2/internal/c/typedef.go
+++ b/lib/openvpn-auth-oauth2/internal/c/typedef.go
@@ -92,6 +92,36 @@ func NewOpenVPNPluginStringList() (*OpenVPNPluginStringList, error) {
 	return returnList, nil
 }
 
+// Add appends a name-value pair to the list.
+func (l *OpenVPNPluginStringList) Add(name, value string) error {
+	if l == nil {
+		return errors.New("openvpn plugin string list is nil")
+	}
+
+	tail := l
+	for tail.Next != nil {
+		tail = tail.Next
+	}
+
+	if tail.Name == nil && tail.Value == nil {
+		tail.Name = C.CString(name)
+		tail.Value = C.CString(value)
+
+		return nil
+	}
+
+	next, err := NewOpenVPNPluginStringList()
+	if err != nil {
+		return err
+	}
+
+	next.Name = C.CString(name)
+	next.Value = C.CString(value)
+	tail.Next = next
+
+	return nil
+}
+
 type OpenVPNPluginHandle Uintptr
 
 func NewOpenVPNPluginHandle(value any) OpenVPNPluginHandle {

--- a/lib/openvpn-auth-oauth2/internal/c/typedef_test.go
+++ b/lib/openvpn-auth-oauth2/internal/c/typedef_test.go
@@ -1,0 +1,60 @@
+//go:build (darwin || linux || openbsd || freebsd) && cgo
+
+package c_test
+
+import (
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/lib/openvpn-auth-oauth2/internal/c"
+)
+
+func TestOpenVPNPluginStringList_Add(t *testing.T) {
+	t.Parallel()
+
+	list, err := c.NewOpenVPNPluginStringList()
+	if err != nil {
+		t.Fatalf("NewOpenVPNPluginStringList() error = %v", err)
+	}
+
+	if err := list.Add("first", "one"); err != nil {
+		t.Fatalf("Add() first item error = %v", err)
+	}
+
+	if err := list.Add("second", "two"); err != nil {
+		t.Fatalf("Add() second item error = %v", err)
+	}
+
+	if actual := c.GoString(list.Name); actual != "first" {
+		t.Errorf("first item name = %q, want %q", actual, "first")
+	}
+
+	if actual := c.GoString(list.Value); actual != "one" {
+		t.Errorf("first item value = %q, want %q", actual, "one")
+	}
+
+	if list.Next == nil {
+		t.Fatal("second item is nil")
+	}
+
+	if actual := c.GoString(list.Next.Name); actual != "second" {
+		t.Errorf("second item name = %q, want %q", actual, "second")
+	}
+
+	if actual := c.GoString(list.Next.Value); actual != "two" {
+		t.Errorf("second item value = %q, want %q", actual, "two")
+	}
+
+	if list.Next.Next != nil {
+		t.Error("second item next is not nil")
+	}
+}
+
+func TestOpenVPNPluginStringList_AddNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var list *c.OpenVPNPluginStringList
+
+	if err := list.Add("name", "value"); err == nil {
+		t.Fatal("Add() error = nil, want an error")
+	}
+}

--- a/lib/openvpn-auth-oauth2/internal/openvpn/handle.go
+++ b/lib/openvpn-auth-oauth2/internal/openvpn/handle.go
@@ -321,8 +321,14 @@ func (p *PluginHandle) handleClientConnect(perClientContext *ClientContext, ret 
 		return c.OpenVPNPluginFuncError
 	}
 
-	returnList.Name = c.CString("config")
-	returnList.Value = c.CString(perClientContext.clientConfig)
+	if err := returnList.Add("config", perClientContext.clientConfig); err != nil {
+		p.logger.ErrorContext(
+			p.ctx, "add return list item",
+			slog.Any("err", err),
+		)
+
+		return c.OpenVPNPluginFuncError
+	}
 
 	*ret.ReturnList = returnList
 


### PR DESCRIPTION
## Summary

- add a concrete Add(name, value string) method for OpenVPNPluginStringList
- append C-allocated nodes while preserving OpenVPN ownership semantics
- use the helper for client-connect configuration return values
- cover insertion ordering and nil receiver handling

## Testing

- make fmt
- make lint
- make test
- git diff --check