### PR TITLE
fix: bound OAuth provider response bodies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ lint: golangci  ## Run linter
 
 .PHONY: textlint
 textlint:  ## Run textlint
-	npx textlint --rule terminology .
+	npx --yes --package textlint --package textlint-rule-terminology textlint --rule terminology .
 
 .PHONY: fmt  ## Format code
 fmt:

--- a/internal/oauth2/providers/github/api.go
+++ b/internal/oauth2/providers/github/api.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+const (
+	// Successful API responses are limited to 1 MiB.
+	maxResponseBodySize = 1 << 20
+	// Error responses are retained only as a 4 KiB diagnostic excerpt.
+	maxErrorResponseBodySize = 4 << 10
+)
+
 // get performs an authenticated GitHub API request and decodes the JSON response.
 func get[T any](ctx context.Context, httpClient *http.Client, accessToken, apiURL string, data *T) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
@@ -26,13 +33,33 @@ func get[T any](ctx context.Context, httpClient *http.Client, accessToken, apiUR
 
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	bodyLimit := maxResponseBodySize
+	if resp.StatusCode != http.StatusOK {
+		bodyLimit = maxErrorResponseBodySize
+	}
+
+	respBody, truncated, err := readResponseBody(resp.Body, bodyLimit)
 	if err != nil {
 		return "", fmt.Errorf("unable to read body from GitHub API %s: http status code: %d; error: %w", apiURL, resp.StatusCode, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error from GitHub API %s: http status code: %d; message: %s", apiURL, resp.StatusCode, respBody)
+		truncationMarker := ""
+		if truncated {
+			truncationMarker = " [truncated]"
+		}
+
+		return "", fmt.Errorf(
+			"error from GitHub API %s: http status code: %d; message: %s%s",
+			apiURL,
+			resp.StatusCode,
+			respBody,
+			truncationMarker,
+		)
+	}
+
+	if truncated {
+		return "", fmt.Errorf("response body from GitHub API %s exceeds the %d byte limit", apiURL, maxResponseBodySize)
 	}
 
 	if err = json.Unmarshal(respBody, data); err != nil {
@@ -40,6 +67,19 @@ func get[T any](ctx context.Context, httpClient *http.Client, accessToken, apiUR
 	}
 
 	return getPagination(apiURL, resp), nil
+}
+
+func readResponseBody(body io.Reader, limit int) ([]byte, bool, error) {
+	responseBody, err := io.ReadAll(io.LimitReader(body, int64(limit+1)))
+	if err != nil {
+		return nil, false, fmt.Errorf("read limited response body: %w", err)
+	}
+
+	if len(responseBody) <= limit {
+		return responseBody, false, nil
+	}
+
+	return responseBody[:limit], true, nil
 }
 
 // getPagination returns the next GitHub pagination URL when more pages are available.

--- a/internal/oauth2/providers/github/api_test.go
+++ b/internal/oauth2/providers/github/api_test.go
@@ -2,10 +2,82 @@ package github //nolint:testpackage
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+type apiRoundTripper func(*http.Request) (*http.Response, error)
+
+func (fn apiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestGetResponseBodyLimits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		statusCode      int
+		body            string
+		wantErrContains string
+		wantErrExcludes string
+	}{
+		{
+			name:       "successful response at limit",
+			statusCode: http.StatusOK,
+			body:       "[]" + strings.Repeat(" ", maxResponseBodySize-2),
+		},
+		{
+			name:            "successful response exceeds limit",
+			statusCode:      http.StatusOK,
+			body:            strings.Repeat(" ", maxResponseBodySize+1),
+			wantErrContains: "response body from GitHub API https://api.github.com/test exceeds the 1048576 byte limit",
+		},
+		{
+			name:            "error response is truncated",
+			statusCode:      http.StatusInternalServerError,
+			body:            "visible" + strings.Repeat("x", maxErrorResponseBodySize) + "hidden",
+			wantErrContains: "visible",
+			wantErrExcludes: "hidden",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			httpClient := &http.Client{
+				Transport: apiRoundTripper(func(_ *http.Request) (*http.Response, error) {
+					response := httptest.NewRecorder()
+					response.WriteHeader(testCase.statusCode)
+					_, _ = response.WriteString(testCase.body)
+
+					return response.Result(), nil
+				}),
+			}
+
+			var data any
+
+			_, err := get[any](t.Context(), httpClient, "token", "https://api.github.com/test", &data)
+
+			if testCase.wantErrContains == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(t, err, testCase.wantErrContains)
+
+			if testCase.wantErrExcludes != "" {
+				require.NotContains(t, err.Error(), testCase.wantErrExcludes)
+				require.ErrorContains(t, err, "[truncated]")
+			}
+		})
+	}
+}
 
 func TestGetPagination(t *testing.T) {
 	t.Parallel()

--- a/internal/oauth2/providers/google/api.go
+++ b/internal/oauth2/providers/google/api.go
@@ -14,6 +14,13 @@ import (
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 )
 
+const (
+	// Successful API responses are limited to 1 MiB.
+	maxResponseBodySize = 1 << 20
+	// Error responses are retained only as a 4 KiB diagnostic excerpt.
+	maxErrorResponseBodySize = 4 << 10
+)
+
 //nolint:tagliatelle // The API response is a JSON object with a dynamic structure.
 type groupMembershipPage struct {
 	NextPageToken string `json:"nextPageToken"`
@@ -113,29 +120,22 @@ func get[T any](ctx context.Context, httpClient *http.Client, accessToken string
 
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	bodyLimit := maxResponseBodySize
+	if resp.StatusCode != http.StatusOK {
+		bodyLimit = maxErrorResponseBodySize
+	}
+
+	respBody, truncated, err := readResponseBody(resp.Body, bodyLimit)
 	if err != nil {
 		return fmt.Errorf("unable to read body from Google API %s: http status code: %d; error: %w", apiURL, resp.StatusCode, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		var apiErr apiError
+		return handleErrorResponse(apiURL, resp.StatusCode, respBody, truncated, data)
+	}
 
-		if bytes.HasPrefix(respBody, []byte("{")) {
-			_ = json.Unmarshal(respBody, &apiErr)
-		}
-
-		if strings.HasPrefix(apiErr.Error.Message, "Error(4001):") {
-			// This error indicates that the current user does not have the required permissions to access the group.
-			// Clear the data by setting it to zero value
-			var zero T
-
-			*data = zero
-
-			return nil
-		}
-
-		return fmt.Errorf("error from Google API %s: http status code: %d; message: %s", apiURL, resp.StatusCode, apiErr.Error.Message)
+	if truncated {
+		return fmt.Errorf("response body from Google API %s exceeds the %d byte limit", apiURL, maxResponseBodySize)
 	}
 
 	if err = json.Unmarshal(respBody, data); err != nil {
@@ -143,4 +143,46 @@ func get[T any](ctx context.Context, httpClient *http.Client, accessToken string
 	}
 
 	return nil
+}
+
+func handleErrorResponse[T any](apiURL *url.URL, statusCode int, responseBody []byte, truncated bool, data *T) error {
+	var apiErr apiError
+
+	if bytes.HasPrefix(responseBody, []byte("{")) {
+		_ = json.Unmarshal(responseBody, &apiErr)
+	}
+
+	if strings.HasPrefix(apiErr.Error.Message, "Error(4001):") {
+		// This error indicates that the current user does not have the required permissions to access the group.
+		// Clear the data by setting it to zero value
+		var zero T
+
+		*data = zero
+
+		return nil
+	}
+
+	message := apiErr.Error.Message
+	if message == "" {
+		message = string(responseBody)
+	}
+
+	if truncated {
+		message += " [truncated]"
+	}
+
+	return fmt.Errorf("error from Google API %s: http status code: %d; message: %s", apiURL, statusCode, message)
+}
+
+func readResponseBody(body io.Reader, limit int) ([]byte, bool, error) {
+	responseBody, err := io.ReadAll(io.LimitReader(body, int64(limit+1)))
+	if err != nil {
+		return nil, false, fmt.Errorf("read limited response body: %w", err)
+	}
+
+	if len(responseBody) <= limit {
+		return responseBody, false, nil
+	}
+
+	return responseBody[:limit], true, nil
 }

--- a/internal/oauth2/providers/google/api_test.go
+++ b/internal/oauth2/providers/google/api_test.go
@@ -1,0 +1,83 @@
+package google //nolint:testpackage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type apiRoundTripper func(*http.Request) (*http.Response, error)
+
+func (fn apiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestGetResponseBodyLimits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		statusCode      int
+		body            string
+		wantErrContains string
+		wantErrExcludes string
+	}{
+		{
+			name:       "successful response at limit",
+			statusCode: http.StatusOK,
+			body:       "[]" + strings.Repeat(" ", maxResponseBodySize-2),
+		},
+		{
+			name:            "successful response exceeds limit",
+			statusCode:      http.StatusOK,
+			body:            strings.Repeat(" ", maxResponseBodySize+1),
+			wantErrContains: "response body from Google API https://cloudidentity.googleapis.com/test exceeds the 1048576 byte limit",
+		},
+		{
+			name:            "error response is truncated",
+			statusCode:      http.StatusInternalServerError,
+			body:            "visible" + strings.Repeat("x", maxErrorResponseBodySize) + "hidden",
+			wantErrContains: "visible",
+			wantErrExcludes: "hidden",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			httpClient := &http.Client{
+				Transport: apiRoundTripper(func(_ *http.Request) (*http.Response, error) {
+					response := httptest.NewRecorder()
+					response.WriteHeader(testCase.statusCode)
+					_, _ = response.WriteString(testCase.body)
+
+					return response.Result(), nil
+				}),
+			}
+
+			apiURL := &url.URL{Scheme: "https", Host: "cloudidentity.googleapis.com", Path: "/test"}
+
+			var data any
+
+			err := get[any](t.Context(), httpClient, "token", apiURL, &data)
+
+			if testCase.wantErrContains == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(t, err, testCase.wantErrContains)
+
+			if testCase.wantErrExcludes != "" {
+				require.NotContains(t, err.Error(), testCase.wantErrExcludes)
+				require.ErrorContains(t, err, "[truncated]")
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Limits successful GitHub and Google API response bodies to 1 MiB and retains only a 4 KiB excerpt from error responses. This prevents a hostile or misconfigured provider from causing unbounded memory use. It also updates the textlint target to provision the required terminology rule through npx.

Regression tests cover the exact success boundary, oversized success responses, and truncated error responses.

#### Which issue this PR fixes

No linked issue.

#### Special notes for your reviewer

Checks completed:

- make fmt
- make lint
- make test
- make textlint

#### Particularly user-facing changes

Provider API calls now fail closed when a successful response exceeds 1 MiB.

#### Checklist

- [x] DCO signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect significant changes