### PR TITLE
fix: fail closed on client configuration I/O errors

### DIFF
--- a/internal/openvpn/callbacks.go
+++ b/internal/openvpn/callbacks.go
@@ -163,22 +163,18 @@ func (c *Client) readSingleClientConfig(ctx context.Context, logger *slog.Logger
 }
 
 func (c *Client) handleClientConfigReadError(ctx context.Context, logger *slog.Logger, clientConfigName string, err error) (bool, error) {
-	if !errors.Is(err, fs.ErrNotExist) {
-		c.logClientConfigRead(ctx, logger, clientConfigName, nil, err)
+	if errors.Is(err, fs.ErrNotExist) {
+		logger.LogAttrs(
+			ctx, slog.LevelDebug, "client config file not found",
+			slog.String("config", clientConfigName),
+		)
 
-		return true, nil
+		if c.conf.OpenVPN.ClientConfig.IgnoreNotFound {
+			return true, nil
+		}
 	}
 
-	logger.LogAttrs(
-		ctx, slog.LevelDebug, "client config file not found",
-		slog.String("config", clientConfigName),
-	)
-
-	if !c.conf.OpenVPN.ClientConfig.IgnoreNotFound {
-		return false, err
-	}
-
-	return true, nil
+	return false, fmt.Errorf("read client config %q: %w", clientConfigName, err)
 }
 
 func (c *Client) logClientConfigRead(ctx context.Context, logger *slog.Logger, clientConfigName string, clientConfig []string, err error) {

--- a/internal/openvpn/client_config_merge_test.go
+++ b/internal/openvpn/client_config_merge_test.go
@@ -154,8 +154,116 @@ func TestLoadClientConfigMissingStrict(t *testing.T) {
 	require.Nil(t, clientConfig)
 }
 
-type failOpenFS struct{}
+func TestLoadClientConfigFailsClosedOnIOError(t *testing.T) {
+	t.Parallel()
 
-func (failOpenFS) Open(string) (fs.File, error) {
+	errOpen := errors.New("open failure")
+	errRead := errors.New("read failure")
+
+	strategies := []struct {
+		name     string
+		strategy config.OpenVPNConfigStrategy
+	}{
+		{
+			name:     "merge",
+			strategy: config.OpenVPNConfigStrategyMerge,
+		},
+		{
+			name:     "user selector",
+			strategy: config.OpenVPNConfigStrategyUserSelector,
+		},
+	}
+
+	failures := []struct {
+		name    string
+		fs      fs.FS
+		wantErr error
+	}{
+		{
+			name:    "permission denied",
+			fs:      failOpenFS{err: &fs.PathError{Op: "open", Path: "alice.conf", Err: fs.ErrPermission}},
+			wantErr: fs.ErrPermission,
+		},
+		{
+			name:    "open failure",
+			fs:      failOpenFS{err: errOpen},
+			wantErr: errOpen,
+		},
+		{
+			name: "read failure",
+			fs: readErrorFS{
+				FS: fstest.MapFS{
+					"alice.conf": {Data: []byte("client config")},
+				},
+				err: errRead,
+			},
+			wantErr: errRead,
+		},
+	}
+
+	for _, strategy := range strategies {
+		t.Run(strategy.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, failure := range failures {
+				t.Run(failure.name, func(t *testing.T) {
+					t.Parallel()
+
+					conf := config.Defaults
+					conf.OpenVPN.ClientConfig.Enabled = true
+					conf.OpenVPN.ClientConfig.Strategy = strategy.strategy
+					conf.OpenVPN.ClientConfig.Path = types.FS{FS: failure.fs}
+
+					client := Client{conf: &conf}
+					clientConfig, err := client.loadClientConfig(
+						t.Context(),
+						slog.New(slog.DiscardHandler),
+						state.ClientIdentifier{},
+						[]string{"alice"},
+						"alice",
+					)
+
+					require.ErrorIs(t, err, failure.wantErr)
+					require.Nil(t, clientConfig)
+				})
+			}
+		})
+	}
+}
+
+type failOpenFS struct {
+	err error
+}
+
+func (f failOpenFS) Open(string) (fs.File, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
 	return nil, errors.New("unexpected client config read")
+}
+
+type readErrorFS struct {
+	fs.FS
+
+	err error
+}
+
+func (f readErrorFS) Open(name string) (fs.File, error) {
+	file, err := f.FS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return readErrorFile{File: file, err: f.err}, nil
+}
+
+type readErrorFile struct {
+	fs.File
+
+	err error
+}
+
+func (f readErrorFile) Read([]byte) (int, error) {
+	return 0, f.err
 }


### PR DESCRIPTION
## Summary

- propagate client-configuration permission, open, and read errors instead of skipping the affected profile
- continue ignoring missing profiles only when ignore-not-found permits it
- cover both merge and user-selector strategies with regression tests

## Testing

- make fmt (final formatter lint: 0 issues; perfsprint and tagalign emitted ignored cgo analysis errors)
- make lint
- make test
- git diff --check