### PR TITLE
fix: honor context cancellation for management commands

### DIFF
--- a/internal/openvpn/handler.go
+++ b/internal/openvpn/handler.go
@@ -85,6 +85,7 @@ func (c *Client) sendPassword(ctx context.Context) error {
 
 // handleMessages handles all incoming messages and route messages to different channels.
 func (c *Client) handleMessages(ctx context.Context, errCh chan<- error) {
+	// This handler is the sole producer and owns closing both channels.
 	defer close(c.commandResponseCh)
 	defer close(c.clientsCh)
 
@@ -111,6 +112,18 @@ func (c *Client) handleMessages(ctx context.Context, errCh chan<- error) {
 		}
 
 		if err = c.handleMessage(ctx, buf.String()); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
+				errCh <- nil
+
+				return
+			}
+
+			if c.closed.Load() == 1 && errors.Is(err, ErrConnectionTerminated) {
+				errCh <- nil
+
+				return
+			}
+
 			errCh <- err
 
 			return
@@ -126,14 +139,26 @@ func (c *Client) handleMessage(ctx context.Context, message string) error {
 		case strings.HasPrefix(message, ">CLIEN"):
 			return c.handleClientMessage(ctx, message)
 		case strings.HasPrefix(message, ">HOLD:"):
-			c.commandsCh <- "hold release"
+			select {
+			case c.commandsCh <- "hold release":
+			case <-ctx.Done():
+				return fmt.Errorf("enqueue hold release: %w", ctx.Err())
+			case <-c.shutdownCh:
+				return ErrConnectionTerminated
+			}
 		case strings.HasPrefix(message, ">INFO:"):
 			// welcome message
 			if strings.HasPrefix(message, ">INFO:OpenVPN Management Interface Version") {
 				return nil
 			}
 
-			c.commandResponseCh <- message
+			select {
+			case c.commandResponseCh <- message:
+			case <-ctx.Done():
+				return fmt.Errorf("dispatch info response: %w", ctx.Err())
+			case <-c.shutdownCh:
+				return ErrConnectionTerminated
+			}
 		default:
 			c.writeToPassThroughClient(message)
 		}
@@ -144,6 +169,10 @@ func (c *Client) handleMessage(ctx context.Context, message string) error {
 	default:
 		select {
 		case c.commandResponseCh <- message:
+		case <-ctx.Done():
+			return fmt.Errorf("dispatch command response: %w", ctx.Err())
+		case <-c.shutdownCh:
+			return ErrConnectionTerminated
 		case <-time.After(2 * time.Second):
 			c.logger.LogAttrs(ctx, slog.LevelWarn, "command response not accepted. Was there a timeout before? Dropping message", slog.String("message", message))
 		}
@@ -162,7 +191,13 @@ func (c *Client) handleClientMessage(ctx context.Context, message string) error 
 		return fmt.Errorf("error parsing client message: %w", err)
 	}
 
-	c.clientsCh <- client
+	select {
+	case c.clientsCh <- client:
+	case <-ctx.Done():
+		return fmt.Errorf("enqueue client event: %w", ctx.Err())
+	case <-c.shutdownCh:
+		return ErrConnectionTerminated
+	}
 
 	return nil
 }
@@ -248,12 +283,18 @@ func (c *Client) handleCommands(ctx context.Context, errCh chan<- error) {
 		select {
 		case <-ctx.Done():
 			return // Error somewhere, terminate
+		case <-c.shutdownCh:
+			return
 		case command, ok = <-c.commandsCh:
 			if !ok {
 				return
 			}
 
 			if err := c.rawCommand(ctx, command, managementCommandName(command)); err != nil {
+				if c.closed.Load() == 1 {
+					return
+				}
+
 				errCh <- err
 
 				return

--- a/internal/openvpn/main.go
+++ b/internal/openvpn/main.go
@@ -33,19 +33,23 @@ func New(logger *slog.Logger, conf *config.Config) *Client {
 		conf:   conf,
 		logger: logger,
 
-		connMu:    sync.Mutex{},
-		commandMu: sync.Mutex{},
+		connMu: sync.Mutex{},
 
 		commandsBuffer: bytes.Buffer{},
 
 		clientsCh:         make(chan connection.Client, 10),
+		commandLock:       make(chan struct{}, 1),
 		commandResponseCh: make(chan string),
 		commandTimer:      time.NewTimer(conf.OpenVPN.CommandTimeout),
 		commandsCh:        make(chan string, 10),
 		passThroughCh:     make(chan string, 10),
+		shutdownCh:        make(chan struct{}),
 	}
 
 	client.commandsBuffer.Grow(512)
+
+	client.commandLock <- struct{}{}
+
 	client.commandTimer.Stop()
 
 	return client
@@ -211,12 +215,13 @@ func (c *Client) checkClientSsoCapabilities(client connection.Client) bool {
 
 // Shutdown closes the management connection and stops command processing.
 func (c *Client) Shutdown(ctx context.Context) {
-	c.commandMu.Lock()
-	defer c.commandMu.Unlock()
-
 	if !c.closed.CompareAndSwap(0, 1) {
 		return
 	}
+
+	// commandsCh has multiple producers and is intentionally left open;
+	// shutdownCh owns lifecycle signaling.
+	close(c.shutdownCh)
 
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "shutdown OpenVPN management connection")
 
@@ -226,51 +231,142 @@ func (c *Client) Shutdown(ctx context.Context) {
 	if c.conn != nil {
 		_ = c.conn.Close()
 	}
-
-	close(c.commandsCh)
 }
 
 // SendCommand sends a command to the management interface and waits for its
 // response. When passthrough is true the raw response is returned without any
 // validation. A rejected command returns the raw response together with a
 // [ManagementCommandError].
-func (c *Client) SendCommand(_ context.Context, cmd string, passthrough bool) (string, error) {
-	c.commandMu.Lock()
-	defer c.commandMu.Unlock()
-
+func (c *Client) SendCommand(ctx context.Context, cmd string, passthrough bool) (string, error) {
 	if cmd == "\x00" || c.closed.Load() == 1 {
 		return "", nil
 	}
 
-	c.commandsCh <- cmd
-	// commandMu serializes resets and receives on the reusable timer.
-	c.commandTimer.Reset(c.conf.OpenVPN.CommandTimeout)
-	defer c.commandTimer.Stop()
+	commandName := managementCommandForError(cmd, passthrough)
 
+	if err := c.waitForCommandLock(ctx); err != nil {
+		return "", fmt.Errorf("command error '%s': %w", commandName, err)
+	}
+
+	releaseCommandLock := true
+	defer func() {
+		if releaseCommandLock {
+			c.commandLock <- struct{}{}
+		}
+	}()
+
+	if c.closed.Load() == 1 {
+		return "", ErrConnectionTerminated
+	}
+
+	if err := c.enqueueCommand(ctx, cmd); err != nil {
+		return "", fmt.Errorf("command error '%s': %w", commandName, err)
+	}
+
+	// commandLock serializes resets and receives on the reusable timer.
+	c.commandTimer.Reset(c.conf.OpenVPN.CommandTimeout)
+
+	stopCommandTimer := true
+	defer func() {
+		if stopCommandTimer {
+			c.commandTimer.Stop()
+		}
+	}()
+
+	resp, canceled, err := c.waitForCommandResponse(ctx, commandName, passthrough)
+	if canceled {
+		releaseCommandLock = false
+		stopCommandTimer = false
+
+		go c.discardCommandResponse()
+	}
+
+	return resp, err
+}
+
+func (c *Client) waitForCommandLock(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("wait for command lock: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("wait for command lock: %w", ctx.Err())
+	case <-c.shutdownCh:
+		return ErrConnectionTerminated
+	case <-c.commandLock:
+		return nil
+	}
+}
+
+func (c *Client) enqueueCommand(ctx context.Context, cmd string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("enqueue command: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("enqueue command: %w", ctx.Err())
+	case <-c.shutdownCh:
+		return ErrConnectionTerminated
+	case c.commandsCh <- cmd:
+		return nil
+	}
+}
+
+func (c *Client) waitForCommandResponse(
+	ctx context.Context, commandName string, passthrough bool,
+) (string, bool, error) {
 	select {
 	case resp, ok := <-c.commandResponseCh:
 		if !ok {
-			return "", ErrConnectionTerminated
+			return "", false, ErrConnectionTerminated
 		}
 
-		if passthrough {
-			return resp, nil
-		}
+		response, err := validateCommandResponse(commandName, resp, passthrough)
 
-		if resp == "" {
-			return "", fmt.Errorf("command error '%s': %w", managementCommandForError(cmd, passthrough), ErrEmptyResponse)
-		}
-
-		if strings.HasPrefix(resp, "ERROR:") {
-			return resp, &ManagementCommandError{
-				Command:  managementCommandForError(cmd, passthrough),
-				Response: strings.TrimSpace(resp),
-			}
-		}
-
-		return resp, nil
+		return response, false, err
+	case <-ctx.Done():
+		return "", true, fmt.Errorf("command error '%s': %w", commandName, ctx.Err())
+	case <-c.shutdownCh:
+		return "", false, ErrConnectionTerminated
 	case <-c.commandTimer.C:
-		return "", fmt.Errorf("command error '%s': %w", managementCommandForError(cmd, passthrough), ErrTimeout)
+		return "", false, fmt.Errorf("command error '%s': %w", commandName, ErrTimeout)
+	}
+}
+
+func validateCommandResponse(commandName, resp string, passthrough bool) (string, error) {
+	if passthrough {
+		return resp, nil
+	}
+
+	if resp == "" {
+		return "", fmt.Errorf("command error '%s': %w", commandName, ErrEmptyResponse)
+	}
+
+	if strings.HasPrefix(resp, "ERROR:") {
+		return resp, &ManagementCommandError{
+			Command:  commandName,
+			Response: strings.TrimSpace(resp),
+		}
+	}
+
+	return resp, nil
+}
+
+// discardCommandResponse preserves command-response ordering after the caller
+// stops waiting for a command that was already sent.
+func (c *Client) discardCommandResponse() {
+	defer func() {
+		c.commandTimer.Stop()
+
+		c.commandLock <- struct{}{}
+	}()
+
+	select {
+	case <-c.commandResponseCh:
+	case <-c.shutdownCh:
+	case <-c.commandTimer.C:
 	}
 }
 

--- a/internal/openvpn/main_bench_test.go
+++ b/internal/openvpn/main_bench_test.go
@@ -32,8 +32,17 @@ func BenchmarkSendCommand(b *testing.B) {
 	go func() {
 		defer close(doneCh)
 
-		for range client.commandsCh {
-			client.commandResponseCh <- "SUCCESS: command succeeded"
+		for {
+			select {
+			case <-client.shutdownCh:
+				return
+			case <-client.commandsCh:
+				select {
+				case client.commandResponseCh <- "SUCCESS: command succeeded":
+				case <-client.shutdownCh:
+					return
+				}
+			}
 		}
 	}()
 

--- a/internal/openvpn/main_internal_test.go
+++ b/internal/openvpn/main_internal_test.go
@@ -1,6 +1,15 @@
 package openvpn
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
+)
 
 func TestManagementCommandName(t *testing.T) {
 	t.Parallel()
@@ -25,5 +34,188 @@ func TestManagementCommandName(t *testing.T) {
 				t.Errorf("managementCommandName(%q) = %q, want %q", tc.command, name, tc.expect)
 			}
 		})
+	}
+}
+
+func TestSendCommandHonorsContextWhileWaitingForCommandLock(t *testing.T) {
+	t.Parallel()
+
+	client := newCommandTestClient()
+	firstCtx, cancelFirst := context.WithCancel(t.Context())
+	firstErrCh := make(chan error, 1)
+
+	go func() {
+		_, err := client.SendCommand(firstCtx, "first", false)
+		firstErrCh <- err
+	}()
+
+	requireCommand(t, client, "first")
+
+	secondCtx, cancelSecond := context.WithCancel(t.Context())
+	secondErrCh := make(chan error, 1)
+
+	go func() {
+		_, err := client.SendCommand(secondCtx, "second", false)
+		secondErrCh <- err
+	}()
+
+	cancelSecond()
+	requireErrorIs(t, secondErrCh, context.Canceled)
+
+	cancelFirst()
+	requireErrorIs(t, firstErrCh, context.Canceled)
+	client.Shutdown(t.Context())
+}
+
+func TestSendCommandHonorsContextWhileEnqueueing(t *testing.T) {
+	t.Parallel()
+
+	client := newCommandTestClient()
+	for range cap(client.commandsCh) {
+		client.commandsCh <- "queued"
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := client.SendCommand(ctx, "blocked", false)
+		errCh <- err
+	}()
+
+	requireCommandLockHeld(t, client)
+	cancel()
+	requireErrorIs(t, errCh, context.Canceled)
+	client.Shutdown(t.Context())
+}
+
+func TestSendCommandHonorsContextWhileWaitingForResponse(t *testing.T) {
+	t.Parallel()
+
+	client := newCommandTestClient()
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := client.SendCommand(ctx, "waiting", false)
+		errCh <- err
+	}()
+
+	requireCommand(t, client, "waiting")
+	cancel()
+	requireErrorIs(t, errCh, context.Canceled)
+	client.Shutdown(t.Context())
+}
+
+func TestSendCommandDrainsCanceledCommandResponse(t *testing.T) {
+	t.Parallel()
+
+	client := newCommandTestClient()
+	firstCtx, cancelFirst := context.WithCancel(t.Context())
+	firstErrCh := make(chan error, 1)
+
+	go func() {
+		_, err := client.SendCommand(firstCtx, "first", false)
+		firstErrCh <- err
+	}()
+
+	requireCommand(t, client, "first")
+	cancelFirst()
+	requireErrorIs(t, firstErrCh, context.Canceled)
+
+	secondResultCh := make(chan error, 1)
+
+	go func() {
+		_, err := client.SendCommand(t.Context(), "second", false)
+		secondResultCh <- err
+	}()
+
+	select {
+	case command := <-client.commandsCh:
+		t.Fatalf("received command %q before draining the canceled command response", command)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	client.commandResponseCh <- "SUCCESS: first command succeeded"
+
+	requireCommand(t, client, "second")
+
+	client.commandResponseCh <- "SUCCESS: second command succeeded"
+
+	requireErrorIs(t, secondResultCh, nil)
+	client.Shutdown(t.Context())
+}
+
+func TestShutdownUnblocksSendCommand(t *testing.T) {
+	t.Parallel()
+
+	client := newCommandTestClient()
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := client.SendCommand(context.Background(), "waiting", false)
+		errCh <- err
+	}()
+
+	requireCommand(t, client, "waiting")
+	client.Shutdown(t.Context())
+	requireErrorIs(t, errCh, ErrConnectionTerminated)
+}
+
+func newCommandTestClient() *Client {
+	conf := config.Defaults
+	conf.OpenVPN.CommandTimeout = time.Hour
+
+	return New(slog.New(slog.NewTextHandler(io.Discard, nil)), &conf) //nolint:sloglint
+}
+
+func requireCommand(t *testing.T, client *Client, expected string) {
+	t.Helper()
+
+	select {
+	case actual := <-client.commandsCh:
+		if actual != expected {
+			t.Fatalf("received command %q, want %q", actual, expected)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for command %q", expected)
+	}
+}
+
+func requireCommandLockHeld(t *testing.T, client *Client) {
+	t.Helper()
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline.C:
+			t.Fatal("timeout waiting for command lock")
+		case <-ticker.C:
+			if len(client.commandLock) == 0 {
+				return
+			}
+		}
+	}
+}
+
+func requireErrorIs(t *testing.T, errCh <-chan error, target error) {
+	t.Helper()
+
+	select {
+	case err := <-errCh:
+		if target == nil && err != nil {
+			t.Fatalf("received unexpected error %v", err)
+		}
+
+		if target != nil && !errors.Is(err, target) {
+			t.Fatalf("received error %v, want %v", err, target)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for error %v", target)
 	}
 }

--- a/internal/openvpn/types.go
+++ b/internal/openvpn/types.go
@@ -26,6 +26,7 @@ type Client struct {
 	oauth2               oauth2Client
 	conn                 net.Conn
 	commandResponseCh    chan string
+	commandLock          chan struct{}
 	commandTimer         *time.Timer
 	commandsCh           chan string
 	logger               *slog.Logger
@@ -33,10 +34,10 @@ type Client struct {
 	ctxCancel            context.CancelFunc
 	clientsCh            chan connection.Client
 	passThroughCh        chan string
+	shutdownCh           chan struct{}
 	conf                 *config.Config
 	commandsBuffer       bytes.Buffer
 	acceptMu             sync.Mutex
-	commandMu            sync.Mutex
 	connMu               sync.Mutex
 	closed               atomic.Uint32
 	passThroughConnected atomic.Uint32


### PR DESCRIPTION
## Summary
- honor context cancellation while waiting to serialize, enqueue, or receive a management command
- unblock in-flight commands during shutdown without closing the multi-producer command channel
- drain late responses from canceled commands so later commands cannot consume the wrong response
- make management event dispatch cancellation-aware and add race-focused regression tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- repeated cancellation tests under `GOEXPERIMENT=cgocheck2` and the race detector