### PR TITLE
fix: prevent sensitive OAuth2 data logging

### DIFF
--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -313,7 +313,7 @@ func (c *Client) postCodeExchangeHandler(
 	) {
 		ctx := r.Context()
 
-		logger = withIDTokenClaimsLogger(ctx, logger, tokens)
+		logger = withIDTokenClaimsLogger(logger, tokens)
 
 		user, err := c.fetchUser(ctx, logger, session, tokens, userInfo)
 		if err != nil {
@@ -353,20 +353,16 @@ func (c *Client) postCodeExchangeHandler(
 }
 
 // withIDTokenClaimsLogger enriches the logger with ID token claim fields when claims are available.
-func withIDTokenClaimsLogger(ctx context.Context, logger *slog.Logger, tokens *idtoken.IDToken) *slog.Logger {
+func withIDTokenClaimsLogger(logger *slog.Logger, tokens *idtoken.IDToken) *slog.Logger {
 	if tokens.IDTokenClaims == nil {
 		return logger
 	}
 
-	logger = loggerWithAttrs(logger,
+	return loggerWithAttrs(logger,
 		slog.String("idtoken_subject", tokens.IDTokenClaims.Subject),
 		slog.String("idtoken_email", tokens.IDTokenClaims.EMail),
 		slog.String("idtoken_preferred_username", tokens.IDTokenClaims.PreferredUsername),
 	)
-
-	logger.LogAttrs(ctx, slog.LevelDebug, "claims", slog.Any("claims", tokens.IDTokenClaims.Claims))
-
-	return logger
 }
 
 // withUserLogger enriches the logger with resolved user fields.

--- a/internal/oauth2/handler_bench_test.go
+++ b/internal/oauth2/handler_bench_test.go
@@ -73,14 +73,13 @@ func BenchmarkWithIDTokenClaimsLogger(b *testing.B) {
 	}
 	claims.Subject = "subject"
 	tokens := &idtoken.IDToken{IDTokenClaims: claims}
-	ctx := b.Context()
 
 	var loggerWithClaims *slog.Logger
 
 	b.ReportAllocs()
 
 	for b.Loop() {
-		loggerWithClaims = withIDTokenClaimsLogger(ctx, logger, tokens)
+		loggerWithClaims = withIDTokenClaimsLogger(logger, tokens)
 	}
 
 	_ = loggerWithClaims

--- a/internal/oauth2/handler_internal_test.go
+++ b/internal/oauth2/handler_internal_test.go
@@ -1,0 +1,27 @@
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testlogger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithIDTokenClaimsLoggerOmitsUnrestrictedClaims(t *testing.T) {
+	t.Parallel()
+
+	logger := testlogger.New()
+	tokens := &idtoken.IDToken{
+		IDTokenClaims: &idtoken.Claims{
+			Claims: map[string]any{"custom_sensitive_claim": "secret-custom-claim"},
+		},
+	}
+	tokens.IDTokenClaims.Subject = "subject"
+
+	withIDTokenClaimsLogger(logger.Logger(), tokens).Info("test message")
+
+	require.Contains(t, logger.String(), "idtoken_subject=subject")
+	require.NotContains(t, logger.String(), "custom_sensitive_claim")
+	require.NotContains(t, logger.String(), "secret-custom-claim")
+}

--- a/internal/oauth2/providers/generic/user.go
+++ b/internal/oauth2/providers/generic/user.go
@@ -19,7 +19,7 @@ func (p Provider) GetUser(ctx context.Context, logger *slog.Logger, tokens *idto
 
 	if tokens.IDTokenClaims == nil {
 		if userinfo == nil {
-			logMissingIDToken(ctx, logger, tokens)
+			logMissingIDToken(ctx, logger, tokens.IDToken != "")
 		}
 
 		return user, nil
@@ -89,24 +89,15 @@ func (p Provider) fillUserGroupsAndRoles(
 	return nil
 }
 
-func logMissingIDToken(ctx context.Context, logger *slog.Logger, tokens *idtoken.IDToken) {
-	if tokens.IDToken == "" {
-		// if tokens.Token.Extra("id_token") != nil {
-		// 	logger.Warn("The provider has returned an 'id_token', however, it was configured as an OAUTH2 provider. " +
-		// 		"As a result, user data validation cannot be performed. If you have defined endpoints in the configuration, please remove them and retry.")
-		// 	logger.Debug("id_token", "id_token", tokens.Token.Extra("id_token"))
-		// } else {
-		logger.LogAttrs(ctx, slog.LevelWarn, "provider did not return a id_token. validation of user data is not possible.")
+func logMissingIDToken(ctx context.Context, logger *slog.Logger, idTokenReturned bool) {
+	if !idTokenReturned {
+		logger.LogAttrs(ctx, slog.LevelWarn, "provider did not return an ID token. validation of user data is not possible.")
 
 		return
 	}
 
-	logger.LogAttrs(ctx, slog.LevelWarn, "provider did return a id_token, but it was not parsed correctly. Validation of user data is not possible."+
-		" Enable DEBUG logs to see the raw token and report this to maintainer.")
-	logger.LogAttrs(
-		ctx, slog.LevelDebug, "id_token",
-		slog.String("id_token", tokens.IDToken),
-	)
+	logger.LogAttrs(ctx, slog.LevelWarn,
+		"provider returned an ID token, but it was not parsed correctly. Validation of user data is not possible.")
 }
 
 // extractStringSliceClaim reads a string-list claim from the ID token.

--- a/internal/oauth2/providers/generic/user_test.go
+++ b/internal/oauth2/providers/generic/user_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/providers/generic"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testlogger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -151,6 +152,23 @@ func TestGetUser(t *testing.T) {
 			require.Equal(t, tc.expected, userData)
 		})
 	}
+}
+
+func TestGetUserDoesNotLogRawIDToken(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Defaults
+	provider, err := generic.NewProvider(t.Context(), &conf, http.DefaultClient)
+	require.NoError(t, err)
+
+	logger := testlogger.New()
+
+	const rawIDToken = "secret-raw-id-token"
+
+	_, err = provider.GetUser(t.Context(), logger.Logger(), &idtoken.IDToken{IDToken: rawIDToken}, nil)
+	require.NoError(t, err)
+	require.Contains(t, logger.String(), "provider returned an ID token, but it was not parsed correctly")
+	require.NotContains(t, logger.String(), rawIDToken)
 }
 
 func tokenWithClaims(rawClaims map[string]any, claims idtoken.Claims) *idtoken.IDToken {


### PR DESCRIPTION
## Summary
- stop logging raw ID tokens after claim parsing failures
- stop logging unrestricted ID token claim maps
- add regression tests that keep sensitive values out of debug logs

## Testing
- make fmt
- make lint
- make test