### PR TITLE
fix: return cipher initialization errors

### DIFF
--- a/cmd/openvpn-auth-oauth2/root.go
+++ b/cmd/openvpn-auth-oauth2/root.go
@@ -72,7 +72,13 @@ func run(ctx context.Context, args []string, stdout io.Writer, tokenDataStorage 
 		slog.String("config", conf.String()),
 	)
 
-	tokenStorage := tokenstorage.NewInMemory(conf.OAuth2.Refresh.Secret.String(), conf.OAuth2.Refresh.Expires)
+	tokenStorage, err := tokenstorage.NewInMemory(conf.OAuth2.Refresh.Secret.String(), conf.OAuth2.Refresh.Expires)
+	if err != nil {
+		logger.LogAttrs(ctx, slog.LevelError, "error creating token storage", slog.Any("err", err))
+
+		return ReturnCodeError
+	}
+
 	defer func() {
 		if err := tokenStorage.Close(); err != nil {
 			logger.LogAttrs(ctx, slog.LevelError, "error closing token storage", slog.Any("err", err))

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -51,24 +51,27 @@ type pooledScratch struct {
 // New creates a new Cipher instance with the given encryption key.
 // The AEAD key is derived from the input with HKDF-SHA256. The raw key string is
 // not retained in the Cipher after construction.
-func New(encryptionKey string) *Cipher {
+func New(encryptionKey string) (*Cipher, error) {
 	return NewWithMaxAge(encryptionKey, defaultMaxAge)
 }
 
 // NewWithMaxAge creates a new Cipher instance with the given encryption key and
 // maximum age for timestamped payloads.
-func NewWithMaxAge(encryptionKey string, maxAge time.Duration) *Cipher {
-	key := DeriveKey(encryptionKey)
+func NewWithMaxAge(encryptionKey string, maxAge time.Duration) (*Cipher, error) {
+	key, err := DeriveKey(encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("derive aes-256 key: %w", err)
+	}
 	defer clear(key[:])
 
 	block, err := aes.NewCipher(key[:])
 	if err != nil {
-		panic(fmt.Sprintf("aes.NewCipher: unexpected error: %v", err))
+		return nil, fmt.Errorf("create aes cipher: %w", err)
 	}
 
 	aead, err := cipher.NewGCMWithRandomNonce(block)
 	if err != nil {
-		panic(fmt.Sprintf("cipher.NewGCMWithRandomNonce: unexpected error: %v", err))
+		return nil, fmt.Errorf("create aes-gcm: %w", err)
 	}
 
 	result := &Cipher{
@@ -79,22 +82,21 @@ func NewWithMaxAge(encryptionKey string, maxAge time.Duration) *Cipher {
 		return new(pooledScratch)
 	}
 
-	return result
+	return result, nil
 }
 
 // DeriveKey derives a 32-byte AES-256 key using HKDF-SHA256.
-func DeriveKey(key string) *[32]byte {
+func DeriveKey(key string) (*[32]byte, error) {
 	derivedKey, err := hkdf.Key(sha256.New, []byte(key), nil, keyDerivationInfo, aes256KeySize)
 	if err != nil {
-		// hkdf.Key only errors when keyLength exceeds 255 times the hash size.
-		panic(fmt.Sprintf("hkdf.Key: unexpected error: %v", err))
+		return nil, fmt.Errorf("hkdf-sha256: %w", err)
 	}
 	defer clear(derivedKey)
 
 	var result [32]byte
 	copy(result[:], derivedKey)
 
-	return &result
+	return &result, nil
 }
 
 // EncryptBytes encrypts and authenticates data using AES-256-GCM.

--- a/internal/crypto/crypto_internal_test.go
+++ b/internal/crypto/crypto_internal_test.go
@@ -5,7 +5,11 @@ import "testing"
 func TestPutScratchClearsEncryptedScratch(t *testing.T) {
 	t.Parallel()
 
-	cipher := New("test-key")
+	cipher, err := New("test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	scratch := cipher.getScratch()
 
 	for index := range scratch.encrypted {

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -21,6 +21,15 @@ const (
 	aesGCMOverhead  = aesGCMNonceSize + aesGCMTagSize
 )
 
+func newCipher(tb testing.TB, key string) *crypto.Cipher {
+	tb.Helper()
+
+	cipher, err := crypto.New(key)
+	require.NoError(tb, err)
+
+	return cipher
+}
+
 func TestDeriveKey(t *testing.T) {
 	t.Parallel()
 
@@ -50,13 +59,15 @@ func TestDeriveKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			derivedKey := crypto.DeriveKey(tc.key)
+			derivedKey, err := crypto.DeriveKey(tc.key)
+			require.NoError(t, err)
 
 			// Check that the result is a 32-byte array
 			require.Len(t, derivedKey[:], 32, "expected key length 32")
 
 			// Check that the same key produces the same result
-			derivedKey2 := crypto.DeriveKey(tc.key)
+			derivedKey2, err := crypto.DeriveKey(tc.key)
+			require.NoError(t, err)
 			require.True(t, bytes.Equal(derivedKey[:], derivedKey2[:]), "DeriveKey is not deterministic")
 		})
 	}
@@ -65,8 +76,10 @@ func TestDeriveKey(t *testing.T) {
 func TestDeriveKeyDifferentInputs(t *testing.T) {
 	t.Parallel()
 
-	key1 := crypto.DeriveKey("key1")
-	key2 := crypto.DeriveKey("key2")
+	key1, err := crypto.DeriveKey("key1")
+	require.NoError(t, err)
+	key2, err := crypto.DeriveKey("key2")
+	require.NoError(t, err)
 
 	// Different inputs should produce different keys
 	require.False(t, bytes.Equal(key1[:], key2[:]), "different keys should produce different derived keys")
@@ -76,7 +89,8 @@ func TestNewCipher(t *testing.T) {
 	t.Parallel()
 
 	encryptionKey := "test-key"
-	cipher := crypto.New(encryptionKey)
+	cipher, err := crypto.New(encryptionKey)
+	require.NoError(t, err)
 
 	require.NotNil(t, cipher, "expected cipher to be non-nil")
 
@@ -92,7 +106,7 @@ func TestNewCipher(t *testing.T) {
 func TestEncryptBytesBasic(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 	plainText := []byte("hello world")
 
 	encrypted, err := cipher.EncryptBytes(plainText)
@@ -101,7 +115,8 @@ func TestEncryptBytesBasic(t *testing.T) {
 	expectedSize := len(plainText) + aesGCMOverhead
 	require.Len(t, encrypted, expectedSize)
 
-	key := crypto.DeriveKey("test-key")
+	key, err := crypto.DeriveKey("test-key")
+	require.NoError(t, err)
 	block, err := aes.NewCipher(key[:])
 	require.NoError(t, err)
 	aead, err := stdcipher.NewGCMWithRandomNonce(block)
@@ -115,7 +130,7 @@ func TestEncryptBytesBasic(t *testing.T) {
 func TestEncryptBytesEmpty(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 	plainText := []byte("")
 
 	encrypted, err := cipher.EncryptBytes(plainText)
@@ -127,7 +142,7 @@ func TestEncryptBytesEmpty(t *testing.T) {
 func TestEncryptBytesRandomNonce(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 	plainText := []byte("same plaintext")
 
 	encrypted1, err1 := cipher.EncryptBytes(plainText)
@@ -143,7 +158,7 @@ func TestEncryptBytesRandomNonce(t *testing.T) {
 func TestDecryptBytesBasic(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 	plainText := []byte("hello world")
 
 	encrypted, err := cipher.EncryptBytes(plainText)
@@ -160,7 +175,7 @@ func TestDecryptBytesBasic(t *testing.T) {
 func TestDecryptBytesTampered(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 	plainText := []byte("hello world")
 
 	encrypted, err := cipher.EncryptBytes(plainText)
@@ -175,8 +190,8 @@ func TestDecryptBytesTampered(t *testing.T) {
 func TestDecryptBytesWrongKey(t *testing.T) {
 	t.Parallel()
 
-	cipher1 := crypto.New("key1")
-	cipher2 := crypto.New("key2")
+	cipher1 := newCipher(t, "key1")
+	cipher2 := newCipher(t, "key2")
 
 	plainText := []byte("secret message")
 
@@ -191,7 +206,7 @@ func TestDecryptBytesWrongKey(t *testing.T) {
 func TestDecryptBytesShortData(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 
 	tests := []struct {
 		name string
@@ -220,7 +235,7 @@ func TestDecryptBytesShortData(t *testing.T) {
 func TestRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("my-secret-key")
+	cipher := newCipher(t, "my-secret-key")
 
 	testCases := []struct {
 		name      string
@@ -261,7 +276,7 @@ func TestEncryptBytesWithTimeUsesRawURLBase64(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cipher := crypto.New("test-key")
+			cipher := newCipher(t, "test-key")
 
 			encrypted, err := cipher.EncryptBytesWithTime(tc.plainText)
 			require.NoError(t, err)
@@ -288,7 +303,7 @@ func TestEncryptStringWithTimeUsesRawURLBase64(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cipher := crypto.New("test-key")
+			cipher := newCipher(t, "test-key")
 
 			encrypted, err := cipher.EncryptStringWithTime(tc.plainText)
 			require.NoError(t, err)
@@ -310,16 +325,19 @@ func TestDecryptBytesWithTimeMaxAge(t *testing.T) {
 	issued := time.Now().Add(-3 * time.Minute).Unix()
 	plainText := strconv.AppendInt(nil, issued, 10)
 	plainText = append(plainText, " payload"...)
-	encrypted, err := crypto.New(key).EncryptBytes(plainText)
+	cipher := newCipher(t, key)
+	encrypted, err := cipher.EncryptBytes(plainText)
 	require.NoError(t, err)
 
 	encoded := make([]byte, base64.RawURLEncoding.EncodedLen(len(encrypted)))
 	base64.RawURLEncoding.Encode(encoded, encrypted)
 
-	_, err = crypto.New(key).DecryptBytesWithTime(encoded)
+	_, err = cipher.DecryptBytesWithTime(encoded)
 	require.ErrorContains(t, err, "expired after 2m0s")
 
-	decrypted, err := crypto.NewWithMaxAge(key, 4*time.Minute).DecryptBytesWithTime(encoded)
+	longLivedCipher, err := crypto.NewWithMaxAge(key, 4*time.Minute)
+	require.NoError(t, err)
+	decrypted, err := longLivedCipher.DecryptBytesWithTime(encoded)
 	require.NoError(t, err)
 	require.Equal(t, []byte("payload"), decrypted)
 }
@@ -327,7 +345,7 @@ func TestDecryptBytesWithTimeMaxAge(t *testing.T) {
 func TestDecryptStringWithTime(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 
 	encrypted, err := cipher.EncryptBytesWithTime([]byte("hello world"))
 	require.NoError(t, err)
@@ -340,7 +358,7 @@ func TestDecryptStringWithTime(t *testing.T) {
 func TestDecryptStringWithTimeInto(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 
 	encrypted, err := cipher.EncryptStringWithTime([]byte("hello world"))
 	require.NoError(t, err)
@@ -361,8 +379,8 @@ func TestCipherConsistency(t *testing.T) {
 
 	// Two ciphers with the same key should decrypt each other's output
 	key := "consistent-key"
-	cipher1 := crypto.New(key)
-	cipher2 := crypto.New(key)
+	cipher1 := newCipher(t, key)
+	cipher2 := newCipher(t, key)
 
 	plainText := []byte("consistency test")
 
@@ -377,7 +395,7 @@ func TestCipherConsistency(t *testing.T) {
 func TestMultipleEncryptionRounds(t *testing.T) {
 	t.Parallel()
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 	plainTexts := [][]byte{
 		[]byte("first message"),
 		[]byte("second message"),
@@ -399,7 +417,7 @@ func TestCipherConcurrentUse(t *testing.T) {
 
 	const workerCount = 16
 
-	cipher := crypto.New("test-key")
+	cipher := newCipher(t, "test-key")
 	plainText := []byte("concurrent message")
 
 	var wg sync.WaitGroup
@@ -439,7 +457,9 @@ func BenchmarkDeriveKey(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		crypto.DeriveKey(key)
+		if _, err := crypto.DeriveKey(key); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -449,12 +469,14 @@ func BenchmarkNewCipher(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		crypto.New(key)
+		if _, err := crypto.New(key); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
 func BenchmarkEncryptBytes(b *testing.B) {
-	cipher := crypto.New("benchmark-key")
+	cipher := newCipher(b, "benchmark-key")
 	plainText := []byte("benchmark plaintext")
 
 	b.ResetTimer()
@@ -465,7 +487,7 @@ func BenchmarkEncryptBytes(b *testing.B) {
 }
 
 func BenchmarkDecryptBytes(b *testing.B) {
-	cipher := crypto.New("benchmark-key")
+	cipher := newCipher(b, "benchmark-key")
 	plainText := []byte("benchmark plaintext")
 	encrypted, _ := cipher.EncryptBytes(plainText)
 
@@ -477,7 +499,7 @@ func BenchmarkDecryptBytes(b *testing.B) {
 }
 
 func BenchmarkRoundTrip(b *testing.B) {
-	cipher := crypto.New("benchmark-key")
+	cipher := newCipher(b, "benchmark-key")
 	plainText := []byte("benchmark plaintext")
 
 	b.ResetTimer()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -71,7 +71,11 @@ func setupOpenVPNClient(
 	}
 
 	openvpnClient := openvpn.New(logger, conf)
-	stateCrypto := crypto.NewWithMaxAge(conf.HTTP.Secret.String(), conf.OpenVPN.AuthPendingTimeout)
+
+	stateCrypto, err := crypto.NewWithMaxAge(conf.HTTP.Secret.String(), conf.OpenVPN.AuthPendingTimeout)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create state cipher: %w", err)
+	}
 
 	oAuth2Client, err := oauth2.New(ctx, logger, conf, httpClient, tokenStorage, stateCrypto, provider, openvpnClient)
 	if err != nil {

--- a/internal/httphandler/handler_test.go
+++ b/internal/httphandler/handler_test.go
@@ -32,7 +32,18 @@ func TestAssets(t *testing.T) {
 	provider, err := generic.NewProvider(t.Context(), &conf, http.DefaultClient)
 	require.NoError(t, err)
 
-	oAuth2Client, err := oauth2.New(t.Context(), logger.Logger(), &conf, http.DefaultClient, testsuite.NewFakeStorage(), crypto.New(conf.HTTP.Secret.String()), provider, testsuite.NewFakeOpenVPNClient())
+	stateCrypto, err := crypto.New(conf.HTTP.Secret.String())
+	require.NoError(t, err)
+	oAuth2Client, err := oauth2.New(
+		t.Context(),
+		logger.Logger(),
+		&conf,
+		http.DefaultClient,
+		testsuite.NewFakeStorage(),
+		stateCrypto,
+		provider,
+		testsuite.NewFakeOpenVPNClient(),
+	)
 	require.NoError(t, err)
 
 	handler := httphandler.New(&conf, oAuth2Client)
@@ -58,7 +69,18 @@ func TestCustomAssets(t *testing.T) {
 	provider, err := generic.NewProvider(t.Context(), &conf, http.DefaultClient)
 	require.NoError(t, err)
 
-	oAuth2Client, err := oauth2.New(t.Context(), logger.Logger(), &conf, http.DefaultClient, testsuite.NewFakeStorage(), crypto.New(conf.HTTP.Secret.String()), provider, testsuite.NewFakeOpenVPNClient())
+	stateCrypto, err := crypto.New(conf.HTTP.Secret.String())
+	require.NoError(t, err)
+	oAuth2Client, err := oauth2.New(
+		t.Context(),
+		logger.Logger(),
+		&conf,
+		http.DefaultClient,
+		testsuite.NewFakeStorage(),
+		stateCrypto,
+		provider,
+		testsuite.NewFakeOpenVPNClient(),
+	)
 	require.NoError(t, err)
 
 	conf.HTTP.AssetPath = types.FS{

--- a/internal/oauth2/cel_test.go
+++ b/internal/oauth2/cel_test.go
@@ -289,7 +289,16 @@ func TestCheckIdentityCEL(t *testing.T) {
 			provider, err := generic.NewProvider(t.Context(), &tc.conf, http.DefaultClient)
 			require.NoError(t, err)
 
-			oAuth2Client, err := oauth2.New(t.Context(), slog.New(slog.DiscardHandler), &tc.conf, http.DefaultClient, testsuite.NewFakeStorage(), testsuite.Cipher, provider, testsuite.NewFakeOpenVPNClient())
+			oAuth2Client, err := oauth2.New(
+				t.Context(),
+				slog.New(slog.DiscardHandler),
+				&tc.conf,
+				http.DefaultClient,
+				testsuite.NewFakeStorage(),
+				testsuite.NewCipher(t),
+				provider,
+				testsuite.NewFakeOpenVPNClient(),
+			)
 			if tc.initErr != "" {
 				require.ErrorContains(t, err, tc.initErr)
 

--- a/internal/oauth2/handler_accept_test.go
+++ b/internal/oauth2/handler_accept_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
@@ -24,7 +23,7 @@ func TestAcceptOAuth2ClientDoesNotStoreRefreshStateOnAcceptError(t *testing.T) {
 	conf.OAuth2.Refresh.Enabled = true
 	conf.OAuth2.Refresh.ValidateUser = false
 
-	storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+	storage := newInMemoryStorage(t)
 	client := Client{
 		conf:    &conf,
 		openvpn: failingOpenVPNClient{},

--- a/internal/oauth2/handler_internal_test.go
+++ b/internal/oauth2/handler_internal_test.go
@@ -20,6 +20,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newStateCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+
+	cipher, err := crypto.New("1234567890123456")
+	require.NoError(t, err)
+
+	return cipher
+}
+
+func newInMemoryStorage(t *testing.T) *tokenstorage.InMemory {
+	t.Helper()
+
+	storage, err := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+	require.NoError(t, err)
+
+	return storage
+}
+
 func TestWithIDTokenClaimsLoggerOmitsUnrestrictedClaims(t *testing.T) {
 	t.Parallel()
 
@@ -73,12 +91,8 @@ func TestHandleClientConfigSelectorDeniesClientOnRenderError(t *testing.T) {
 				conf:        &conf,
 				logger:      slog.New(slog.DiscardHandler),
 				openvpn:     openVPNClient,
-				stateCrypto: crypto.New("1234567890123456"),
-				storage: tokenstorage.NewInMemoryWithGC(
-					"1234567890123456",
-					time.Hour,
-					0,
-				),
+				stateCrypto: newStateCipher(t),
+				storage:     newInMemoryStorage(t),
 			}
 			session := state.State{Client: state.ClientIdentifier{CID: 1, KID: 2}}
 

--- a/internal/oauth2/handler_profile_refresh_test.go
+++ b/internal/oauth2/handler_profile_refresh_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/state"
@@ -25,7 +24,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 
 		conf := config.Defaults
 		conf.OAuth2.Refresh.Enabled = false
-		storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+		storage := newInMemoryStorage(t)
 		client := Client{conf: &conf, storage: storage}
 
 		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "alice", "selected")
@@ -40,7 +39,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		conf := config.Defaults
 		conf.OAuth2.Refresh.Enabled = true
 		conf.OAuth2.Refresh.ValidateUser = false
-		storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+		storage := newInMemoryStorage(t)
 		client := Client{conf: &conf, storage: storage}
 
 		client.storeSelectedProfileRefreshState(ctx, logger, session, "7", "alice", "selected")
@@ -60,7 +59,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		conf := config.Defaults
 		conf.OAuth2.Refresh.Enabled = true
 		conf.OAuth2.Refresh.ValidateUser = true
-		storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+		storage := newInMemoryStorage(t)
 		storedToken, err := encodeProviderRefreshToken("provider-refresh-token", []string{"previous"})
 		require.NoError(t, err)
 		require.NoError(t, storage.Set(ctx, "7", storedToken))
@@ -97,7 +96,7 @@ func TestStoreSelectedProfileRefreshState(t *testing.T) {
 		conf := config.Defaults
 		conf.OAuth2.Refresh.Enabled = true
 		conf.OAuth2.Refresh.ValidateUser = true
-		storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+		storage := newInMemoryStorage(t)
 		require.NoError(t, storage.Set(ctx, "7", providerRefreshTokenPrefix+"{"))
 
 		client := Client{conf: &conf, storage: storage}

--- a/internal/oauth2/handler_test.go
+++ b/internal/oauth2/handler_test.go
@@ -649,7 +649,7 @@ func TestHandler(t *testing.T) {
 			case tc.state == (state.State{}):
 				session = ""
 			default:
-				session, err = state.Encrypt(testsuite.Cipher, tc.state)
+				session, err = state.Encrypt(testsuite.NewCipher(t), tc.state)
 				require.NoError(t, err)
 			}
 
@@ -888,7 +888,7 @@ func TestOAuth2ProfileSubmit(t *testing.T) {
 
 				token := fmt.Sprintf("%d -", time.Now().Unix())
 
-				encryptedToken, err := testsuite.Cipher.EncryptBytes([]byte(token))
+				encryptedToken, err := testsuite.NewCipher(t).EncryptBytes([]byte(token))
 				require.NoError(t, err)
 
 				req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/oauth2/profile-submit",
@@ -909,7 +909,7 @@ func TestOAuth2ProfileSubmit(t *testing.T) {
 
 				token := fmt.Sprintf(`%d {}`, time.Now().Unix())
 
-				encryptedToken, err := testsuite.Cipher.EncryptBytes([]byte(token))
+				encryptedToken, err := testsuite.NewCipher(t).EncryptBytes([]byte(token))
 				require.NoError(t, err)
 
 				req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/oauth2/profile-submit",
@@ -931,12 +931,12 @@ func TestOAuth2ProfileSubmit(t *testing.T) {
 
 				sessionState := state.State{Client: state.ClientIdentifier{CID: 1, KID: 2}, IPAddr: "127.0.0.1", IPPort: "12345"}
 
-				encryptedState, err := state.Encrypt(testsuite.Cipher, sessionState)
+				encryptedState, err := state.Encrypt(testsuite.NewCipher(t), sessionState)
 				require.NoError(t, err)
 
 				token := fmt.Sprintf(`%d {"state": %q}`, time.Now().Unix(), encryptedState)
 
-				encryptedToken, err := testsuite.Cipher.EncryptBytes([]byte(token))
+				encryptedToken, err := testsuite.NewCipher(t).EncryptBytes([]byte(token))
 				require.NoError(t, err)
 
 				req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/oauth2/profile-submit",

--- a/internal/oauth2/provider_test.go
+++ b/internal/oauth2/provider_test.go
@@ -157,7 +157,16 @@ func TestNewProvider(t *testing.T) {
 
 			require.NoError(t, err)
 
-			oAuth2Client, err := oauth2.New(ctx, logger.Logger(), &tc.conf, http.DefaultClient, testsuite.NewFakeStorage(), testsuite.Cipher, provider, testsuite.NewFakeOpenVPNClient())
+			oAuth2Client, err := oauth2.New(
+				ctx,
+				logger.Logger(),
+				&tc.conf,
+				http.DefaultClient,
+				testsuite.NewFakeStorage(),
+				testsuite.NewCipher(t),
+				provider,
+				testsuite.NewFakeOpenVPNClient(),
+			)
 			if tc.err != "" {
 				require.Error(t, err)
 				assert.Equal(t, tc.err, strings.TrimSpace(err.Error()))

--- a/internal/oauth2/refresh_internal_test.go
+++ b/internal/oauth2/refresh_internal_test.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/idtoken"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/types"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/openvpn/connection"
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/tokenstorage"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 )
@@ -23,7 +21,7 @@ func TestRefreshClientAuthInternalTokenRestoresClientConfigNames(t *testing.T) {
 	conf.OAuth2.Refresh.Enabled = true
 	conf.OAuth2.Refresh.ValidateUser = false
 
-	storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+	storage := newInMemoryStorage(t)
 	internalToken, err := encodeInternalRefreshToken("alice", []string{"profile", "base"})
 	require.NoError(t, err)
 	require.NoError(t, storage.Set(ctx, "7", internalToken))
@@ -46,7 +44,7 @@ func TestRefreshClientAuthInternalTokenKeepsLegacyEmptyToken(t *testing.T) {
 	conf.OAuth2.Refresh.Enabled = true
 	conf.OAuth2.Refresh.ValidateUser = false
 
-	storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+	storage := newInMemoryStorage(t)
 	require.NoError(t, storage.Set(ctx, "7", types.EmptyToken))
 
 	client := Client{conf: &conf, storage: storage}
@@ -66,7 +64,7 @@ func TestRefreshClientAuthInternalTokenKeepsLegacyClientConfigToken(t *testing.T
 	conf.OAuth2.Refresh.Enabled = true
 	conf.OAuth2.Refresh.ValidateUser = false
 
-	storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+	storage := newInMemoryStorage(t)
 	require.NoError(t, storage.Set(
 		ctx,
 		"7",
@@ -96,7 +94,7 @@ func TestRefreshClientAuthInternalTokenWithoutUsernameFallsBackToInteractiveAuth
 	conf.OAuth2.Refresh.ValidateUser = false
 	conf.OpenVPN.EnforceUniqueUser = true
 
-	storage := tokenstorage.NewInMemoryWithGC("1234567890123456", time.Hour, 0)
+	storage := newInMemoryStorage(t)
 	require.NoError(t, storage.Set(
 		ctx,
 		"7",

--- a/internal/openvpn/main_test.go
+++ b/internal/openvpn/main_test.go
@@ -327,7 +327,7 @@ func TestClientFull(t *testing.T) {
 				matches := regexp.MustCompile(`state=(.+)"`).FindStringSubmatch(auth)
 				require.Len(t, matches, 2)
 
-				sessionState, err := state.Decrypt(testsuite.Cipher, matches[1])
+				sessionState, err := state.Decrypt(testsuite.NewCipher(t), matches[1])
 				require.NoError(t, err)
 
 				require.Equal(t, uint64(1), sessionState.Client.CID)

--- a/internal/state/bench_test.go
+++ b/internal/state/bench_test.go
@@ -22,6 +22,7 @@ func benchmarkSessionState() state.State {
 }
 
 func BenchmarkStateEncrypt(b *testing.B) {
+	cipher := testsuite.NewCipher(b)
 	sessionState := benchmarkSessionState()
 
 	var encryptedState state.EncryptedState
@@ -32,7 +33,7 @@ func BenchmarkStateEncrypt(b *testing.B) {
 	for b.Loop() {
 		var err error
 
-		encryptedState, err = state.Encrypt(testsuite.Cipher, sessionState)
+		encryptedState, err = state.Encrypt(cipher, sessionState)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -42,7 +43,8 @@ func BenchmarkStateEncrypt(b *testing.B) {
 }
 
 func BenchmarkStateDecrypt(b *testing.B) {
-	encodedTokenString, err := state.Encrypt(testsuite.Cipher, benchmarkSessionState())
+	cipher := testsuite.NewCipher(b)
+	encodedTokenString, err := state.Encrypt(cipher, benchmarkSessionState())
 	require.NoError(b, err)
 
 	var decryptedState state.State
@@ -53,7 +55,7 @@ func BenchmarkStateDecrypt(b *testing.B) {
 	for b.Loop() {
 		var decryptErr error
 
-		decryptedState, decryptErr = state.Decrypt(testsuite.Cipher, encodedTokenString)
+		decryptedState, decryptErr = state.Decrypt(cipher, encodedTokenString)
 		if decryptErr != nil {
 			b.Fatal(decryptErr)
 		}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestState(t *testing.T) {
 	t.Parallel()
+	cipher := testsuite.NewCipher(t)
 
 	for _, tc := range []struct {
 		name         string
@@ -47,10 +48,10 @@ func TestState(t *testing.T) {
 				SessionState: tc.sessionState,
 			}
 
-			encryptedToken, err := state.Encrypt(testsuite.Cipher, sessionState)
+			encryptedToken, err := state.Encrypt(cipher, sessionState)
 			require.NoError(t, err)
 
-			token, err := state.Decrypt(testsuite.Cipher, encryptedToken)
+			token, err := state.Decrypt(cipher, encryptedToken)
 			require.NoError(t, err)
 
 			require.Equal(t, token, sessionState)
@@ -60,6 +61,7 @@ func TestState(t *testing.T) {
 
 func TestStateInvalid(t *testing.T) {
 	t.Parallel()
+	cipher := testsuite.NewCipher(t)
 
 	for _, tc := range []struct {
 		name         string
@@ -90,7 +92,7 @@ func TestStateInvalid(t *testing.T) {
 		{
 			name: "state too short",
 			encodedToken: func() (state.EncryptedState, error) {
-				encrypted, err := testsuite.Cipher.EncryptBytesWithTime([]byte{2, 0})
+				encrypted, err := cipher.EncryptBytesWithTime([]byte{2, 0})
 				if err != nil {
 					return "", err
 				}
@@ -102,7 +104,7 @@ func TestStateInvalid(t *testing.T) {
 		{
 			name: "unsupported state version",
 			encodedToken: func() (state.EncryptedState, error) {
-				encrypted, err := testsuite.Cipher.EncryptBytesWithTime([]byte{1, 0, '0', 1, 1})
+				encrypted, err := cipher.EncryptBytesWithTime([]byte{1, 0, '0', 1, 1})
 				if err != nil {
 					return "", err
 				}
@@ -114,7 +116,7 @@ func TestStateInvalid(t *testing.T) {
 		{
 			name: "invalid CID",
 			encodedToken: func() (state.EncryptedState, error) {
-				encrypted, err := testsuite.Cipher.EncryptBytesWithTime([]byte{2, 0, '0'})
+				encrypted, err := cipher.EncryptBytesWithTime([]byte{2, 0, '0'})
 				if err != nil {
 					return "", err
 				}
@@ -126,7 +128,7 @@ func TestStateInvalid(t *testing.T) {
 		{
 			name: "invalid KID",
 			encodedToken: func() (state.EncryptedState, error) {
-				encrypted, err := testsuite.Cipher.EncryptBytesWithTime([]byte{2, 0, '0', 1})
+				encrypted, err := cipher.EncryptBytesWithTime([]byte{2, 0, '0', 1})
 				if err != nil {
 					return "", err
 				}
@@ -138,7 +140,7 @@ func TestStateInvalid(t *testing.T) {
 		{
 			name: "truncated common name",
 			encodedToken: func() (state.EncryptedState, error) {
-				encrypted, err := testsuite.Cipher.EncryptBytesWithTime([]byte{2, 2, '0', 1, 1, 5, 'a'})
+				encrypted, err := cipher.EncryptBytesWithTime([]byte{2, 2, '0', 1, 1, 5, 'a'})
 				if err != nil {
 					return "", err
 				}
@@ -150,7 +152,7 @@ func TestStateInvalid(t *testing.T) {
 		{
 			name: "trailing data",
 			encodedToken: func() (state.EncryptedState, error) {
-				encrypted, err := testsuite.Cipher.EncryptBytesWithTime([]byte{2, 0, '0', 1, 1, 'x'})
+				encrypted, err := cipher.EncryptBytesWithTime([]byte{2, 0, '0', 1, 1, 'x'})
 				if err != nil {
 					return "", err
 				}
@@ -166,7 +168,7 @@ func TestStateInvalid(t *testing.T) {
 			encodedTokenString, err := tc.encodedToken()
 			require.NoError(t, err)
 
-			_, err = state.Decrypt(testsuite.Cipher, encodedTokenString)
+			_, err = state.Decrypt(cipher, encodedTokenString)
 
 			require.ErrorContains(t, err, tc.expectedErr)
 		})

--- a/internal/test/testsuite/const.go
+++ b/internal/test/testsuite/const.go
@@ -3,7 +3,6 @@ package testsuite
 import (
 	"crypto/sha256"
 
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/crypto"
 	"golang.org/x/text/language"
 )
 
@@ -18,7 +17,6 @@ const (
 
 //nolint:gochecknoglobals
 var (
-	Cipher             = crypto.New(Secret)
 	HashSecret         = sha256.Sum256([]byte(Secret))
 	SupportedUILocales = []language.Tag{language.English}
 )

--- a/internal/test/testsuite/testsuite.go
+++ b/internal/test/testsuite/testsuite.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/config/types"
+	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/crypto"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/httphandler"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2"
 	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/oauth2/providers/generic"
@@ -43,6 +44,15 @@ type Suite struct {
 	oAuth2Client                  *oauth2.Client
 	errOpenVPNClientCh            chan error
 	conf                          *config.Config
+}
+
+func NewCipher(tb testing.TB) *crypto.Cipher {
+	tb.Helper()
+
+	cipher, err := crypto.New(Secret)
+	require.NoError(tb, err)
+
+	return cipher
 }
 
 func New(conf *config.Config, opts ...Options) *Suite {
@@ -90,7 +100,8 @@ func (s *Suite) SetupMockEnvironment(ctx context.Context, tb testing.TB, opConf 
 		s.conf.OpenVPN.ClientConfig.Path = config.Defaults.OpenVPN.ClientConfig.Path
 	}
 
-	tokenStorage := tokenstorage.NewInMemory(Secret, s.conf.OAuth2.Refresh.Expires)
+	tokenStorage, err := tokenstorage.NewInMemory(Secret, s.conf.OAuth2.Refresh.Expires)
+	require.NoError(tb, err)
 
 	s.oAuth2Client, s.openVPNClient = s.SetupOpenVPNOAuth2Clients(ctx, tb, tokenStorage)
 
@@ -239,7 +250,8 @@ func (s *Suite) SetupOpenVPNOAuth2Clients(ctx context.Context, tb testing.TB, to
 			refreshExpires = time.Hour
 		}
 
-		tokenStorage = tokenstorage.NewInMemory(Secret, refreshExpires)
+		tokenStorage, err = tokenstorage.NewInMemory(Secret, refreshExpires)
+		require.NoError(tb, err)
 	}
 
 	switch s.conf.OAuth2.Provider {
@@ -256,7 +268,16 @@ func (s *Suite) SetupOpenVPNOAuth2Clients(ctx context.Context, tb testing.TB, to
 	require.NoError(tb, err)
 
 	openVPNClient := openvpn.New(s.logger.Logger(), s.conf)
-	oAuth2Client, err := oauth2.New(ctx, s.logger.Logger(), s.conf, s.httpClient, tokenStorage, Cipher, provider, openVPNClient)
+	oAuth2Client, err := oauth2.New(
+		ctx,
+		s.logger.Logger(),
+		s.conf,
+		s.httpClient,
+		tokenStorage,
+		NewCipher(tb),
+		provider,
+		openVPNClient,
+	)
 	require.NoError(tb, err)
 
 	openVPNClient.SetOAuth2Client(oAuth2Client)

--- a/internal/tokenstorage/bench_test.go
+++ b/internal/tokenstorage/bench_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/test/testsuite"
-	"github.com/jkroepke/openvpn-auth-oauth2/v2/internal/tokenstorage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +18,7 @@ func BenchmarkStorageInMemory(b *testing.B) {
 	ctx := context.Background()
 
 	b.Run("set", func(b *testing.B) {
-		storage := tokenstorage.NewInMemoryWithGC(testsuite.Secret, time.Hour, 0)
+		storage := newInMemoryWithGC(b, time.Hour, 0)
 
 		b.Cleanup(func() {
 			require.NoError(b, storage.Close())
@@ -37,7 +35,7 @@ func BenchmarkStorageInMemory(b *testing.B) {
 	})
 
 	b.Run("get", func(b *testing.B) {
-		storage := tokenstorage.NewInMemoryWithGC(testsuite.Secret, time.Hour, 0)
+		storage := newInMemoryWithGC(b, time.Hour, 0)
 		require.NoError(b, storage.Set(ctx, benchmarkClientID, benchmarkToken))
 
 		var tokenValue string
@@ -62,7 +60,7 @@ func BenchmarkStorageInMemory(b *testing.B) {
 	})
 
 	b.Run("delete", func(b *testing.B) {
-		storage := tokenstorage.NewInMemoryWithGC(testsuite.Secret, time.Hour, 0)
+		storage := newInMemoryWithGC(b, time.Hour, 0)
 		clientIDs := make([]string, b.N)
 
 		for idx := range b.N {
@@ -88,7 +86,7 @@ func BenchmarkStorageInMemory(b *testing.B) {
 	})
 
 	b.Run("lifecycle", func(b *testing.B) {
-		storage := tokenstorage.NewInMemoryWithGC(testsuite.Secret, time.Hour, 0)
+		storage := newInMemoryWithGC(b, time.Hour, 0)
 
 		var tokenValue string
 

--- a/internal/tokenstorage/inmemory.go
+++ b/internal/tokenstorage/inmemory.go
@@ -32,16 +32,21 @@ type InMemory struct {
 
 // NewInMemory creates a new in-memory token storage with the given encryption key and expiration duration.
 // It starts a background goroutine for garbage collection of expired tokens.
-func NewInMemory(encryptionKey string, expires time.Duration) *InMemory {
+func NewInMemory(encryptionKey string, expires time.Duration) (*InMemory, error) {
 	return NewInMemoryWithGC(encryptionKey, expires, DefaultGCInterval)
 }
 
 // NewInMemoryWithGC creates a new in-memory token storage with custom GC interval.
 // If gcInterval is 0 or negative, garbage collection is disabled.
-func NewInMemoryWithGC(encryptionKey string, expires, gcInterval time.Duration) *InMemory {
+func NewInMemoryWithGC(encryptionKey string, expires, gcInterval time.Duration) (*InMemory, error) {
+	encryptionCipher, err := crypto.New(encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("create token cipher: %w", err)
+	}
+
 	storage := &InMemory{
 		data:       DataMap{},
-		cipher:     crypto.New(encryptionKey),
+		cipher:     encryptionCipher,
 		expires:    expires,
 		gcInterval: gcInterval,
 		gcStop:     make(chan struct{}),
@@ -51,7 +56,7 @@ func NewInMemoryWithGC(encryptionKey string, expires, gcInterval time.Duration) 
 		storage.startGC()
 	}
 
-	return storage
+	return storage, nil
 }
 
 // SetStorage replaces the current storage data with the provided DataMap.

--- a/internal/tokenstorage/inmemory_internal_test.go
+++ b/internal/tokenstorage/inmemory_internal_test.go
@@ -13,7 +13,8 @@ func TestInMemoryExpiredLookupPreservesConcurrentRefresh(t *testing.T) {
 	const clientID = "client"
 
 	ctx := t.Context()
-	tokenStorage := NewInMemory("test-secret", time.Hour)
+	tokenStorage, err := NewInMemory("test-secret", time.Hour)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		require.NoError(t, tokenStorage.Close())

--- a/internal/tokenstorage/inmemory_test.go
+++ b/internal/tokenstorage/inmemory_test.go
@@ -11,11 +11,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newInMemory(tb testing.TB, encryptionKey string, expires time.Duration) *tokenstorage.InMemory {
+	tb.Helper()
+
+	storage, err := tokenstorage.NewInMemory(encryptionKey, expires)
+	require.NoError(tb, err)
+
+	return storage
+}
+
+func newInMemoryWithGC(
+	tb testing.TB,
+	expires, gcInterval time.Duration,
+) *tokenstorage.InMemory {
+	tb.Helper()
+
+	storage, err := tokenstorage.NewInMemoryWithGC(testsuite.Secret, expires, gcInterval)
+	require.NoError(tb, err)
+
+	return storage
+}
+
 func TestStorageInMemory(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tokenStorage := tokenstorage.NewInMemory(testsuite.Secret, time.Millisecond*400)
+	tokenStorage := newInMemory(t, testsuite.Secret, time.Millisecond*400)
 
 	t.Cleanup(func() {
 		require.NoError(t, tokenStorage.Close())
@@ -56,7 +77,7 @@ func TestStorageInMemory_Consume(t *testing.T) {
 	const consumers = 32
 
 	ctx := t.Context()
-	tokenStorage := tokenstorage.NewInMemory(testsuite.Secret, time.Hour)
+	tokenStorage := newInMemory(t, testsuite.Secret, time.Hour)
 
 	t.Cleanup(func() {
 		require.NoError(t, tokenStorage.Close())
@@ -105,7 +126,7 @@ func TestStorageInMemory_Expire(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tokenStorage := tokenstorage.NewInMemory(testsuite.Secret, 0)
+	tokenStorage := newInMemory(t, testsuite.Secret, 0)
 
 	t.Cleanup(func() {
 		require.NoError(t, tokenStorage.Close())
@@ -127,7 +148,7 @@ func TestStorageInMemory_InvalidSecret(t *testing.T) {
 	ctx := context.Background()
 	key := "invalid"
 
-	tokenStorage := tokenstorage.NewInMemory(key, time.Second)
+	tokenStorage := newInMemory(t, key, time.Second)
 
 	t.Cleanup(func() {
 		require.NoError(t, tokenStorage.Close())
@@ -144,7 +165,7 @@ func TestStorageInMemory_InvalidSecret(t *testing.T) {
 func TestStorageInMemory_InvalidData(t *testing.T) {
 	t.Parallel()
 
-	tokenStorage := tokenstorage.NewInMemory(testsuite.Secret, 0)
+	tokenStorage := newInMemory(t, testsuite.Secret, 0)
 
 	t.Cleanup(func() {
 		require.NoError(t, tokenStorage.Close())
@@ -158,7 +179,7 @@ func TestStorageInMemory_GarbageCollection(t *testing.T) {
 
 	ctx := context.Background()
 	// Use short expiration and GC interval for testing
-	tokenStorage := tokenstorage.NewInMemoryWithGC(testsuite.Secret, 50*time.Millisecond, 100*time.Millisecond)
+	tokenStorage := newInMemoryWithGC(t, 50*time.Millisecond, 100*time.Millisecond)
 
 	t.Cleanup(func() {
 		require.NoError(t, tokenStorage.Close())
@@ -183,7 +204,7 @@ func TestStorageInMemory_NoGC(t *testing.T) {
 
 	ctx := context.Background()
 	// Disable GC by passing 0 interval
-	tokenStorage := tokenstorage.NewInMemoryWithGC(testsuite.Secret, 50*time.Millisecond, 0)
+	tokenStorage := newInMemoryWithGC(t, 50*time.Millisecond, 0)
 
 	t.Cleanup(func() {
 		require.NoError(t, tokenStorage.Close())


### PR DESCRIPTION
## Summary

- return errors from AES-GCM cipher and HKDF initialization instead of panicking
- propagate cipher setup failures through token storage, daemon setup, and CLI startup
- update callers, test helpers, and benchmarks for the error-returning constructors

This lets FIPS-only mode report short key material as a normal startup error instead of terminating with a panic.

## Testing

- make fmt
- make lint
- make test
- git diff --check
- gopls diagnostics on all changed Go files
- GOEXPERIMENT=cgocheck2 GODEBUG=fips140=only go test ./internal/crypto -run TestCipherConsistency -count=1