### PR TITLE
fix: avoid panic on refresh without ID token

### DIFF
--- a/internal/oauth2/refresh.go
+++ b/internal/oauth2/refresh.go
@@ -260,6 +260,10 @@ func (c *Client) refreshedUserInfo(ctx context.Context, tokens *idtoken.IDToken)
 		return nil, nil //nolint:nilnil // UserInfo is optional and absent when disabled.
 	}
 
+	if tokens.IDTokenClaims == nil {
+		return nil, fmt.Errorf("user info subject unavailable: %w", rp.ErrMissingIDToken)
+	}
+
 	userInfo, err := rp.Userinfo[*types.UserInfo](ctx, tokens.AccessToken, tokens.TokenType, tokens.IDTokenClaims.GetSubject(), c.relyingParty)
 	if err != nil {
 		return nil,

--- a/internal/oauth2/refresh_internal_test.go
+++ b/internal/oauth2/refresh_internal_test.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/openvpn/connection"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/tokenstorage"
 	"github.com/stretchr/testify/require"
+	"github.com/zitadel/oidc/v3/pkg/client/rp"
 )
 
 func TestRefreshClientAuthInternalTokenRestoresClientConfigNames(t *testing.T) {
@@ -113,6 +115,19 @@ func TestRefreshClientAuthInternalTokenWithoutUsernameFallsBackToInteractiveAuth
 	require.Equal(t, types.UserInfo{}, user)
 	require.Nil(t, tokens)
 	require.Nil(t, clientConfigNames)
+}
+
+func TestRefreshedUserInfoMissingIDTokenClaimsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Defaults
+	conf.OAuth2.UserInfo = true
+
+	client := Client{conf: &conf}
+	userInfo, err := client.refreshedUserInfo(t.Context(), &idtoken.IDToken{})
+
+	require.ErrorIs(t, err, rp.ErrMissingIDToken)
+	require.Nil(t, userInfo)
 }
 
 func TestProviderRefreshTokenStoresClientConfigNames(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it

The OIDC refresh helper accepts a successful token response without a new ID token. Such a response has no ID token claims. When UserInfo was enabled, the refresh path called GetSubject on those missing claims and panicked.

Check for missing claims before requesting UserInfo and return a wrapped rp.ErrMissingIDToken instead. Silent reauthentication then fails normally and the client proceeds to interactive authentication.

A focused unit test covers the missing-claims case at the crash boundary.

#### Which issue this PR fixes

Not applicable.

#### Special notes for your reviewer

The wrapped rp.ErrMissingIDToken remains detectable with errors.Is.

Testing:

- make fmt
- make lint
- make test
- make textlint
- GOEXPERIMENT=cgocheck2 go test ./internal/oauth2 -run TestRefreshedUserInfoMissingIDTokenClaimsReturnsError -count=1

#### Particularly user-facing changes

A refresh response without a new ID token no longer crashes openvpn-auth-oauth2. The affected client falls back to interactive authentication.

#### Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary of the significant user-facing change