### PR TITLE
feat!: use AES-256-GCM for encrypted data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,149 +1,77 @@
-# Instructions for AI Agents
+# Agent instructions
 
-The following guidelines apply to all files in this repository.
-
-Follow all development, testing, documentation, and pull request requirements in
-[`CONTRIBUTING.md`](CONTRIBUTING.md) before modifying the repository.
+Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for all changes. See
+[`DEVELOPER.md`](DEVELOPER.md) for the architecture and `docs/` for user-facing
+configuration and behavior.
 
 ## Pull request labels
 
-Applying changelog labels is an AI-agent-only operation. External contributors
-must not be instructed to set them.
+Before merging, apply at least one label from [`.github/release.yml`](.github/release.yml):
 
-Before merging, apply at least one changelog label defined in
-[`.github/release.yml`](.github/release.yml):
+- `💥 breaking-change`: breaking changes
+- `✨ enhancement`: user-visible functionality
+- `🐞 bug`: fixes
+- `🛠️ dependencies`: dependency updates
+- `📖 docs`: documentation
+- `chore`: internal performance work, tests, CI, or maintenance
 
-- `💥 breaking-change` for breaking changes
-- `✨ enhancement` for new functionality
-- `🐞 bug` for fixes
-- `🛠️ dependencies` for dependency updates
-- `📖 docs` for documentation
-- `chore` for internal technical changes excluded from the user-facing changelog
-
-Use `chore` for implementation-only performance improvements, tests, CI, and
-maintenance that do not change user-facing behavior. Use `✨ enhancement` only
-when a change adds functionality that users can observe or use.
-
-Add `💥 breaking-change` whenever a change is breaking, even if another label
-also applies.
+Add `💥 breaking-change` alongside any other applicable label. Labeling is an
+AI-agent-only operation; do not tell external contributors to apply labels.
 
 ## Program overview
 
-`openvpn-auth-oauth2` is written in Go and acts as a management client for an
-OpenVPN server. It bridges the OpenVPN [webauth protocol](https://github.com/OpenVPN/openvpn3/blob/master/doc/webauth.md)
-with OIDC providers. The executable communicates with the OpenVPN management
-interface via a Unix or TCP socket, and it exposes an HTTP listener that handles
-browser-based authentication.
-
-The typical authentication flow:
-
-1. A VPN client connects to the OpenVPN server.
-2. The server contacts `openvpn-auth-oauth2` using the management interface and
-   receives a `WEBAUTH:` URL.
-3. The VPN client opens that URL in a browser and logs in against the OIDC
-   provider.
-4. After a successful login, the token is validated, and the result is sent back to
-   the OpenVPN server to complete the connection.
-
-Configuration is usually done through a YAML file or environment variables. The
-project's `docs/` directory contains detailed guides such as
-[`docs/Configuration.md`](docs/Configuration.md) and
-[`docs/Home.md`](docs/Home.md).
+This Go application bridges OpenVPN's webauth protocol with OIDC providers. It
+communicates with the OpenVPN management interface and serves the browser-based
+authentication flow over HTTP.
 
 ## Client-visible error classification
 
-Keep client-visible errors non-specific, but preserve their broad failure
-class whenever the code can determine it reliably from structured context:
+Preserve broad failure classes without exposing implementation details:
 
-- Use `client rejected` for authentication or authorization failures.
-- Use `internal error` for infrastructure and internal processing failures,
-  such as network, storage, or template-rendering errors.
+- `client rejected`: authentication or authorization failures
+- `internal error`: infrastructure or internal processing failures
 
-Never expose the underlying provider, network, storage, template, token, or
-other implementation error in an HTTP response or OpenVPN denial reason. Log
-the technical error instead. Browser error pages should show an opaque error ID
-that an administrator can correlate with the logs.
-
-Do not classify errors by matching their message strings. If an upstream API
-does not provide a structured distinction, retain its generic classification
-instead of introducing fragile string matching. See
-[issue #1121](https://github.com/jkroepke/openvpn-auth-oauth2/issues/1121) for
-the rationale.
+Log the technical error. Browser error pages must show an opaque, log-correlated
+error ID. Never classify errors by matching message strings; if upstream provides
+no structured distinction, keep the generic classification. See
+[issue #1121](https://github.com/jkroepke/openvpn-auth-oauth2/issues/1121).
 
 ## Plugin cgo pointer checks
 
-All tests must be compiled with `GOEXPERIMENT=cgocheck2` so the plugin's Go/C
-boundary receives the complete, expensive cgo pointer checks. The `test` target
-in `Makefile` and the build-and-test job in `.github/workflows/ci.yaml` set the
-experiment at build time.
+Compile all tests with `GOEXPERIMENT=cgocheck2`; the `Makefile` and CI test job
+already set it.
+Do not try to enable it at runtime with `GODEBUG`, `//go:debug`, or `t.Setenv`.
 
-Do not try to enable the experiment with `//go:debug cgocheck2=1`,
-`//go:debug cgocheck=2`, `GODEBUG=cgocheck=2`, or `t.Setenv`. The first is not a
-`GODEBUG` setting, while the others cannot enable the build-time instrumentation.
+## Encrypted-state format migrations
+
+Only client-held OAuth state and profile-selector ciphertext can cross an
+executable upgrade, and they remain active for at most five minutes. Refresh-token
+ciphertext is process-local, is lost on restart, and survives only in-process
+configuration reloads. Do not add refresh-token migration or background
+re-encryption solely for a format change.
+
+Switch formats directly if affected users may retry authentication. Otherwise,
+temporarily read legacy ciphertext while writing the new version. Legacy reads
+are needed only until five minutes after the last old instance stops issuing
+ciphertext. For rolling deployments, stage the switch because old instances
+cannot read the new format.
 
 ## OpenVPN management command size
 
-When changing the URL-length validation for `client-pending-auth`, distinguish
-the project's conservative limit from OpenVPN's actual management-interface
-limit. OpenVPN allocates a 1024-byte command accumulator:
+For `client-pending-auth` URL validation:
 
-```c
-man->connection.in = command_line_new(1024);
-```
+- OpenVPN accepts at most 1023 command-body bytes before the terminating LF.
+  This is a byte limit. OpenVPN discards this project's CR, so CR does not reduce
+  the allowance.
+- For `client-pending-auth <CID> <KID> "WEB_AUTH::<URL>" <TIMEOUT>`, the body is
+  `35 + digits(CID) + digits(KID) + bytes(URL) + digits(TIMEOUT)` bytes.
+- Therefore, the maximum URL size is
+  `988 - digits(CID) - digits(KID) - digits(TIMEOUT)` bytes. Assuming a CID of
+  at most five digits, a one-digit KID, and timeout `300`, the URL may contain at
+  most 979 bytes. Quoting or escaping consumes more.
+- Do not confuse a conservative project policy with OpenVPN's actual limit.
+- OpenVPN's later TLS `EXTRA` limit is 1013 parsed bytes; the 1023-byte management
+  command limit is tighter for this template.
 
-It stores only printable bytes and line feeds. If another stored byte does not
-fit, it clears the accumulated command:
-
-```c
-if (buf[i] && char_class(buf[i], (CC_PRINT | CC_NEWLINE)))
-{
-    if (!buf_write_u8(&cl->buf, buf[i]))
-    {
-        buf_clear(&cl->buf);
-    }
-}
-```
-
-Therefore, a management command may contain at most **1023 bytes before the
-terminating LF**. This is a byte limit, not a character limit. This project
-writes CRLF in `internal/openvpn/main.go`, but OpenVPN discards CR because the
-accepted character classes above include `CC_NEWLINE` and not `CC_CR`; CR does
-not reduce the 1023-byte command-body allowance.
-
-For the exact template in `internal/openvpn/client.go`:
-
-```text
-client-pending-auth <CID> <KID> "WEB_AUTH::<URL>" <TIMEOUT>
-```
-
-the body size is:
-
-```text
-35 + digits(CID) + digits(KID) + bytes(URL) + digits(TIMEOUT)
-```
-
-Consequently:
-
-```text
-maximum URL bytes = 988 - digits(CID) - digits(KID) - digits(TIMEOUT)
-```
-
-For example, CID `1`, KID `0`, and timeout `300` permit a URL of at most
-**983 bytes**. Quoting or escaping additional characters consumes more bytes.
-The existing `len(startURL) >= 245` validation is therefore a conservative
-project policy (maximum 244 bytes), not OpenVPN's management command limit.
-
-There is also a later TLS-control-message guard. OpenVPN defines
-`PUSH_BUNDLE_SIZE` as 1024 and accepts the parsed `EXTRA` only when
-`strlen(extra) + 1 + sizeof("INFO_PRE,") <= 1024`, giving a maximum parsed
-`EXTRA` size of 1013 bytes. For this project's command template, the 1023-byte
-management command limit is tighter.
-
-Source proof, pinned to OpenVPN commit
-[`a6537f7549f70f16bb2efd5c0683e0e94a236f0c`](https://github.com/OpenVPN/openvpn/commit/a6537f7549f70f16bb2efd5c0683e0e94a236f0c):
-
-- [the 1024-byte command accumulator](https://github.com/OpenVPN/openvpn/blob/a6537f7549f70f16bb2efd5c0683e0e94a236f0c/src/openvpn/manage.c#L2743-L2748)
-- [input filtering, overflow clearing, and LF detection](https://github.com/OpenVPN/openvpn/blob/a6537f7549f70f16bb2efd5c0683e0e94a236f0c/src/openvpn/manage.c#L4017-L4041)
-- [`CC_NEWLINE` and `CC_CR` are separate classes](https://github.com/OpenVPN/openvpn/blob/a6537f7549f70f16bb2efd5c0683e0e94a236f0c/src/openvpn/buffer.h#L918-L947)
-- [`PUSH_BUNDLE_SIZE` is 1024](https://github.com/OpenVPN/openvpn/blob/a6537f7549f70f16bb2efd5c0683e0e94a236f0c/src/openvpn/common.h#L84-L89)
-- [the `INFO_PRE`/`EXTRA` length check](https://github.com/OpenVPN/openvpn/blob/a6537f7549f70f16bb2efd5c0683e0e94a236f0c/src/openvpn/push.c#L438-L476)
+The source evidence is pinned to OpenVPN commit
+[`a6537f7549f70f16bb2efd5c0683e0e94a236f0c`](https://github.com/OpenVPN/openvpn/commit/a6537f7549f70f16bb2efd5c0683e0e94a236f0c).

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,7 +26,7 @@ For a step-by-step sequence diagram see `docs/Home.md`.
 3. **`internal/httphandler`** – Registers HTTP routes such as `/oauth2/start` and `/oauth2/callback`, and serves static assets.
 4. **`internal/oauth2`** – Implements OAuth2 logic. The `New` function creates the client and configures options like scopes and nonce generation. Sub-packages (`generic`, `github`, `google`) handle provider-specific behaviour.
 5. **`internal/openvpn`** – Manages the connection to the OpenVPN management interface, parses events and sends commands to the server. It decides whether a client should be accepted or rejected.
-6. **`internal/state`** – Generates and validates the OAuth2 `state` parameter. It stores information such as IP address, ports and OpenVPN IDs using Salsa20 with an HMAC (encrypt-then-MAC) and timestamp validation for authenticated encryption.
+6. **`internal/state`** – Generates and validates the OAuth2 `state` parameter. It stores information such as IP address, ports and OpenVPN IDs using XChaCha20-Poly1305 authenticated encryption and timestamp validation.
 7. **`internal/tokenstorage`** – Stores encrypted refresh tokens (for example in memory) so that a user can log in again without manual interaction.
 8. **`internal/utils`** – Helper functions including HTTP transport with custom user-agent and filesystem helpers.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,7 +26,7 @@ For a step-by-step sequence diagram see `docs/Home.md`.
 3. **`internal/httphandler`** – Registers HTTP routes such as `/oauth2/start` and `/oauth2/callback`, and serves static assets.
 4. **`internal/oauth2`** – Implements OAuth2 logic. The `New` function creates the client and configures options like scopes and nonce generation. Sub-packages (`generic`, `github`, `google`) handle provider-specific behaviour.
 5. **`internal/openvpn`** – Manages the connection to the OpenVPN management interface, parses events and sends commands to the server. It decides whether a client should be accepted or rejected.
-6. **`internal/state`** – Generates and validates the OAuth2 `state` parameter. It stores information such as IP address, ports and OpenVPN IDs using XChaCha20-Poly1305 authenticated encryption and timestamp validation.
+6. **`internal/state`** – Generates and validates the OAuth2 `state` parameter. It stores information such as IP address, ports and OpenVPN IDs using AES-256-GCM authenticated encryption and timestamp validation.
 7. **`internal/tokenstorage`** – Stores encrypted refresh tokens (for example in memory) so that a user can log in again without manual interaction.
 8. **`internal/utils`** – Helper functions including HTTP transport with custom user-agent and filesystem helpers.
 

--- a/docs/Security considerations.md
+++ b/docs/Security considerations.md
@@ -2,16 +2,16 @@
 
 ## Encryption of Sensitive Data
 
-openvpn-auth-oauth2 uses **Salsa20 stream cipher with HMAC-SHA256 authentication** to encrypt:
+openvpn-auth-oauth2 uses **XChaCha20-Poly1305 authenticated encryption** to protect:
 - OAuth2 refresh tokens (when enabled)
 - State parameters in authentication flows
 - User session information
 
 This approach provides:
-- ✅ **Confidentiality**: Strong encryption with stream cipher
-- ✅ **Integrity**: HMAC-SHA256 detects any tampering
-- ✅ **Authentication**: Verifies data wasn't modified by attackers
-- ✅ **Minimal overhead**: Only 24 bytes extra per encrypted message
+- ✅ **Confidentiality**: Sensitive values are encrypted
+- ✅ **Integrity and authentication**: Modified values are rejected
+- ✅ **Wide nonces**: The 192-bit nonce makes accidental reuse impractical
+- ✅ **Bounded overhead**: The nonce and authentication tag add 40 bytes
 
 ## Potential Risks Caused by State Reuse
 

--- a/docs/Security considerations.md
+++ b/docs/Security considerations.md
@@ -2,7 +2,7 @@
 
 ## Encryption of Sensitive Data
 
-openvpn-auth-oauth2 uses **XChaCha20-Poly1305 authenticated encryption** to protect:
+openvpn-auth-oauth2 uses **AES-256-GCM authenticated encryption** to protect:
 - OAuth2 refresh tokens (when enabled)
 - State parameters in authentication flows
 - User session information
@@ -10,8 +10,10 @@ openvpn-auth-oauth2 uses **XChaCha20-Poly1305 authenticated encryption** to prot
 This approach provides:
 - ✅ **Confidentiality**: Sensitive values are encrypted
 - ✅ **Integrity and authentication**: Modified values are rejected
-- ✅ **Wide nonces**: The 192-bit nonce makes accidental reuse impractical
-- ✅ **Bounded overhead**: The nonce and authentication tag add 40 bytes
+- ✅ **Random nonces**: Go generates and prepends a fresh 96-bit nonce
+- ✅ **Bounded overhead**: The nonce and authentication tag add 28 bytes
+
+An encryption key must not protect more than `2^32` messages.
 
 ## Potential Risks Caused by State Reuse
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/zitadel/oidc/v3 v3.49.6
 	go.yaml.in/yaml/v3 v3.0.5
-	golang.org/x/crypto v0.55.0
 	golang.org/x/net v0.58.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.41.0
@@ -70,6 +69,7 @@ require (
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.46.0 // indirect
 	go.opentelemetry.io/otel/trace v1.46.0 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260824195058-e88cd73687aa // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260904163448-b1c236e22ff4 // indirect

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -2,9 +2,9 @@ package crypto
 
 import (
 	"bytes"
+	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hkdf"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
@@ -14,17 +14,18 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/crypto/chacha20poly1305"
 )
 
 const (
-	keyDerivationInfo = "xchacha20-poly1305"
+	aes256KeySize     = 32
+	aesGCMNonceSize   = 12
+	aesGCMTagSize     = 16
+	keyDerivationInfo = "aes-256-gcm"
 	defaultMaxAge     = 2 * time.Minute
 
 	// timedPlainTextScratchSize covers typical authentication payloads while append retains a heap fallback.
 	timedPlainTextScratchSize = 128
-	timedEncryptedScratchSize = timedPlainTextScratchSize + chacha20poly1305.NonceSizeX + chacha20poly1305.Overhead
+	timedEncryptedScratchSize = timedPlainTextScratchSize + aesGCMNonceSize + aesGCMTagSize
 	base64SourceChunkSize     = timedEncryptedScratchSize - timedEncryptedScratchSize%3
 	base64EncodedChunkSize    = base64SourceChunkSize / 3 * 4
 )
@@ -35,7 +36,7 @@ var ErrCipherTextBlockSize = errors.New("ciphertext block size is too short")
 // ErrAuthenticationFailed is returned when ciphertext authentication fails.
 var ErrAuthenticationFailed = errors.New("ciphertext authentication failed")
 
-// Cipher provides authenticated encryption using XChaCha20-Poly1305.
+// Cipher provides authenticated encryption using AES-256-GCM.
 type Cipher struct {
 	scratchPool sync.Pool
 	aead        cipher.AEAD
@@ -60,10 +61,14 @@ func NewWithMaxAge(encryptionKey string, maxAge time.Duration) *Cipher {
 	key := DeriveKey(encryptionKey)
 	defer clear(key[:])
 
-	aead, err := chacha20poly1305.NewX(key[:])
+	block, err := aes.NewCipher(key[:])
 	if err != nil {
-		// XChaCha20-Poly1305 is required by this package and is unavailable in FIPS-only mode.
-		panic(fmt.Sprintf("chacha20poly1305.NewX: unexpected error: %v", err))
+		panic(fmt.Sprintf("aes.NewCipher: unexpected error: %v", err))
+	}
+
+	aead, err := cipher.NewGCMWithRandomNonce(block)
+	if err != nil {
+		panic(fmt.Sprintf("cipher.NewGCMWithRandomNonce: unexpected error: %v", err))
 	}
 
 	result := &Cipher{
@@ -77,9 +82,9 @@ func NewWithMaxAge(encryptionKey string, maxAge time.Duration) *Cipher {
 	return result
 }
 
-// DeriveKey derives a 32-byte XChaCha20-Poly1305 key using HKDF-SHA256.
+// DeriveKey derives a 32-byte AES-256 key using HKDF-SHA256.
 func DeriveKey(key string) *[32]byte {
-	derivedKey, err := hkdf.Key(sha256.New, []byte(key), nil, keyDerivationInfo, chacha20poly1305.KeySize)
+	derivedKey, err := hkdf.Key(sha256.New, []byte(key), nil, keyDerivationInfo, aes256KeySize)
 	if err != nil {
 		// hkdf.Key only errors when keyLength exceeds 255 times the hash size.
 		panic(fmt.Sprintf("hkdf.Key: unexpected error: %v", err))
@@ -92,14 +97,14 @@ func DeriveKey(key string) *[32]byte {
 	return &result
 }
 
-// EncryptBytes encrypts and authenticates data using XChaCha20-Poly1305.
+// EncryptBytes encrypts and authenticates data using AES-256-GCM.
 func (c *Cipher) EncryptBytes(plainText []byte) ([]byte, error) {
 	return c.encryptBytesInto(nil, plainText)
 }
 
 // DecryptBytes decrypts data encrypted with EncryptBytes.
 func (c *Cipher) DecryptBytes(encryptedData []byte) ([]byte, error) {
-	if len(encryptedData) < chacha20poly1305.NonceSizeX+chacha20poly1305.Overhead {
+	if len(encryptedData) < c.aead.Overhead() {
 		return nil, ErrCipherTextBlockSize
 	}
 
@@ -240,31 +245,21 @@ func encodeRawURLBase64String(src []byte) string {
 
 // encryptBytesInto encrypts plainText into dst, allocating only when its capacity is insufficient.
 func (c *Cipher) encryptBytesInto(dst, plainText []byte) ([]byte, error) {
-	resultSize := chacha20poly1305.NonceSizeX + len(plainText) + chacha20poly1305.Overhead
+	resultSize := len(plainText) + c.aead.Overhead()
 
-	var result []byte
 	if cap(dst) < resultSize {
-		result = make([]byte, chacha20poly1305.NonceSizeX, resultSize)
+		dst = make([]byte, 0, resultSize)
 	} else {
-		result = dst[:chacha20poly1305.NonceSizeX]
+		dst = dst[:0]
 	}
 
-	nonce := result[:chacha20poly1305.NonceSizeX]
-
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, fmt.Errorf("failed to generate nonce: %w", err)
-	}
-
-	return c.aead.Seal(result, nonce, plainText, nil), nil
+	return c.aead.Seal(dst, nil, plainText, nil), nil
 }
 
 // decryptBytesInto authenticates encryptedData and decrypts it into dst.
 // Callers must reject ciphertext shorter than the nonce and authentication tag.
 func (c *Cipher) decryptBytesInto(dst, encryptedData []byte) ([]byte, error) {
-	nonce := encryptedData[:chacha20poly1305.NonceSizeX]
-	cipherText := encryptedData[chacha20poly1305.NonceSizeX:]
-
-	plainText, err := c.aead.Open(dst, nonce, cipherText, nil)
+	plainText, err := c.aead.Open(dst, nil, encryptedData, nil)
 	if err != nil {
 		return nil, ErrAuthenticationFailed
 	}
@@ -275,12 +270,12 @@ func (c *Cipher) decryptBytesInto(dst, encryptedData []byte) ([]byte, error) {
 // decryptTimedPayload authenticates, decrypts, and validates
 // an already base64-decoded timestamped payload.
 func (c *Cipher) decryptTimedPayload(encrypted []byte) ([]byte, error) {
-	if len(encrypted) < chacha20poly1305.NonceSizeX+chacha20poly1305.Overhead {
+	if len(encrypted) < c.aead.Overhead() {
 		return nil, ErrCipherTextBlockSize
 	}
 
 	data, err := c.decryptBytesInto(
-		encrypted[chacha20poly1305.NonceSizeX:chacha20poly1305.NonceSizeX],
+		encrypted[:0],
 		encrypted,
 	)
 	if err != nil {

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -2,32 +2,29 @@ package crypto
 
 import (
 	"bytes"
+	"crypto/cipher"
 	"crypto/hkdf"
-	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"hash"
 	"io"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/crypto/salsa20"
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 const (
-	salsa20NonceSize = 8
-	hmacTagSize      = 16
-	derivedKeySize   = 32
-	defaultMaxAge    = 2 * time.Minute
+	keyDerivationInfo = "xchacha20-poly1305"
+	defaultMaxAge     = 2 * time.Minute
 
 	// timedPlainTextScratchSize covers typical authentication payloads while append retains a heap fallback.
 	timedPlainTextScratchSize = 128
-	timedEncryptedScratchSize = timedPlainTextScratchSize + salsa20NonceSize + hmacTagSize
+	timedEncryptedScratchSize = timedPlainTextScratchSize + chacha20poly1305.NonceSizeX + chacha20poly1305.Overhead
 	base64SourceChunkSize     = timedEncryptedScratchSize - timedEncryptedScratchSize%3
 	base64EncodedChunkSize    = base64SourceChunkSize / 3 * 4
 )
@@ -35,32 +32,24 @@ const (
 // ErrCipherTextBlockSize is returned when the ciphertext block size is too short.
 var ErrCipherTextBlockSize = errors.New("ciphertext block size is too short")
 
-// ErrHMACVerificationFailed is returned when HMAC verification fails.
-var ErrHMACVerificationFailed = errors.New("hmac verification failed")
+// ErrAuthenticationFailed is returned when ciphertext authentication fails.
+var ErrAuthenticationFailed = errors.New("ciphertext authentication failed")
 
-// Cipher provides encryption and decryption operations using Salsa20 + HMAC-SHA256.
+// Cipher provides authenticated encryption using XChaCha20-Poly1305.
 type Cipher struct {
-	macPool sync.Pool
-	encKey  *[32]byte
-	macKey  []byte
-	maxAge  time.Duration
+	scratchPool sync.Pool
+	aead        cipher.AEAD
+	maxAge      time.Duration
 }
 
-// pooledMAC keeps reusable HMAC state and timed-encryption/decryption scratch together.
-// A local Sum scratch escapes through hash.Hash, while encrypted is consumed
-// before the object returns to the pool and is never returned to callers.
-type pooledMAC struct {
-	hash.Hash
-
-	sum       [sha256.Size]byte
+// pooledScratch keeps timed-encryption and decryption scratch between calls.
+type pooledScratch struct {
 	encrypted [timedEncryptedScratchSize]byte
 }
 
 // New creates a new Cipher instance with the given encryption key.
-// Both the encryption key and the MAC key are independently derived from the
-// input using HKDF-SHA256 with distinct info strings ("salsa20-encryption" and
-// "hmac-authentication") to ensure domain separation. The raw key string is not
-// retained in memory after construction.
+// The AEAD key is derived from the input with HKDF-SHA256. The raw key string is
+// not retained in the Cipher after construction.
 func New(encryptionKey string) *Cipher {
 	return NewWithMaxAge(encryptionKey, defaultMaxAge)
 }
@@ -68,77 +57,62 @@ func New(encryptionKey string) *Cipher {
 // NewWithMaxAge creates a new Cipher instance with the given encryption key and
 // maximum age for timestamped payloads.
 func NewWithMaxAge(encryptionKey string, maxAge time.Duration) *Cipher {
-	secret := []byte(encryptionKey)
+	key := DeriveKey(encryptionKey)
+	defer clear(key[:])
 
-	encKeyBytes := deriveHKDFKey(secret, "salsa20-encryption")
-	macKeyBytes := deriveHKDFKey(secret, "hmac-authentication")
+	aead, err := chacha20poly1305.NewX(key[:])
+	if err != nil {
+		// XChaCha20-Poly1305 is required by this package and is unavailable in FIPS-only mode.
+		panic(fmt.Sprintf("chacha20poly1305.NewX: unexpected error: %v", err))
+	}
 
-	var encKey [32]byte
-	copy(encKey[:], encKeyBytes)
-
-	cipher := &Cipher{
-		encKey: &encKey,
-		macKey: macKeyBytes,
+	result := &Cipher{
+		aead:   aead,
 		maxAge: maxAge,
 	}
-	cipher.macPool.New = func() any {
-		return &pooledMAC{
-			Hash: hmac.New(sha256.New, cipher.macKey),
-		}
+	result.scratchPool.New = func() any {
+		return new(pooledScratch)
 	}
 
-	return cipher
+	return result
 }
 
-// DeriveKey derives a 32-byte key from the input key string using HKDF-SHA256
-// with the "salsa20-encryption" info string.
+// DeriveKey derives a 32-byte XChaCha20-Poly1305 key using HKDF-SHA256.
 func DeriveKey(key string) *[32]byte {
-	b := deriveHKDFKey([]byte(key), "salsa20-encryption")
+	derivedKey, err := hkdf.Key(sha256.New, []byte(key), nil, keyDerivationInfo, chacha20poly1305.KeySize)
+	if err != nil {
+		// hkdf.Key only errors when keyLength exceeds 255 times the hash size.
+		panic(fmt.Sprintf("hkdf.Key: unexpected error: %v", err))
+	}
+	defer clear(derivedKey)
 
 	var result [32]byte
-	copy(result[:], b)
+	copy(result[:], derivedKey)
 
 	return &result
 }
 
-// deriveHKDFKey derives a 32-byte key using HKDF-SHA256 with the given secret and info string.
-func deriveHKDFKey(secret []byte, info string) []byte {
-	key, err := hkdf.Key(sha256.New, secret, nil, info, derivedKeySize)
-	if err != nil {
-		// hkdf.Key only errors when keyLength > 255*hashLen (where hashLen=32 for SHA-256); 32 bytes is always safe.
-		panic(fmt.Sprintf("hkdf.Key: unexpected error: %v", err))
-	}
-
-	return key
-}
-
-// EncryptBytes encrypts data using Salsa20 + HMAC-SHA256 (Encrypt-then-MAC).
-// Salsa20 provides stream cipher encryption with minimal overhead (8-byte nonce),
-// and HMAC-SHA256 provides authentication and tamper detection.
+// EncryptBytes encrypts and authenticates data using XChaCha20-Poly1305.
 func (c *Cipher) EncryptBytes(plainText []byte) ([]byte, error) {
-	macHash := c.getMAC()
-	defer c.putMAC(macHash)
-
-	return c.encryptBytesInto(nil, plainText, macHash)
+	return c.encryptBytesInto(nil, plainText)
 }
 
 // DecryptBytes decrypts data encrypted with EncryptBytes.
-// Verifies HMAC-SHA256 tag before decryption to ensure data integrity (Encrypt-then-MAC).
 func (c *Cipher) DecryptBytes(encryptedData []byte) ([]byte, error) {
-	// Minimum size: nonce (8) + optional ciphertext (0+) + HMAC tag (16)
-	if len(encryptedData) < salsa20NonceSize+hmacTagSize {
+	if len(encryptedData) < chacha20poly1305.NonceSizeX+chacha20poly1305.Overhead {
 		return nil, ErrCipherTextBlockSize
 	}
 
 	return c.decryptBytesInto(nil, encryptedData)
 }
 
-// EncryptBytesWithTime prefixes plaintext with the current Unix timestamp, encrypts it, and returns raw URL-base64 bytes.
+// EncryptBytesWithTime prefixes plaintext with the current Unix timestamp,
+// encrypts it, and returns raw URL-base64 bytes.
 func (c *Cipher) EncryptBytesWithTime(plainText []byte) ([]byte, error) {
-	macHash := c.getMAC()
-	defer c.putMAC(macHash)
+	scratch := c.getScratch()
+	defer c.putScratch(scratch)
 
-	encrypted, err := c.encryptTimedBytes(plainText, macHash)
+	encrypted, err := c.encryptTimedBytes(scratch.encrypted[:0], plainText)
 	if err != nil {
 		return nil, err
 	}
@@ -153,10 +127,10 @@ func (c *Cipher) EncryptBytesWithTime(plainText []byte) ([]byte, error) {
 // EncryptStringWithTime prefixes plaintext with the current Unix timestamp,
 // encrypts it, and returns a raw URL-base64 string.
 func (c *Cipher) EncryptStringWithTime(plainText []byte) (string, error) {
-	macHash := c.getMAC()
-	defer c.putMAC(macHash)
+	scratch := c.getScratch()
+	defer c.putScratch(scratch)
 
-	encrypted, err := c.encryptTimedBytes(plainText, macHash)
+	encrypted, err := c.encryptTimedBytes(scratch.encrypted[:0], plainText)
 	if err != nil {
 		return "", err
 	}
@@ -208,14 +182,14 @@ func (c *Cipher) DecryptStringWithTimeInto(dst []byte, encryptedBase64 string) (
 		return decodedLen, io.ErrShortBuffer
 	}
 
-	macHash := c.getMAC()
-	defer c.putMAC(macHash)
+	scratch := c.getScratch()
+	defer c.putScratch(scratch)
 
 	var encrypted []byte
-	if decodedLen > cap(macHash.encrypted) {
+	if decodedLen > cap(scratch.encrypted) {
 		encrypted = make([]byte, decodedLen)
 	} else {
-		encrypted = macHash.encrypted[:decodedLen]
+		encrypted = scratch.encrypted[:decodedLen]
 	}
 
 	decodedLen, err := base64.RawURLEncoding.Decode(encrypted, []byte(encryptedBase64))
@@ -223,7 +197,7 @@ func (c *Cipher) DecryptStringWithTimeInto(dst []byte, encryptedBase64 string) (
 		return 0, fmt.Errorf("base64 decode %q: %w", encryptedBase64, err)
 	}
 
-	plainText, err := c.decryptTimedPayloadWithMAC(encrypted[:decodedLen], macHash)
+	plainText, err := c.decryptTimedPayload(encrypted[:decodedLen])
 	if err != nil {
 		return 0, err
 	}
@@ -231,9 +205,8 @@ func (c *Cipher) DecryptStringWithTimeInto(dst []byte, encryptedBase64 string) (
 	return copy(dst, plainText), nil
 }
 
-// encryptTimedBytes prefixes plaintext with a timestamp and encrypts it into pooled scratch.
-// The returned bytes are valid only until macHash is returned to the pool.
-func (c *Cipher) encryptTimedBytes(plainText []byte, macHash *pooledMAC) ([]byte, error) {
+// encryptTimedBytes prefixes plaintext with a timestamp and encrypts it into dst.
+func (c *Cipher) encryptTimedBytes(dst, plainText []byte) ([]byte, error) {
 	issued := time.Now().Round(time.Second).Unix()
 
 	var scratch [timedPlainTextScratchSize]byte
@@ -242,7 +215,7 @@ func (c *Cipher) encryptTimedBytes(plainText []byte, macHash *pooledMAC) ([]byte
 	timedPlainText = append(timedPlainText, ' ')
 	timedPlainText = append(timedPlainText, plainText...)
 
-	return c.encryptBytesInto(macHash.encrypted[:0], timedPlainText, macHash)
+	return c.encryptBytesInto(dst, timedPlainText)
 }
 
 func encodeRawURLBase64String(src []byte) string {
@@ -266,64 +239,35 @@ func encodeRawURLBase64String(src []byte) string {
 }
 
 // encryptBytesInto encrypts plainText into dst, allocating only when its capacity is insufficient.
-func (c *Cipher) encryptBytesInto(dst, plainText []byte, macHash *pooledMAC) ([]byte, error) {
-	resultSize := salsa20NonceSize + len(plainText) + hmacTagSize
+func (c *Cipher) encryptBytesInto(dst, plainText []byte) ([]byte, error) {
+	resultSize := chacha20poly1305.NonceSizeX + len(plainText) + chacha20poly1305.Overhead
 
 	var result []byte
 	if cap(dst) < resultSize {
-		result = make([]byte, resultSize)
+		result = make([]byte, chacha20poly1305.NonceSizeX, resultSize)
 	} else {
-		result = dst[:resultSize]
+		result = dst[:chacha20poly1305.NonceSizeX]
 	}
 
-	nonce := result[:salsa20NonceSize]
+	nonce := result[:chacha20poly1305.NonceSizeX]
 
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("failed to generate nonce: %w", err)
 	}
 
-	cipherText := result[salsa20NonceSize : len(result)-hmacTagSize]
-	salsa20.XORKeyStream(cipherText, plainText, nonce, c.encKey)
-
-	macHash.Write(nonce)
-	macHash.Write(cipherText)
-
-	tag := macHash.Sum(macHash.sum[:0])
-	copy(result[len(result)-hmacTagSize:], tag[:hmacTagSize])
-
-	return result, nil
+	return c.aead.Seal(result, nonce, plainText, nil), nil
 }
 
 // decryptBytesInto authenticates encryptedData and decrypts it into dst.
 // Callers must reject ciphertext shorter than the nonce and authentication tag.
 func (c *Cipher) decryptBytesInto(dst, encryptedData []byte) ([]byte, error) {
-	macHash := c.getMAC()
-	defer c.putMAC(macHash)
+	nonce := encryptedData[:chacha20poly1305.NonceSizeX]
+	cipherText := encryptedData[chacha20poly1305.NonceSizeX:]
 
-	return c.decryptBytesWithMACInto(dst, encryptedData, macHash)
-}
-
-func (c *Cipher) decryptBytesWithMACInto(dst, encryptedData []byte, macHash *pooledMAC) ([]byte, error) {
-	nonce := encryptedData[:salsa20NonceSize]
-	cipherText := encryptedData[salsa20NonceSize : len(encryptedData)-hmacTagSize]
-	tag := encryptedData[len(encryptedData)-hmacTagSize:]
-
-	macHash.Write(nonce)
-	macHash.Write(cipherText)
-
-	expectedTag := macHash.Sum(macHash.sum[:0])
-	if !hmac.Equal(tag, expectedTag[:hmacTagSize]) {
-		return nil, ErrHMACVerificationFailed
+	plainText, err := c.aead.Open(dst, nonce, cipherText, nil)
+	if err != nil {
+		return nil, ErrAuthenticationFailed
 	}
-
-	var plainText []byte
-	if dst == nil || cap(dst) < len(cipherText) {
-		plainText = make([]byte, len(cipherText))
-	} else {
-		plainText = dst[:len(cipherText):len(cipherText)]
-	}
-
-	salsa20.XORKeyStream(plainText, cipherText, nonce, c.encKey)
 
 	return plainText, nil
 }
@@ -331,18 +275,14 @@ func (c *Cipher) decryptBytesWithMACInto(dst, encryptedData []byte, macHash *poo
 // decryptTimedPayload authenticates, decrypts, and validates
 // an already base64-decoded timestamped payload.
 func (c *Cipher) decryptTimedPayload(encrypted []byte) ([]byte, error) {
-	macHash := c.getMAC()
-	defer c.putMAC(macHash)
-
-	return c.decryptTimedPayloadWithMAC(encrypted, macHash)
-}
-
-func (c *Cipher) decryptTimedPayloadWithMAC(encrypted []byte, macHash *pooledMAC) ([]byte, error) {
-	if len(encrypted) < salsa20NonceSize+hmacTagSize {
+	if len(encrypted) < chacha20poly1305.NonceSizeX+chacha20poly1305.Overhead {
 		return nil, ErrCipherTextBlockSize
 	}
 
-	data, err := c.decryptBytesWithMACInto(encrypted[salsa20NonceSize:salsa20NonceSize], encrypted, macHash)
+	data, err := c.decryptBytesInto(
+		encrypted[chacha20poly1305.NonceSizeX:chacha20poly1305.NonceSizeX],
+		encrypted,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -359,24 +299,20 @@ func (c *Cipher) decryptTimedPayloadWithMAC(encrypted []byte, macHash *pooledMAC
 	return data, nil
 }
 
-// getMAC returns a reset HMAC-SHA256 instance from the cipher-local pool.
-func (c *Cipher) getMAC() *pooledMAC {
-	macHash, ok := c.macPool.Get().(*pooledMAC)
+// getScratch returns reusable scratch for timed encryption and decryption.
+func (c *Cipher) getScratch() *pooledScratch {
+	scratch, ok := c.scratchPool.Get().(*pooledScratch)
 	if !ok {
-		return &pooledMAC{
-			Hash: hmac.New(sha256.New, c.macKey),
-		}
+		return new(pooledScratch)
 	}
 
-	return macHash
+	return scratch
 }
 
-// putMAC resets and returns an HMAC-SHA256 instance to the cipher-local pool.
-func (c *Cipher) putMAC(macHash *pooledMAC) {
-	macHash.Reset()
-	// In-place decryption may leave OAuth state plaintext in the pooled scratch.
-	clear(macHash.encrypted[:])
-	c.macPool.Put(macHash)
+// putScratch clears plaintext before returning scratch to the pool.
+func (c *Cipher) putScratch(scratch *pooledScratch) {
+	clear(scratch.encrypted[:])
+	c.scratchPool.Put(scratch)
 }
 
 // checkTokenSize rejects unreasonably large encoded payloads before allocating decode buffers.

--- a/internal/crypto/crypto_internal_test.go
+++ b/internal/crypto/crypto_internal_test.go
@@ -2,19 +2,19 @@ package crypto
 
 import "testing"
 
-func TestPutMACClearsEncryptedScratch(t *testing.T) {
+func TestPutScratchClearsEncryptedScratch(t *testing.T) {
 	t.Parallel()
 
 	cipher := New("test-key")
-	macHash := cipher.getMAC()
+	scratch := cipher.getScratch()
 
-	for index := range macHash.encrypted {
-		macHash.encrypted[index] = 0xff
+	for index := range scratch.encrypted {
+		scratch.encrypted[index] = 0xff
 	}
 
-	cipher.putMAC(macHash)
+	cipher.putScratch(scratch)
 
-	for index, value := range macHash.encrypted {
+	for index, value := range scratch.encrypted {
 		if value != 0 {
 			t.Fatalf("encrypted scratch byte %d was not cleared", index)
 		}

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/crypto"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 func TestDeriveKey(t *testing.T) {
@@ -90,12 +91,21 @@ func TestEncryptBytesBasic(t *testing.T) {
 	encrypted, err := cipher.EncryptBytes(plainText)
 	require.NoError(t, err, "EncryptBytes failed")
 
-	// Check that encrypted data is longer than plaintext (nonce + tag overhead)
-	require.Greater(t, len(encrypted), len(plainText), "encrypted data should be longer than plaintext")
+	expectedSize := chacha20poly1305.NonceSizeX + len(plainText) + chacha20poly1305.Overhead
+	require.Len(t, encrypted, expectedSize)
 
-	// Minimum size: nonce (8) + ciphertext (at least 1) + HMAC tag (16)
-	expectedMinSize := 8 + 1 + 16
-	require.GreaterOrEqual(t, len(encrypted), expectedMinSize, "encrypted data is too short")
+	key := crypto.DeriveKey("test-key")
+	aead, err := chacha20poly1305.NewX(key[:])
+	require.NoError(t, err)
+
+	decrypted, err := aead.Open(
+		nil,
+		encrypted[:chacha20poly1305.NonceSizeX],
+		encrypted[chacha20poly1305.NonceSizeX:],
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, plainText, decrypted)
 }
 
 func TestEncryptBytesEmpty(t *testing.T) {
@@ -107,8 +117,7 @@ func TestEncryptBytesEmpty(t *testing.T) {
 	encrypted, err := cipher.EncryptBytes(plainText)
 	require.NoError(t, err, "EncryptBytes failed")
 
-	// Empty plaintext produces: nonce (8 bytes) + empty ciphertext (0 bytes) + HMAC tag (16 bytes) = 24 bytes
-	expectedSize := 8 + 16
+	expectedSize := chacha20poly1305.NonceSizeX + chacha20poly1305.Overhead
 	require.Len(t, encrypted, expectedSize)
 }
 
@@ -154,13 +163,10 @@ func TestDecryptBytesTampered(t *testing.T) {
 	encrypted, err := cipher.EncryptBytes(plainText)
 	require.NoError(t, err, "EncryptBytes failed")
 
-	// Tamper with the encrypted data (modify one byte in the middle)
-	if len(encrypted) > 8+1 {
-		encrypted[8] ^= 0xFF
-	}
+	encrypted[chacha20poly1305.NonceSizeX] ^= 0xFF
 
 	_, err = cipher.DecryptBytes(encrypted)
-	require.Equal(t, crypto.ErrHMACVerificationFailed, err, "expected ErrHMACVerificationFailed for tampered data")
+	require.ErrorIs(t, err, crypto.ErrAuthenticationFailed)
 }
 
 func TestDecryptBytesWrongKey(t *testing.T) {
@@ -176,7 +182,7 @@ func TestDecryptBytesWrongKey(t *testing.T) {
 
 	// Try to decrypt with different key
 	_, err = cipher2.DecryptBytes(encrypted)
-	require.Equal(t, crypto.ErrHMACVerificationFailed, err, "expected ErrHMACVerificationFailed when decrypting with wrong key")
+	require.ErrorIs(t, err, crypto.ErrAuthenticationFailed)
 }
 
 func TestDecryptBytesShortData(t *testing.T) {
@@ -188,11 +194,14 @@ func TestDecryptBytesShortData(t *testing.T) {
 		name string
 		data []byte
 	}{
-		{"empty", []byte("")},
-		{"too short", []byte("short")},
-		{"just nonce size", make([]byte, 8)},
-		{"nonce + 1 byte", make([]byte, 8+1)},
-		{"nonce + tag - 1 byte", make([]byte, 8+16-1)},
+		{name: "empty", data: []byte("")},
+		{name: "too short", data: []byte("short")},
+		{name: "just nonce size", data: make([]byte, chacha20poly1305.NonceSizeX)},
+		{name: "nonce + 1 byte", data: make([]byte, chacha20poly1305.NonceSizeX+1)},
+		{
+			name: "nonce + tag - 1 byte",
+			data: make([]byte, chacha20poly1305.NonceSizeX+chacha20poly1305.Overhead-1),
+		},
 	}
 
 	for _, tt := range tests {
@@ -200,7 +209,7 @@ func TestDecryptBytesShortData(t *testing.T) {
 			t.Parallel()
 
 			_, err := cipher.DecryptBytes(tt.data)
-			require.Equal(t, crypto.ErrCipherTextBlockSize, err, "expected ErrCipherTextBlockSize")
+			require.ErrorIs(t, err, crypto.ErrCipherTextBlockSize)
 		})
 	}
 }

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -2,6 +2,8 @@ package crypto_test
 
 import (
 	"bytes"
+	"crypto/aes"
+	stdcipher "crypto/cipher"
 	"encoding/base64"
 	"io"
 	"strconv"
@@ -11,7 +13,12 @@ import (
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/crypto"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/chacha20poly1305"
+)
+
+const (
+	aesGCMNonceSize = 12
+	aesGCMTagSize   = 16
+	aesGCMOverhead  = aesGCMNonceSize + aesGCMTagSize
 )
 
 func TestDeriveKey(t *testing.T) {
@@ -91,19 +98,16 @@ func TestEncryptBytesBasic(t *testing.T) {
 	encrypted, err := cipher.EncryptBytes(plainText)
 	require.NoError(t, err, "EncryptBytes failed")
 
-	expectedSize := chacha20poly1305.NonceSizeX + len(plainText) + chacha20poly1305.Overhead
+	expectedSize := len(plainText) + aesGCMOverhead
 	require.Len(t, encrypted, expectedSize)
 
 	key := crypto.DeriveKey("test-key")
-	aead, err := chacha20poly1305.NewX(key[:])
+	block, err := aes.NewCipher(key[:])
+	require.NoError(t, err)
+	aead, err := stdcipher.NewGCMWithRandomNonce(block)
 	require.NoError(t, err)
 
-	decrypted, err := aead.Open(
-		nil,
-		encrypted[:chacha20poly1305.NonceSizeX],
-		encrypted[chacha20poly1305.NonceSizeX:],
-		nil,
-	)
+	decrypted, err := aead.Open(nil, nil, encrypted, nil)
 	require.NoError(t, err)
 	require.Equal(t, plainText, decrypted)
 }
@@ -117,8 +121,7 @@ func TestEncryptBytesEmpty(t *testing.T) {
 	encrypted, err := cipher.EncryptBytes(plainText)
 	require.NoError(t, err, "EncryptBytes failed")
 
-	expectedSize := chacha20poly1305.NonceSizeX + chacha20poly1305.Overhead
-	require.Len(t, encrypted, expectedSize)
+	require.Len(t, encrypted, aesGCMOverhead)
 }
 
 func TestEncryptBytesRandomNonce(t *testing.T) {
@@ -163,7 +166,7 @@ func TestDecryptBytesTampered(t *testing.T) {
 	encrypted, err := cipher.EncryptBytes(plainText)
 	require.NoError(t, err, "EncryptBytes failed")
 
-	encrypted[chacha20poly1305.NonceSizeX] ^= 0xFF
+	encrypted[len(encrypted)/2] ^= 0xFF
 
 	_, err = cipher.DecryptBytes(encrypted)
 	require.ErrorIs(t, err, crypto.ErrAuthenticationFailed)
@@ -196,11 +199,11 @@ func TestDecryptBytesShortData(t *testing.T) {
 	}{
 		{name: "empty", data: []byte("")},
 		{name: "too short", data: []byte("short")},
-		{name: "just nonce size", data: make([]byte, chacha20poly1305.NonceSizeX)},
-		{name: "nonce + 1 byte", data: make([]byte, chacha20poly1305.NonceSizeX+1)},
+		{name: "just nonce size", data: make([]byte, aesGCMNonceSize)},
+		{name: "nonce + 1 byte", data: make([]byte, aesGCMNonceSize+1)},
 		{
 			name: "nonce + tag - 1 byte",
-			data: make([]byte, chacha20poly1305.NonceSizeX+chacha20poly1305.Overhead-1),
+			data: make([]byte, aesGCMOverhead-1),
 		},
 	}
 

--- a/internal/crypto/doc.go
+++ b/internal/crypto/doc.go
@@ -1,15 +1,15 @@
 // Package crypto provides compact authenticated encryption for values that are
 // sent through OpenVPN clients and later accepted back by the server.
 //
-// The package uses XChaCha20-Poly1305 authenticated encryption. The serialized
+// The package uses AES-256-GCM authenticated encryption. The serialized
 // ciphertext layout is:
 //
-//	24-byte random nonce || ciphertext || 16-byte Poly1305 tag
+//	12-byte random nonce || ciphertext || 16-byte GCM tag
 //
-// The wide random nonce makes accidental reuse impractical. Authentication is
-// verified before plaintext is returned, so modified client-controlled data is
-// rejected before it is interpreted. The AEAD key is derived from the configured
-// secret with HKDF-SHA256.
+// Go generates and prepends a fresh random nonce for each encryption.
+// Authentication is verified before plaintext is returned, so modified
+// client-controlled data is rejected before it is interpreted. The AEAD key is
+// derived from the configured secret with HKDF-SHA256.
 //
 // EncryptBytesWithTime wraps the encrypted payload with an issued timestamp and
 // encodes the result using unpadded URL-safe base64. DecryptBytesWithTime and

--- a/internal/crypto/doc.go
+++ b/internal/crypto/doc.go
@@ -1,16 +1,15 @@
 // Package crypto provides compact authenticated encryption for values that are
 // sent through OpenVPN clients and later accepted back by the server.
 //
-// The package uses Salsa20 for encryption and HMAC-SHA256 for authentication in
-// an encrypt-then-MAC construction. The serialized ciphertext layout is:
+// The package uses XChaCha20-Poly1305 authenticated encryption. The serialized
+// ciphertext layout is:
 //
-//	8-byte random nonce || ciphertext || 16-byte truncated HMAC tag
+//	24-byte random nonce || ciphertext || 16-byte Poly1305 tag
 //
-// Salsa20 is used because it has a small nonce and does not expand the
-// plaintext. The HMAC is verified before decryption with constant-time
-// comparison, so modified client-controlled data is rejected before plaintext is
-// interpreted. Encryption and authentication keys are derived independently of
-// the configured secret with HKDF-SHA256 and different info strings.
+// The wide random nonce makes accidental reuse impractical. Authentication is
+// verified before plaintext is returned, so modified client-controlled data is
+// rejected before it is interpreted. The AEAD key is derived from the configured
+// secret with HKDF-SHA256.
 //
 // EncryptBytesWithTime wraps the encrypted payload with an issued timestamp and
 // encodes the result using unpadded URL-safe base64. DecryptBytesWithTime and

--- a/internal/openvpn/client_test.go
+++ b/internal/openvpn/client_test.go
@@ -76,12 +76,12 @@ func TestBuildClientPendingAuthCommand(t *testing.T) {
 func TestBuildClientPendingAuthCommandLimit(t *testing.T) {
 	t.Parallel()
 
-	client := connection.Client{CID: 1, KID: 0}
+	client := connection.Client{CID: 12345, KID: 0}
 
-	command, err := buildClientPendingAuthCommand(client, strings.Repeat("a", 983), 300*time.Second)
+	command, err := buildClientPendingAuthCommand(client, strings.Repeat("a", 979), 300*time.Second)
 	require.NoError(t, err)
 	require.Len(t, command, openVPNManagementCommandBodyLimit)
 
-	_, err = buildClientPendingAuthCommand(client, strings.Repeat("a", 984), 300*time.Second)
+	_, err = buildClientPendingAuthCommand(client, strings.Repeat("a", 980), 300*time.Second)
 	require.EqualError(t, err, "client-pending-auth command is 1024 bytes; OpenVPN accepts at most 1023 bytes")
 }

--- a/internal/state/doc.go
+++ b/internal/state/doc.go
@@ -14,7 +14,7 @@
 // the callback path. Encrypt therefore uses a versioned binary payload with
 // varint client identifiers, flag-controlled optional fields, compact
 // session-state codes, binary IP address fields, unpadded URL-safe base64, and
-// an XChaCha20-Poly1305 envelope. This keeps the command inside the OpenVPN
+// an AES-256-GCM envelope. This keeps the command inside the OpenVPN
 // management interface constraint while preserving integrity and expiry checks
 // for untrusted input.
 package state

--- a/internal/state/doc.go
+++ b/internal/state/doc.go
@@ -14,7 +14,7 @@
 // the callback path. Encrypt therefore uses a versioned binary payload with
 // varint client identifiers, flag-controlled optional fields, compact
 // session-state codes, binary IP address fields, unpadded URL-safe base64, and
-// a low-overhead Salsa20 plus HMAC envelope. The extra complexity keeps the
-// command inside the OpenVPN management interface constraint while preserving
-// integrity and expiry checks for untrusted input.
+// an XChaCha20-Poly1305 envelope. This keeps the command inside the OpenVPN
+// management interface constraint while preserving integrity and expiry checks
+// for untrusted input.
 package state

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -40,7 +40,7 @@ const (
 // thus preventing CSRF (Cross-Site Request Forgery) attacks. The `State` value is returned
 // by the OAuth2 Identity Provider (IDP) in the redirect URL.
 //
-// To prevent tampering, the State is protected using XChaCha20-Poly1305.
+// To prevent tampering, the State is protected using AES-256-GCM.
 type State struct {
 	IPAddr       string
 	IPPort       string

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -40,7 +40,7 @@ const (
 // thus preventing CSRF (Cross-Site Request Forgery) attacks. The `State` value is returned
 // by the OAuth2 Identity Provider (IDP) in the redirect URL.
 //
-// To prevent tampering, the `State` is protected using Salsa20 + HMAC encryption.
+// To prevent tampering, the State is protected using XChaCha20-Poly1305.
 type State struct {
 	IPAddr       string
 	IPPort       string
@@ -61,7 +61,7 @@ type ClientIdentifier struct {
 	UsernameIsDefined int    // 1 if username is defined, 0 otherwise
 }
 
-// Encrypt serializes the state into a compact binary, Salsa20-encrypted, base64-URL-safe string.
+// Encrypt serializes the state into a compact binary, authenticated, base64-URL-safe string.
 // The result is safe for use in URL parameters and has a ~1-second resolution timestamp.
 func Encrypt(cipher *crypto.Cipher, state State) (EncryptedState, error) {
 	if cipher == nil {

--- a/internal/tokenstorage/inmemory.go
+++ b/internal/tokenstorage/inmemory.go
@@ -70,7 +70,7 @@ func (s *InMemory) SetStorage(data DataMap) error {
 }
 
 // Set stores an encrypted token for a given client, with an expiration time.
-// The token is encrypted using Salsa20 before storage.
+// The token is encrypted using XChaCha20-Poly1305 before storage.
 func (s *InMemory) Set(_ context.Context, client, token string) error {
 	encryptedBytes, err := s.cipher.EncryptBytes([]byte(token))
 	if err != nil {

--- a/internal/tokenstorage/inmemory.go
+++ b/internal/tokenstorage/inmemory.go
@@ -70,7 +70,7 @@ func (s *InMemory) SetStorage(data DataMap) error {
 }
 
 // Set stores an encrypted token for a given client, with an expiration time.
-// The token is encrypted using XChaCha20-Poly1305 before storage.
+// The token is encrypted using AES-256-GCM before storage.
 func (s *InMemory) Set(_ context.Context, client, token string) error {
 	encryptedBytes, err := s.cipher.EncryptBytes([]byte(token))
 	if err != nil {

--- a/internal/tokenstorage/inmemory_test.go
+++ b/internal/tokenstorage/inmemory_test.go
@@ -133,7 +133,7 @@ func TestStorageInMemory_InvalidSecret(t *testing.T) {
 		require.NoError(t, tokenStorage.Close())
 	})
 
-	// Salsa20 with SHA256-derived keys accepts any key length.
+	// HKDF derives the fixed-size AEAD key from any input length.
 	// Test that encryption/decryption works even with short keys.
 	require.NoError(t, tokenStorage.Set(ctx, "0", "TEST0"))
 	token, err := tokenStorage.Get(ctx, "0")


### PR DESCRIPTION
## Summary

- replace the Salsa20 plus truncated HMAC envelope with standard-library AES-256-GCM
- use cipher.NewGCMWithRandomNonce for generated and prepended 96-bit nonces
- derive a dedicated 256-bit AEAD key with HKDF-SHA256 and clear temporary key and plaintext scratch material
- reduce envelope overhead from the proposed XChaCha format from 40 bytes to 28 bytes
- remove the direct golang.org/x/crypto dependency; it remains transitive
- condense agent guidance and test the five-digit CID command-size boundary

## Compatibility

This is a direct ciphertext-format cutover. OAuth state and profile-selector tokens created by an older process are rejected and affected users must retry authentication; these values remain active for at most five minutes. Refresh-token ciphertext is process-local and does not survive an executable restart.

Mixed old and new instances cannot decrypt newly issued ciphertext from one another during a rolling deployment. Each AES-GCM key must protect no more than 2^32 messages.

## Testing

- make fmt
- make lint
- make test
- make textlint
- git diff --check
- GOEXPERIMENT=cgocheck2 GODEBUG=fips140=only go test ./internal/crypto -run TestCipherConsistency -count=1