### PR TITLE
fix: harden management version parsing

### DIFF
--- a/internal/openvpn/main.go
+++ b/internal/openvpn/main.go
@@ -22,7 +22,10 @@ import (
 // OpenVPN management interface.
 const minManagementInterfaceVersion = 5
 
-const managementPluginVersionPrefix = "OpenVPN Version: openvpn-auth-oauth2"
+const (
+	managementVersionPrefix       = "Management Version: "
+	managementPluginVersionPrefix = "OpenVPN Version: openvpn-auth-oauth2"
+)
 
 const WelcomeBanner = ">INFO:OpenVPN Management Interface Version 5 -- type 'help' for more info"
 
@@ -193,9 +196,9 @@ func (c *Client) checkManagementInterfaceVersion(ctx context.Context) error {
 		return ErrEnforceUniqueUserUnsupported
 	}
 
-	managementInterfaceVersion, err := strconv.Atoi(versionParts[1][len(versionParts[1])-1:])
+	managementInterfaceVersion, err := parseManagementInterfaceVersion(versionParts[1])
 	if err != nil {
-		return fmt.Errorf("unable to parse openvpn management interface version: %w", err)
+		return err
 	}
 
 	// Management Interface Version 5 is required at minimum
@@ -205,6 +208,20 @@ func (c *Client) checkManagementInterfaceVersion(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func parseManagementInterfaceVersion(versionLine string) (int, error) {
+	prefix, version, found := strings.Cut(versionLine, managementVersionPrefix)
+	if !found || prefix != "" {
+		return 0, fmt.Errorf("%w: %s", ErrUnexpectedResponseFromVersionCommand, versionLine)
+	}
+
+	managementInterfaceVersion, err := strconv.Atoi(version)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse openvpn management interface version: %w", err)
+	}
+
+	return managementInterfaceVersion, nil
 }
 
 // checkClientSsoCapabilities reports whether the given client supports SSO via

--- a/internal/openvpn/main_internal_test.go
+++ b/internal/openvpn/main_internal_test.go
@@ -5,11 +5,67 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 )
+
+func TestParseManagementInterfaceVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		versionLine string
+		expect      int
+		err         error
+	}{
+		{
+			name:        "minimum supported version",
+			versionLine: "Management Version: 5",
+			expect:      5,
+		},
+		{
+			name:        "multi-digit version",
+			versionLine: "Management Version: 10",
+			expect:      10,
+		},
+		{
+			name:        "empty line",
+			versionLine: "",
+			err:         ErrUnexpectedResponseFromVersionCommand,
+		},
+		{
+			name:        "missing numeric field",
+			versionLine: managementVersionPrefix,
+			err:         strconv.ErrSyntax,
+		},
+		{
+			name:        "malformed numeric field",
+			versionLine: "Management Version: invalid",
+			err:         strconv.ErrSyntax,
+		},
+		{
+			name:        "unexpected prefix",
+			versionLine: "Unexpected Management Version: 5",
+			err:         ErrUnexpectedResponseFromVersionCommand,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := parseManagementInterfaceVersion(tc.versionLine)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("parseManagementInterfaceVersion(%q) error = %v, want %v", tc.versionLine, err, tc.err)
+			}
+
+			if actual != tc.expect {
+				t.Errorf("parseManagementInterfaceVersion(%q) = %d, want %d", tc.versionLine, actual, tc.expect)
+			}
+		})
+	}
+}
 
 func TestManagementCommandName(t *testing.T) {
 	t.Parallel()

--- a/internal/openvpn/main_test.go
+++ b/internal/openvpn/main_test.go
@@ -371,19 +371,24 @@ func TestClientInvalidVersion(t *testing.T) {
 		err     error
 	}{
 		{
-			"invalid parts",
-			"OpenVPN Version: OpenVPN Mock\r\nEND\r\n",
-			openvpn.ErrUnexpectedResponseFromVersionCommand,
+			name:    "invalid parts",
+			version: "OpenVPN Version: OpenVPN Mock\r\nEND\r\n",
+			err:     openvpn.ErrUnexpectedResponseFromVersionCommand,
 		},
 		{
-			"invalid version",
-			"OpenVPN Version: OpenVPN Mock\r\nManagement Interface Version:\r\nEND\r\n",
-			strconv.ErrSyntax,
+			name:    "empty version line",
+			version: "OpenVPN Version: OpenVPN Mock\r\n\r\nEND\r\n",
+			err:     openvpn.ErrUnexpectedResponseFromVersionCommand,
 		},
 		{
-			"version to low",
-			"OpenVPN Version: OpenVPN Mock\r\nManagement Interface Version: 4\r\nEND\r\n",
-			openvpn.ErrRequireManagementInterfaceVersion5,
+			name:    "invalid version",
+			version: "OpenVPN Version: OpenVPN Mock\r\nManagement Version: invalid\r\nEND\r\n",
+			err:     strconv.ErrSyntax,
+		},
+		{
+			name:    "version too low",
+			version: "OpenVPN Version: OpenVPN Mock\r\nManagement Version: 4\r\nEND\r\n",
+			err:     openvpn.ErrRequireManagementInterfaceVersion5,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -408,6 +413,30 @@ func TestClientInvalidVersion(t *testing.T) {
 	}
 }
 
+func TestClientMultiDigitManagementVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	suite := testsuite.New(new(config.Defaults))
+	errOpenVPNClientCh := suite.SetupMockEnvironment(ctx, t, nil)
+	suite.SendMessagef(t, openvpn.WelcomeBanner)
+	suite.ExpectMessage(t, "version")
+	suite.SendMessagef(
+		t,
+		"OpenVPN Version: OpenVPN Mock\r\nManagement Version: 10\r\nEND\r\n",
+	)
+	require.NoError(t, suite.GetManagementInterfaceConn().Close())
+
+	select {
+	case err := <-errOpenVPNClientCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for connection to close. Logs:\n\n%s", suite.Logs())
+	}
+}
+
 func TestClientEnforceUniqueUserRejectsPluginShim(t *testing.T) {
 	t.Parallel()
 
@@ -424,7 +453,7 @@ func TestClientEnforceUniqueUserRejectsPluginShim(t *testing.T) {
 	suite.ExpectMessage(t, "version")
 	suite.SendMessagef(
 		t,
-		"OpenVPN Version: openvpn-auth-oauth2 2.0.0\r\nManagement Interface Version: 5\r\nEND",
+		"OpenVPN Version: openvpn-auth-oauth2 2.0.0\r\nManagement Version: 5\r\nEND",
 	)
 
 	select {

--- a/internal/openvpn/passthrough_test.go
+++ b/internal/openvpn/passthrough_test.go
@@ -188,7 +188,7 @@ func TestPassThroughFull(t *testing.T) {
 				require.NotContains(t, suite.Logs(), "super-secret-value")
 
 				// version
-				forwardPassThroughCommand(t, suite, passThroughConn, "version", "OpenVPN Version: openvpn-auth-oauth2\r\nManagement Interface Version: 5\r\nEND")
+				forwardPassThroughCommand(t, suite, passThroughConn, "version", "OpenVPN Version: openvpn-auth-oauth2\r\nManagement Version: 5\r\nEND")
 
 				// status
 				forwardPassThroughCommand(t, suite, passThroughConn, "status", OpenVPNManagementInterfaceCommandResultStatus)

--- a/internal/test/testsuite/connection.go
+++ b/internal/test/testsuite/connection.go
@@ -131,7 +131,7 @@ func expectVersionAndReleaseHold(tb testing.TB, conn net.Conn, reader *bufio.Rea
 
 			expectedCommand++
 		case ManagementCommandVersion:
-			sendMessagef(tb, conn, logs, "OpenVPN Version: OpenVPN Mock\r\nManagement Interface Version: 5\r\nEND")
+			sendMessagef(tb, conn, logs, "OpenVPN Version: OpenVPN Mock\r\nManagement Version: 5\r\nEND")
 
 			expectedCommand++
 		default:

--- a/lib/openvpn-auth-oauth2/internal/management/management.go
+++ b/lib/openvpn-auth-oauth2/internal/management/management.go
@@ -302,6 +302,7 @@ func (s *Server) handleManagementClient(ctx context.Context, conn net.Conn) erro
 	s.connected.Store(1)
 	s.connectionMu.Unlock()
 
+	// https://github.com/OpenVPN/openvpn/blame/d988ef4508e63b28c8e3efcb9f62eb8c836907fe/src/openvpn/manage.c#L208
 	_ = s.writeToClient(">INFO:OpenVPN Management Interface Version 5 -- type 'help' for more info")
 
 scan:
@@ -325,7 +326,7 @@ scan:
 
 			continue
 		case strings.HasPrefix(line, "version"):
-			_ = s.writeToClient(fmt.Sprintf("OpenVPN Version: openvpn-auth-oauth2 %s\nManagement Interface Version: 5\nEND", version.Version))
+			_ = s.writeToClient(fmt.Sprintf("OpenVPN Version: openvpn-auth-oauth2 %s\nManagement Version: 5\nEND", version.Version))
 
 			continue
 		case strings.HasPrefix(line, "help"):

--- a/lib/openvpn-auth-oauth2/internal/management/management_test.go
+++ b/lib/openvpn-auth-oauth2/internal/management/management_test.go
@@ -65,7 +65,7 @@ func TestServer_Listen(t *testing.T) {
 			clientConn.ExpectMessage(t, openvpn.WelcomeBanner)
 			clientConn.SendMessagef(t, "")
 			clientConn.SendAndExpectMessage(t, "hold release", "SUCCESS: hold released")
-			clientConn.SendAndExpectMessage(t, "version", fmt.Sprintf("OpenVPN Version: openvpn-auth-oauth2 %s\nManagement Interface Version: 5\nEND", version.Version))
+			clientConn.SendAndExpectMessage(t, "version", fmt.Sprintf("OpenVPN Version: openvpn-auth-oauth2 %s\nManagement Version: 5\nEND", version.Version))
 			clientConn.SendAndExpectMessage(t, "help", "SUCCESS: help")
 			clientConn.SendAndExpectMessage(t, "unknown", "ERROR: unknown command, enter 'help' for more options")
 


### PR DESCRIPTION
## Summary

- parse the complete management interface version field instead of its final byte
- reject empty, malformed, and incorrectly prefixed version lines without indexing
- cover multi-digit versions and malformed responses with regression tests

## Testing

- `make fmt`
- `make lint`
- `make test`
- `git diff --check`