### PR TITLE
fix: deny clients on profile selector render errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,26 @@ project's `docs/` directory contains detailed guides such as
 [`docs/Configuration.md`](docs/Configuration.md) and
 [`docs/Home.md`](docs/Home.md).
 
+## Client-visible error classification
+
+Keep client-visible errors non-specific, but preserve their broad failure
+class whenever the code can determine it reliably from structured context:
+
+- Use `client rejected` for authentication or authorization failures.
+- Use `internal error` for infrastructure and internal processing failures,
+  such as network, storage, or template-rendering errors.
+
+Never expose the underlying provider, network, storage, template, token, or
+other implementation error in an HTTP response or OpenVPN denial reason. Log
+the technical error instead. Browser error pages should show an opaque error ID
+that an administrator can correlate with the logs.
+
+Do not classify errors by matching their message strings. If an upstream API
+does not provide a structured distinction, retain its generic classification
+instead of introducing fragile string matching. See
+[issue #1121](https://github.com/jkroepke/openvpn-auth-oauth2/issues/1121) for
+the rationale.
+
 ## Plugin cgo pointer checks
 
 All tests must be compiled with `GOEXPERIMENT=cgocheck2` so the plugin's Go/C

--- a/internal/oauth2/handler.go
+++ b/internal/oauth2/handler.go
@@ -549,20 +549,21 @@ func (c *Client) renderClientConfigProfileSelector(
 		"clientConfigProfiles": clientConfigProfiles,
 	})
 	if err != nil {
-		req.logger.LogAttrs(ctx, slog.LevelError, "template error", slog.Any(
-			"err", fmt.Errorf("executing template: %w", err),
-		))
-		w.WriteHeader(http.StatusInternalServerError)
-
-		return nil
+		return &profileSelectorError{
+			err:           fmt.Errorf("executing profile selector template: %w", err),
+			errorType:     "profile selector template",
+			openvpnReason: "internal error",
+		}
 	}
 
 	w.WriteHeader(http.StatusOK)
 
 	if _, err = response.WriteTo(w); err != nil {
-		req.logger.LogAttrs(ctx, slog.LevelError, "response write error", slog.Any("err", err))
-
-		return nil
+		return &profileSelectorError{
+			err:           fmt.Errorf("writing profile selector response: %w", err),
+			errorType:     "profile selector response",
+			openvpnReason: "internal error",
+		}
 	}
 
 	req.logger.LogAttrs(

--- a/internal/oauth2/handler_internal_test.go
+++ b/internal/oauth2/handler_internal_test.go
@@ -1,10 +1,22 @@
 package oauth2
 
 import (
+	"context"
+	"errors"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
+	configtypes "github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/crypto"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testlogger"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/tokenstorage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,4 +36,130 @@ func TestWithIDTokenClaimsLoggerOmitsUnrestrictedClaims(t *testing.T) {
 	require.Contains(t, logger.String(), "idtoken_subject=subject")
 	require.NotContains(t, logger.String(), "custom_sensitive_claim")
 	require.NotContains(t, logger.String(), "secret-custom-claim")
+}
+
+func TestHandleClientConfigSelectorDeniesClientOnRenderError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template configtypes.Template
+		writer   http.ResponseWriter
+	}{
+		{
+			name: "template execution",
+			template: configtypes.Template{Template: template.Must(
+				template.New("index.gohtml").Parse(`{{ slice .message 999 }}`),
+			)},
+			writer: httptest.NewRecorder(),
+		},
+		{
+			name:     "response write",
+			template: config.Defaults.HTTP.Template,
+			writer: &errorResponseWriter{
+				err: errors.New("write failed"),
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			conf := config.Defaults
+			conf.HTTP.Template = testCase.template
+			openVPNClient := &recordingOpenVPNClient{}
+			client := Client{
+				conf:        &conf,
+				logger:      slog.New(slog.DiscardHandler),
+				openvpn:     openVPNClient,
+				stateCrypto: crypto.New("1234567890123456"),
+				storage: tokenstorage.NewInMemoryWithGC(
+					"1234567890123456",
+					time.Hour,
+					0,
+				),
+			}
+			session := state.State{Client: state.ClientIdentifier{CID: 1, KID: 2}}
+
+			handled := client.handleClientConfigSelector(t.Context(), testCase.writer, codeExchangeRequest{
+				logger:         slog.New(slog.DiscardHandler),
+				encryptedState: "state",
+				session:        session,
+				clientID:       "1",
+			}, []string{"profile-a", "profile-b"})
+
+			require.True(t, handled)
+			require.Zero(t, openVPNClient.acceptCount)
+			require.Equal(t, 1, openVPNClient.denyCount)
+			require.Equal(t, session.Client, openVPNClient.deniedClient)
+			require.Equal(t, "internal error", openVPNClient.denyReason)
+		})
+	}
+}
+
+type errorResponseWriter struct {
+	err error
+}
+
+func (errorResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (w errorResponseWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+func (errorResponseWriter) WriteHeader(int) {
+}
+
+type recordingOpenVPNClient struct {
+	deniedClient state.ClientIdentifier
+	denyReason   string
+	acceptCount  int
+	denyCount    int
+}
+
+func (c *recordingOpenVPNClient) AcceptClient(
+	context.Context,
+	*slog.Logger,
+	state.ClientIdentifier,
+	string,
+	...string,
+) error {
+	c.acceptCount++
+
+	return nil
+}
+
+func (c *recordingOpenVPNClient) DenyClient(
+	_ context.Context,
+	_ *slog.Logger,
+	client state.ClientIdentifier,
+	reason string,
+) {
+	c.denyCount++
+	c.deniedClient = client
+	c.denyReason = reason
+}
+
+func TestWriteHTTPErrorDoesNotExposeTechnicalDetails(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Defaults
+	client := Client{conf: &conf}
+	recorder := httptest.NewRecorder()
+
+	client.writeHTTPError(
+		t.Context(),
+		recorder,
+		slog.New(slog.DiscardHandler),
+		http.StatusInternalServerError,
+		"profile selector template",
+		"sensitive render detail",
+	)
+
+	require.Contains(t, recorder.Body.String(), "Please contact your administrator")
+	require.NotContains(t, recorder.Body.String(), "profile selector template")
+	require.NotContains(t, recorder.Body.String(), "sensitive render detail")
 }


### PR DESCRIPTION
## Summary

- propagate profile-selector template execution and response-write failures
- deny the pending OpenVPN client with the non-specific internal error classification
- keep technical rendering details in logs and return only a generic HTTP error page with an opaque error ID
- document the non-specific but distinct client-visible error classification in AGENTS.md
- add regression coverage for both rendering failure modes and client-visible error redaction

Task 7 was already completed by #1148; this PR completes task 8.

Context: #1121

## Testing

- make fmt
- make lint
- make test
- make textlint